### PR TITLE
fix: only trigger build on v* tags and manual dispatch

### DIFF
--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -2,25 +2,8 @@ name: Build pk-opencode
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "app-prefixable/**"
-      - "docker/**"
-      - "shared/**"
-      - ".github/workflows/pk-opencode.yml"
     tags:
       - "v*"
-    # Note: For tags, paths filter is ignored by GitHub Actions
-    # Tags matching v* will always trigger, regardless of paths
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "app-prefixable/**"
-      - "docker/**"
-      - "shared/**"
-      - ".github/workflows/pk-opencode.yml"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

- Remove `push` trigger on `main` branch (with path filters)
- Remove `pull_request` trigger entirely
- Keep only `v*` tag pushes and `workflow_dispatch` (manual trigger)

The build workflow was failing on every push and PR because the GCP secrets (`GCP_SA_KEY`, `GCP_ARTIFACT_REGISTRY_PATH`) are not configured. Since builds push Docker images to GCP Artifact Registry, there's no point running them without credentials. Restricting to tagged commits means builds only run for intentional releases.