### PR TITLE
feat: add session forking (branch from any user message)

### DIFF
--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -163,6 +163,7 @@ export function Session() {
     const msgs = sync.messages(id);
     return msgs
       .filter((m) => m.info.role === "user")
+      .sort((a, b) => b.info.time.created - a.info.time.created)
       .map((m) => {
         const preview = textFromParts(m.parts, " ", 80);
         const date = new Date(m.info.time.created);
@@ -177,8 +178,7 @@ export function Session() {
           title: preview || (m.parts && m.parts.length > 0 ? "(attachments)" : "(empty message)"),
           description: timestamp,
         };
-      })
-      .reverse();
+      });
   });
   const [showSlashPopover, setShowSlashPopover] = createSignal(false);
   const [slashQuery, setSlashQuery] = createSignal("");


### PR DESCRIPTION
Closes #97

## Summary

- Add `/fork` slash command that opens a picker dialog showing all user messages from the current session in reverse chronological order with timestamps
- On selection, calls `client.session.fork({ sessionID, messageID })` to create a new branched session via the API
- Navigates to the newly forked session and restores the selected message's text into the input field
- Disabled when session has no user messages (command is a no-op)
- Reuses the existing `PickerDialog` component for message selection
- Adds `showForkPicker` to the double-Escape abort exclusion list so the dialog can be closed normally

## Files Changed

- `app-prefixable/src/pages/session.tsx` — added `/fork` slash command, fork picker state, fork picker dialog, and escape handler integration