### PR TITLE
fix: prevent FOUC with early theme detection (closes #72)

### DIFF
--- a/app-prefixable/src/index.html
+++ b/app-prefixable/src/index.html
@@ -9,15 +9,19 @@
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <script>
       (function() {
+        var t = "system";
         try {
-          var t = localStorage.getItem("opencode.theme");
-          var prefersDark = typeof window.matchMedia === "function"
-            ? window.matchMedia("(prefers-color-scheme: dark)").matches
-            : false;
-          if (t === "dark" || ((t !== "light" && t !== "dark") && prefersDark)) {
-            document.documentElement.classList.add("dark");
+          var stored = localStorage.getItem("opencode.theme");
+          if (stored === "light" || stored === "dark") {
+            t = stored;
           }
         } catch (e) {}
+        var prefersDark = typeof window.matchMedia === "function"
+          ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          : false;
+        if (t === "dark" || (t === "system" && prefersDark)) {
+          document.documentElement.classList.add("dark");
+        }
       })();
     </script>
     <link rel="stylesheet" href="./styles.css" />


### PR DESCRIPTION
## Summary
- Add inline script in `<head>` to detect theme preference before first paint
- Make loading screen colors theme-aware with `.dark` variant
- Eliminates flash of wrong theme on page load

Closes #72