### PR TITLE
fix: question prompt missing after page reload

### DIFF
--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -476,10 +476,8 @@ export function Session() {
         }
       }
     });
-    onCleanup(() => {
-      state.stale = true;
-      unsub();
-    });
+    onCleanup(unsub);
+    onCleanup(() => { state.stale = true; });
 
     client.question.list({ directory })
       .then((res) => {


### PR DESCRIPTION
Closes #22

Fixes a race condition where the question prompt overlay disappears after page reload on a session with a pending question.

**Approach:** Subscribes to SSE events immediately (synchronously within `createEffect`) and fires the HTTP `question.list()` call concurrently. Guard state variables coordinate between the two data sources:

- `loaded` — prevents historical SSE replay of `question.replied`/`question.rejected` from clearing the question before the HTTP seed arrives. Only blocks clearing events when no live SSE question has been seen (`receivedViaSse` is false).
- `receivedViaSse` — tracks whether a live `question.asked` event arrived via SSE during the HTTP flight. Prevents the HTTP result from overwriting a live question. Also allows clearing events to bypass the `loaded` guard (since the question is known to be live, not a replay).
- `clearedViaSse` — tracks whether a clearing event was already processed via SSE. Prevents the HTTP result from restoring an already-answered question when the reply SSE arrives before the HTTP response.
- `stale` — set to `true` in `onCleanup` when the effect re-runs (e.g., session navigation). Causes the in-flight HTTP `.then()`/`.catch()` callbacks to bail out, preventing stale data from corrupting the new session's state.

The subscription cleanup uses `onCleanup(unsub)` directly (consistent with other subscriptions in this file) with a separate `onCleanup` for the stale flag.