### PR TITLE
fix: Token counter not updating in local dev mode

### DIFF
--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -269,12 +269,23 @@ export function SyncProvider(props: ParentProps) {
     if (event.type === "message.updated") {
       const msgProps = props as { info?: Message; parts?: Part[] }
       const info = msgProps.info
+      const parts = msgProps.parts
       if (!info?.sessionID) return
 
       setStore("message", info.sessionID, (existing: MessageWithParts[]) => {
         if (!existing || existing.length === 0) return existing
-        return existing.map((m) => (m.info.id === info.id ? { ...m, info } : m))
+        return existing.map((m) => {
+          if (m.info.id !== info.id) return m
+          // Merge info and optionally update parts if provided
+          const updatedParts = parts ? sortParts(parts) : m.parts
+          return { info, parts: updatedParts }
+        })
       })
+
+      // Also update parts store if parts were provided
+      if (parts && info.id) {
+        setStore("part", info.id, sortParts(parts))
+      }
     }
 
     // Provider events


### PR DESCRIPTION
## Summary

- Fix message.updated event handler to properly merge parts data along with info
- Token data arrives in the parts array, which was previously ignored during updates

## Changes

The `message.updated` event handler in `sync.tsx` was only updating the `info` object but ignoring any `parts` data included in the event. This caused the token counter to remain stuck since token information comes with the updated message parts.

Now properly merges both `info` and `parts` when a `message.updated` event is received, and also updates the parts store.

Closes #1