### PR TITLE
fix: Review panel not working in local dev mode

### DIFF
--- a/app-prefixable/src/components/review-panel.tsx
+++ b/app-prefixable/src/components/review-panel.tsx
@@ -42,7 +42,7 @@ interface ReviewPanelProps {
 }
 
 export function ReviewPanel(props: ReviewPanelProps) {
-  const { client } = useSDK();
+  const { client, directory } = useSDK();
   const events = useEvents();
   const layout = useLayout();
 
@@ -58,7 +58,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
   async function checkGitRepo() {
     try {
       // Try to get VCS info - if it fails or returns no branch, it's not a git repo
-      const res = await client.vcs.get();
+      const res = await client.vcs.get({ directory });
       setIsGitRepo(res.data?.branch !== undefined);
     } catch {
       setIsGitRepo(false);
@@ -69,7 +69,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
     const current = ++version;
     setLoading(true);
     try {
-      const res = await client.session.diff({ sessionID: props.sessionId });
+      const res = await client.session.diff({ sessionID: props.sessionId, directory });
       // Only update state if this is still the latest request
       if (current !== version) return;
       if (res.data) {


### PR DESCRIPTION
## Summary

- Pass `directory` parameter to `client.vcs.get()` and `client.session.diff()` calls
- Fixes issue where review panel showed "Not a Git repository" even in valid repos

## Changes

The review panel was calling the VCS and diff APIs without passing the `directory` parameter from the SDK context. This caused the backend to not know which directory to check for Git status or session diffs.

Now properly extracts `directory` from `useSDK()` and passes it to both API calls.

Closes #2