### PR TITLE
fix: strip session/ prefix in SessionIndex Navigate href

### DIFF
--- a/app-prefixable/src/app.tsx
+++ b/app-prefixable/src/app.tsx
@@ -31,7 +31,9 @@ function DirectoryIndex() {
 function SessionIndex() {
   const params = useParams<{ dir: string }>()
   const href = getLastSessionHref(params.dir)
-  return href === "session" ? <Session /> : <Navigate href={href} replace />
+  if (href === "session") return <Session />
+  const id = href.replace(/^session\//, "")
+  return <Navigate href={id} replace />
 }
 
 function AppRoutes() {


### PR DESCRIPTION
## Summary

- Fix doubled `session/session/<id>` URL when restoring last session across workspace switches
- `SessionIndex` now strips the `session/` prefix from `getLastSessionHref()` since it's already at `/:dir/session`

Closes #34