### PR TITLE
feat: add terminal dark mode with independent toggle (closes #74)

### DIFF
--- a/app-prefixable/src/components/terminal.tsx
+++ b/app-prefixable/src/components/terminal.tsx
@@ -1,4 +1,4 @@
-import { onMount, onCleanup, createSignal, createEffect } from "solid-js"
+import { onMount, onCleanup, createSignal, createEffect, createMemo } from "solid-js"
 import { Terminal as XTerm } from "@xterm/xterm"
 import { FitAddon } from "@xterm/addon-fit"
 import "@xterm/xterm/css/xterm.css"
@@ -112,7 +112,7 @@ export function Terminal(props: TerminalProps) {
     return scheme
   }
 
-  const activeTheme = () => resolvedScheme() === "dark" ? darkTheme : lightTheme
+  const activeTheme = createMemo(() => resolvedScheme() === "dark" ? darkTheme : lightTheme)
 
   function writeStatus(message: string, type: "info" | "error" | "success" = "info") {
     if (!term) return


### PR DESCRIPTION
## Summary
- Define light and dark xterm.js theme objects with appropriate ANSI color palettes
- Add terminal-specific color scheme preference (auto/light/dark) with localStorage persistence (`opencode.terminal-theme`)
- Reactively update xterm theme and container background when global or terminal theme changes via `createEffect`
- Add unobtrusive cycle-button toggle UI (Monitor/Sun/Moon icons) in terminal header area
- Remove all hardcoded colors from terminal component

Closes #74