### PR TITLE
fix: prevent session ID change effect from resetting AI rename spinner

### DIFF
--- a/app-prefixable/src/components/session-header.tsx
+++ b/app-prefixable/src/components/session-header.tsx
@@ -236,6 +236,7 @@ export function SessionHeader(props: SessionHeaderProps) {
       })
       .finally(() => {
         setAiRenaming(false)
+        setAiRenameSessionId(null)
         // Clean up child session
         if (ref2.childId) {
           client.session.delete({ sessionID: ref2.childId })


### PR DESCRIPTION
## Summary

- Guards `setAiRenaming(false)` in the session ID change effect so it only resets when navigating to a *genuinely different* session, not when the same session ID re-triggers due to SolidJS store proxy changes
- Adds `aiRenameSessionId` signal to track which session initiated the AI rename
- The `aiRenaming` signal is still properly managed by the Promise's `.finally()` block for normal completion

## Root Cause

When "Rename with AI" creates a child session (`client.session.create({ parentID: session.id })`), the resulting SSE `session.created` event triggers a SolidJS store mutation in `sync.tsx`. This can cause `props.session?.id` to re-evaluate, firing the reset effect and setting `aiRenaming` to `false` before the rename completes.

## Changes

| File | Change |
|------|--------|
| `app-prefixable/src/components/session-header.tsx` | Added `aiRenameSessionId` signal; guarded `setAiRenaming(false)` reset to only fire on genuine session navigation; clear `aiRenameSessionId` in `.finally()` |

Closes #53