### PR TITLE
fix: Text in input field wraps under widget buttons

### DIFF
--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -1573,7 +1573,7 @@ export function Session() {
                   }}
                   placeholder="Type a message... (Tab to switch agent, / for commands)"
                   rows={1}
-                  class="w-full px-4 py-3 focus:outline-none resize-none bg-transparent"
+                  class="w-full px-4 pt-3 pb-2 focus:outline-none resize-none bg-transparent"
                   style={{
                     color: "var(--text-base)",
                     "min-height": "48px",


### PR DESCRIPTION
## Summary

Closes #61

- Tightens vertical spacing between textarea and bottom button bar (py-3 → pt-3 pb-2)
- The main fix was already applied in a prior commit that moved widget buttons from an absolute overlay to a separate bottom bar below the textarea, eliminating the text-under-buttons problem entirely

### Modified files
- `app-prefixable/src/pages/session.tsx`