### PR TITLE
feat: add slash commands /compact, /share, /unshare, /undo, /redo, /terminal

### DIFF
--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -85,17 +85,17 @@ export function Session() {
   // Unified toast system — only one toast visible at a time
   const [toastMessage, setToastMessage] = createSignal<string | null>(null);
   const [toastVariant, setToastVariant] = createSignal<"default" | "hint">("default");
-  const toastMsgTimer = { id: 0 as ReturnType<typeof setTimeout> };
-  onCleanup(() => clearTimeout(toastMsgTimer.id));
+  const toastMsgTimer: { id: ReturnType<typeof setTimeout> | null } = { id: null };
+  onCleanup(() => { if (toastMsgTimer.id !== null) clearTimeout(toastMsgTimer.id); });
 
   function hideToast() {
-    clearTimeout(toastMsgTimer.id);
-    toastMsgTimer.id = undefined as unknown as ReturnType<typeof setTimeout>;
+    if (toastMsgTimer.id !== null) clearTimeout(toastMsgTimer.id);
+    toastMsgTimer.id = null;
     setToastMessage(null);
   }
 
   function showToast(msg: string, duration = 2500, variant: "default" | "hint" = "default") {
-    clearTimeout(toastMsgTimer.id);
+    if (toastMsgTimer.id !== null) clearTimeout(toastMsgTimer.id);
     setToastMessage(msg);
     setToastVariant(variant);
     toastMsgTimer.id = setTimeout(() => hideToast(), duration);


### PR DESCRIPTION
Closes #100

## Summary

- Added 6 new slash commands to the session page: `/compact`, `/share`, `/unshare`, `/undo`, `/redo`, `/terminal`
- Commands are conditionally shown based on session state (e.g., `/undo` only appears when there are user messages, `/redo` only when in a reverted state, `/unshare` only when session is shared)
- `/compact` calls `session.summarize()` with the currently selected model/provider
- `/share` generates a shareable link and copies it to clipboard; if already shared, copies the existing link
- `/unshare` removes the shared link via `session.unshare()`
- `/undo` reverts the last user message via `session.revert()` and restores the message text into the input field
- `/redo` restores reverted messages via `session.unrevert()`
- `/terminal` toggles the terminal panel (same as `Ctrl+``)
- Added a general-purpose toast notification system for command feedback
- Converted `baseSlashCommands` from a static array to a `createMemo` so commands update reactively based on session state

## Files Changed

- `app-prefixable/src/pages/session.tsx` — all changes in this single file