### PR TITLE
fix: inherit model when switching agents to prevent send block

### DIFF
--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -178,8 +178,16 @@ export function ProviderProvider(props: ParentProps) {
   }
 
   function setSelectedAgent(agent: string) {
-    if (!store.modelsByAgent[agent] && store.modelsByAgent[store.selectedAgent]) {
-      setStore("modelsByAgent", agent, store.modelsByAgent[store.selectedAgent])
+    if (!store.modelsByAgent[agent]) {
+      const source = store.modelsByAgent[store.selectedAgent]
+        ? store.selectedAgent
+        : store.modelsByAgent[DEFAULT_AGENT]
+          ? DEFAULT_AGENT
+          : null
+
+      if (source) {
+        setStore("modelsByAgent", agent, store.modelsByAgent[source])
+      }
     }
     setStore("selectedAgent", agent)
   }


### PR DESCRIPTION
## Summary

Closes #49

When switching agents (via the agent picker, Tab key cycling, or `/agent` slash command), the selected model was not carried over to the new agent. Since `selectedModel` is stored per-agent in `modelsByAgent`, any agent without a prior model assignment would return `null`, blocking message sending with the warning: *"Please select a model before sending messages."*

## Changes

**`app-prefixable/src/context/providers.tsx`** — Updated `setSelectedAgent()` to automatically copy the current agent's model to the new agent if it has no model assigned yet. The user can still override the model per-agent via the model picker.

## How it works

```typescript
function setSelectedAgent(agent: string) {
  if (!store.modelsByAgent[agent] && store.modelsByAgent[store.selectedAgent]) {
    setStore("modelsByAgent", agent, store.modelsByAgent[store.selectedAgent])
  }
  setStore("selectedAgent", agent)
}
```

- If the target agent already has a model → no change (preserves user's per-agent override)
- If the target agent has no model and the current agent does → inherits the current agent's model
- The model is persisted via the existing `createEffect` that writes `modelsByAgent` to localStorage

## Acceptance Criteria

- [x] Switching agents does not block sending
- [x] The new agent inherits a model if it has none assigned
- [x] The user can still override the model per-agent via the model picker
- [x] Tab key cycling between agents works without triggering the warning
- [x] No new TypeScript errors introduced