### PR TITLE
feat: add session search in sidebar

### DIFF
--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -867,6 +867,12 @@ export function Layout(props: ParentProps) {
         return;
       }
 
+      if (e.key === "Escape") {
+        e.preventDefault();
+        clearSearch();
+        searchInputRef?.focus();
+        return;
+      }
       if (e.key === "ArrowDown") {
         e.preventDefault();
         const next = searchFocusIdx() < results.length - 1 ? searchFocusIdx() + 1 : 0;


### PR DESCRIPTION
Closes #99

## Summary

- Added a search input to the sidebar between the "New Session" button and the session list
- Typing filters sessions by title via the backend API (`session.list({ search, directory, roots: true })`) with 300ms debouncing
- Shows a loading spinner during search, clear button (X) to reset, and "No results" when empty
- Search results include both active and archived sessions with visual distinction (archive icon + dimmed style)
- Clicking a result navigates to the session and clears the search; Escape key also clears
- The normal grouped-by-date session list is hidden during search and restored when search is cleared
- Search input does not steal focus on page load

## Files Changed

- `app-prefixable/src/pages/layout.tsx` — search state signals, debounced API call, search input UI, conditional rendering of search results vs grouped sessions