### PR TITLE
feat: session rename and delete

### DIFF
--- a/app-prefixable/src/components/confirm-dialog.tsx
+++ b/app-prefixable/src/components/confirm-dialog.tsx
@@ -7,7 +7,9 @@ interface Props {
   message: string
   confirmLabel?: string
   cancelLabel?: string
+  confirmDisabled?: boolean
   variant?: "danger" | "warning" | "default"
+  error?: string
   onConfirm: () => void
   onCancel: () => void
 }
@@ -29,7 +31,9 @@ export function ConfirmDialog(props: Props) {
     function handleTab(e: KeyboardEvent) {
       if (e.key !== "Tab") return
 
-      const buttons = el!.querySelectorAll("button")
+      const buttons = Array.from(
+        el!.querySelectorAll<HTMLButtonElement>("button:not([disabled])")
+      )
       const first = buttons[0]
       const last = buttons[buttons.length - 1]
 
@@ -110,26 +114,35 @@ export function ConfirmDialog(props: Props) {
               </p>
             </div>
 
-            <div class="px-4 py-3 flex justify-end gap-2" style={{ "border-top": "1px solid var(--border-base)" }}>
-              <button
-                type="button"
-                onClick={props.onCancel}
-                class="px-4 py-2 text-sm font-medium rounded-md transition-colors"
-                style={{
-                  background: "var(--surface-inset)",
-                  color: "var(--text-base)",
-                }}
-              >
-                {props.cancelLabel ?? "Cancel"}
-              </button>
-              <button
-                type="button"
-                onClick={props.onConfirm}
-                class="px-4 py-2 text-sm font-medium rounded-md transition-colors"
-                style={confirmStyle()}
-              >
-                {props.confirmLabel ?? "Confirm"}
-              </button>
+            <div class="px-4 py-3 flex flex-col gap-2" style={{ "border-top": "1px solid var(--border-base)" }}>
+              <Show when={props.error}>
+                <p class="text-xs" style={{ color: "var(--text-critical-base)" }}>{props.error}</p>
+              </Show>
+              <div class="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={props.onCancel}
+                  class="px-4 py-2 text-sm font-medium rounded-md transition-colors"
+                  style={{
+                    background: "var(--surface-inset)",
+                    color: "var(--text-base)",
+                  }}
+                >
+                  {props.cancelLabel ?? "Cancel"}
+                </button>
+                <button
+                  type="button"
+                  onClick={props.onConfirm}
+                  disabled={props.confirmDisabled}
+                  class="px-4 py-2 text-sm font-medium rounded-md transition-colors"
+                  style={{
+                    ...confirmStyle(),
+                    ...(props.confirmDisabled ? { opacity: "0.6", cursor: "not-allowed" } : {}),
+                  }}
+                >
+                  {props.confirmLabel ?? "Confirm"}
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/app-prefixable/src/components/session-header.tsx
+++ b/app-prefixable/src/components/session-header.tsx
@@ -1,4 +1,4 @@
-import { Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { Show, createEffect, createSignal, onCleanup } from "solid-js"
 import { useNavigate, useParams } from "@solidjs/router"
 import { Spinner } from "./ui/spinner"
 import { useLayout } from "../context/layout"
@@ -6,10 +6,8 @@ import { useMCP } from "../context/mcp"
 import { usePermission } from "../context/permission"
 import { useTerminal } from "../context/terminal"
 import { useSDK } from "../context/sdk"
-import { useSync } from "../context/sync"
-import { useProviders } from "../context/providers"
 import { ConfirmDialog } from "./confirm-dialog"
-import { PanelBottom, FileCode, ListTodo, Plug, ArrowLeft, Users, MoreHorizontal, Pencil, Archive, Trash2, Sparkles } from "lucide-solid"
+import { PanelBottom, FileCode, ListTodo, Plug, ArrowLeft, Users, MoreHorizontal, Pencil, Archive, Trash2 } from "lucide-solid"
 import { base64Encode } from "../utils/path"
 import { PrButton } from "./pr-button"
 import type { Session } from "../sdk/client"
@@ -29,19 +27,17 @@ export function SessionHeader(props: SessionHeaderProps) {
   const permission = usePermission()
   const terminal = useTerminal()
   const { client, directory } = useSDK()
-  const sync = useSync()
-  const providers = useProviders()
   const navigate = useNavigate()
   const params = useParams<{ dir: string }>()
 
-  const dirSlug = createMemo(() => (directory ? base64Encode(directory) : params.dir))
+  const dirSlug = () => (directory ? base64Encode(directory) : params.dir)
   const parentId = () => props.session?.parentID
   const [renaming, setRenaming] = createSignal(false)
   const [renameValue, setRenameValue] = createSignal("")
   const [menuOpen, setMenuOpen] = createSignal(false)
   const [confirmDelete, setConfirmDelete] = createSignal(false)
   const [deleting, setDeleting] = createSignal(false)
-  const [aiRenaming, setAiRenaming] = createSignal(false)
+  const [deleteError, setDeleteError] = createSignal<string | null>(null)
 
   function navigateToParent() {
     const id = parentId()
@@ -61,97 +57,6 @@ export function SessionHeader(props: SessionHeaderProps) {
       .finally(() => setRenaming(false))
   }
 
-  async function renameWithAI() {
-    setMenuOpen(false)
-    const session = props.session
-    if (!session) return
-
-    const msgs = sync.messages(session.id)
-    const userMsgs = msgs
-      .filter((m) => m.info.role === "user")
-      .slice(0, 10)
-      .map((m) => {
-        const text = m.parts
-          .filter((p) => p.type === "text")
-          .map((p) => (p as { text?: string }).text ?? "")
-          .join(" ")
-        return text.slice(0, 500)
-      })
-      .filter((t) => t.length > 0)
-
-    if (userMsgs.length === 0) return
-
-    const promptText = `Suggest a short title (5 words or fewer) for the following conversation. Reply with only the title, no punctuation, no quotes.\n\n${userMsgs.join("\n")}`
-
-    // Use last assistant message's model or fall back to selected model
-    const lastAssistant = [...msgs].reverse().find((m) => m.info.role === "assistant")
-    const model = lastAssistant
-      ? {
-          providerID: (lastAssistant.info as { providerID?: string }).providerID ?? "",
-          modelID: (lastAssistant.info as { modelID?: string }).modelID ?? "",
-        }
-      : providers.selectedModel
-
-    setAiRenaming(true)
-
-    const childRes = await client.session.create({ parentID: session.id }).catch((err: unknown) => {
-      console.error("[AI Rename] Failed to create child session:", err)
-      return null
-    })
-
-    const childID = childRes?.data?.id
-
-    if (!childID) {
-      setAiRenaming(false)
-      return
-    }
-
-    const cleanup = () =>
-      client.session.delete({ sessionID: childID })
-        .catch(err => console.warn("[AI Rename] Failed to delete child session:", childID, err))
-
-    const res = await client.session
-      .prompt({
-        sessionID: childID,
-        parts: [{ type: "text", text: promptText }],
-        agent: "build",
-        ...(model ? { model } : {}),
-      })
-      .catch((err: unknown) => {
-        console.error("[AI Rename] Prompt failed:", err)
-        return null
-      })
-
-    await cleanup()
-    setAiRenaming(false)
-
-    if (!res?.data) return
-
-    const title = res.data.parts
-      .filter((p) => p.type === "text")
-      .map((p) => (p as { text?: string }).text ?? "")
-      .join("")
-      .trim()
-      .replace(/^["']+|["']+$/g, "")
-      .trim()
-
-    if (!title) {
-      console.error("[AI Rename] Empty title returned")
-      return
-    }
-
-    // Pre-fill the rename input with the AI suggestion so user can confirm/edit
-    setRenameValue(title)
-    setRenaming(true)
-  }
-
-  // Whether the session has messages (for enabling AI rename)
-  const hasMessages = createMemo(() => {
-    const session = props.session
-    if (!session) return false
-    return sync.messages(session.id).length > 0
-  })
-
   // Navigate to session list only after a successful archive; do not navigate on failure
   function archiveSession() {
     setMenuOpen(false)
@@ -167,6 +72,7 @@ export function SessionHeader(props: SessionHeaderProps) {
     if (deleting()) return
     const session = props.session
     if (!session) return
+    setDeleteError(null)
     setDeleting(true)
     client.session.delete({ sessionID: session.id })
       .then(() => {
@@ -181,7 +87,7 @@ export function SessionHeader(props: SessionHeaderProps) {
       })
       .catch(err => {
         console.error("Failed to delete session", err)
-        alert("Failed to delete session. Please try again.")
+        setDeleteError("Failed to delete session. Please try again.")
       })
       .finally(() => setDeleting(false))
   }
@@ -244,24 +150,18 @@ export function SessionHeader(props: SessionHeaderProps) {
             <Show
               when={renaming()}
               fallback={
-                <>
-                  <h1
-                    class="text-sm font-medium truncate cursor-text"
-                    style={{ color: "var(--text-strong)" }}
-                    title="Double-click to rename"
-                    onDblClick={() => {
-                      if (!props.session) return
-                      setRenameValue(props.session.title ?? "")
-                      setRenaming(true)
-                    }}
-                  >
-                    {props.session?.title || "New Session"}
-                  </h1>
-                  {/* Spinner shown while AI rename is in progress */}
-                  <Show when={aiRenaming()}>
-                    <Spinner class="w-3.5 h-3.5 shrink-0" style={{ color: "var(--text-interactive-base)" }} />
-                  </Show>
-                </>
+                <h1
+                  class="text-sm font-medium truncate cursor-text"
+                  style={{ color: "var(--text-strong)" }}
+                  title="Double-click to rename"
+                  onDblClick={() => {
+                    if (!props.session) return
+                    setRenameValue(props.session.title ?? "")
+                    setRenaming(true)
+                  }}
+                >
+                  {props.session?.title || "New Session"}
+                </h1>
               }
             >
               {/* dataset cancel flag prevents Escape triggering onBlur commit */}
@@ -290,8 +190,8 @@ export function SessionHeader(props: SessionHeaderProps) {
               />
             </Show>
 
-            {/* ⋯ more-options dropdown — only show when session is loaded and not AI renaming */}
-            <Show when={props.session && !aiRenaming()}>
+            {/* ⋯ more-options dropdown — only show when session is loaded */}
+            <Show when={props.session}>
               <div class="relative" data-session-menu>
                 <button
                   onClick={(e) => {
@@ -335,31 +235,6 @@ export function SessionHeader(props: SessionHeaderProps) {
                       Rename
                     </button>
 
-                    {/* Rename with AI */}
-                    <button
-                      class="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left transition-colors"
-                      disabled={!hasMessages()}
-                      style={{
-                        color: hasMessages() ? "var(--text-base)" : "var(--text-weak)",
-                        opacity: hasMessages() ? 1 : 0.5,
-                        cursor: hasMessages() ? "pointer" : "not-allowed",
-                      }}
-                      onMouseEnter={(e) => {
-                        if (hasMessages()) e.currentTarget.style.background = "var(--surface-inset)"
-                      }}
-                      onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-                      onClick={() => {
-                        if (hasMessages()) renameWithAI()
-                      }}
-                      title={hasMessages() ? "Suggest a title using AI" : "Send a message first to enable AI rename"}
-                    >
-                      <Sparkles
-                        class="w-3.5 h-3.5 shrink-0"
-                        style={{ color: hasMessages() ? "var(--text-interactive-base)" : "var(--icon-weak)" }}
-                      />
-                      Rename with AI
-                    </button>
-
                     {/* Archive */}
                     <button
                       class="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left transition-colors"
@@ -383,6 +258,7 @@ export function SessionHeader(props: SessionHeaderProps) {
                       onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
                       onClick={() => {
                         setMenuOpen(false)
+                        setDeleteError(null)
                         setConfirmDelete(true)
                       }}
                     >
@@ -547,10 +423,12 @@ export function SessionHeader(props: SessionHeaderProps) {
         title="Delete session?"
         message={`This will permanently delete "${props.session?.title || "this session"}". This cannot be undone.`}
         confirmLabel={deleting() ? "Deleting..." : "Delete"}
+        confirmDisabled={deleting()}
         cancelLabel="Cancel"
         variant="danger"
+        error={deleteError() ?? undefined}
         onConfirm={confirmAndDelete}
-        onCancel={() => setConfirmDelete(false)}
+        onCancel={() => { setDeleteError(null); setConfirmDelete(false) }}
       />
     </header>
   )

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -733,32 +733,41 @@ export function Layout(props: ParentProps) {
                                       <CircleHelp class="w-4 h-4" style={{ color: "var(--icon-warning-base)" }} />
                                     </Show>
                                   </span>
-                                  {/* dataset cancel flag for Escape; ref to select all text */}
-                                  <input
-                                    class="flex-1 min-w-0 text-sm bg-transparent outline-none"
-                                    style={{ color: "var(--text-base)" }}
-                                    value={session.title || ""}
-                                    autofocus
-                                    ref={(el) => setTimeout(() => { el.focus(); el.select() }, 0)}
-                                    onKeyDown={(e) => {
-                                      if (e.key === "Enter") {
-                                        renameSession(session, e.currentTarget.value);
-                                        setRenamingId(null);
-                                      } else if (e.key === "Escape") {
-                                        e.currentTarget.dataset.cancelRename = "true";
-                                        setRenamingId(null);
-                                      }
-                                    }}
-                                    onBlur={(e) => {
-                                      if (e.currentTarget.dataset.cancelRename === "true") return;
-                                      renameSession(session, e.currentTarget.value);
-                                      setRenamingId(null);
-                                    }}
-                                  />
+                                  {/* Local signal isolates edit state from reactive session.title updates */}
+                                  {(() => {
+                                    const [editTitle, setEditTitle] = createSignal(session.title || "");
+                                    return (
+                                      <input
+                                        class="flex-1 min-w-0 text-sm bg-transparent outline-none"
+                                        style={{ color: "var(--text-base)" }}
+                                        value={editTitle()}
+                                        aria-label="Session title"
+                                        autofocus
+                                        ref={(el) => setTimeout(() => { el.focus(); el.select() }, 0)}
+                                        onInput={(e) => setEditTitle(e.currentTarget.value)}
+                                        onKeyDown={(e) => {
+                                          if (e.key === "Enter") {
+                                            e.currentTarget.dataset.committed = "true";
+                                            renameSession(session, editTitle());
+                                            setRenamingId(null);
+                                          } else if (e.key === "Escape") {
+                                            e.currentTarget.dataset.cancelRename = "true";
+                                            setRenamingId(null);
+                                          }
+                                        }}
+                                        onBlur={(e) => {
+                                          if (e.currentTarget.dataset.cancelRename === "true") return;
+                                          if (e.currentTarget.dataset.committed === "true") return;
+                                          renameSession(session, editTitle());
+                                          setRenamingId(null);
+                                        }}
+                                      />
+                                    );
+                                  })()}
                                 </div>
                               </Show>
                               <Show when={renamingId() !== session.id}>
-                                <div class="absolute right-1.5 top-1/2 -translate-y-1/2 hidden group-hover:flex items-center gap-0.5">
+                                <div class="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto">
                                   <button
                                     onClick={(e) => {
                                       e.preventDefault();
@@ -883,7 +892,7 @@ export function Layout(props: ParentProps) {
                                 e.stopPropagation();
                                 restoreSession(session);
                               }}
-                              class="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 rounded hidden group-hover:flex items-center justify-center transition-colors"
+                              class="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 rounded flex items-center justify-center transition-colors opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
                               style={{ color: "var(--icon-weak)" }}
                               onMouseEnter={(e) =>
                                 (e.currentTarget.style.color =

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -364,6 +364,28 @@ export function Session() {
     if (id) await sync.session.sync(id);
   };
 
+  // Navigate to next/previous session after archive or delete
+  function navigateAfterRemove(id: string) {
+    const current = sync.sessions().find(s => s.id === id);
+
+    // If it's a child session, navigate to parent
+    if (current?.parentID) {
+      navigate(`/${dirSlug()}/session/${current.parentID}`);
+      return;
+    }
+
+    // Otherwise find next/prev root session
+    const all = sync.sessions()
+      .filter(s => s.directory === directory && !s.time?.archived && !s.parentID)
+      .slice()
+      .sort((a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0));
+
+    if (!all.length) { navigate(`/${dirSlug()}/session`); return; }
+    const idx = all.findIndex(s => s.id === id);
+    const next = idx === -1 ? all[0] : (all[idx + 1] ?? all[idx - 1]);
+    navigate(next ? `/${dirSlug()}/session/${next.id}` : `/${dirSlug()}/session`);
+  }
+
   // Start processing state - SSE events will handle updates and completion
   function startProcessing() {
     console.log("[Session] Starting processing, relying on SSE events");
@@ -970,6 +992,7 @@ export function Session() {
           processing={processing()}
           onOpenMCPDialog={() => setShowMCPDialog(true)}
           onSendPrompt={(prompt) => setInput(prompt)}
+          onDelete={() => navigateAfterRemove(session()?.id ?? "")}
         />
 
         {/* Messages - using rich message timeline with lazy rendering */}


### PR DESCRIPTION
## Summary

- Adds a **⋯ more-options dropdown** in the session header with Rename, Archive (separator), and Delete actions
- **Rename**: double-clicking the session title (or clicking ⋯ → Rename) replaces the `<h1>` with an inline `<input>`; Enter saves (calls `client.session.update`), Escape or blur without change cancels
- **Delete**: opens a confirmation dialog ("Delete session? This cannot be undone.") before calling `client.session.delete`, then navigates away
- **Archive**: calls `client.session.update` with `time.archived` timestamp, navigates away
- Sidebar session list now shows a **pencil icon button** on hover that triggers inline rename on the list item; saving optimistically updates the local sessions list
- Sidebar also shows Archive button alongside pencil on hover (two icons instead of one)

Closes #6, closes #7