### PR TITLE
fix: move session memo before baseSlashCommands to avoid TDZ crash

### DIFF
--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -378,6 +378,13 @@ export function Session() {
   let slashPopoverRef: HTMLDivElement | undefined;
   let fileInputRef: HTMLInputElement | undefined;
 
+  // Get session from sync context - reactive, automatically updated via SSE
+  const session = createMemo(() => {
+    const id = params.id;
+    if (!id) return null;
+    return sync.session.get(id) ?? null;
+  });
+
   // Slash commands — computed so state-dependent commands update reactively
   const baseSlashCommands = createMemo<Command[]>(() => {
     const id = sessionId();
@@ -788,13 +795,6 @@ export function Session() {
 
   onCleanup(() => {
     window.removeEventListener("keydown", handleGlobalKeyDown);
-  });
-
-  // Get session from sync context - reactive, automatically updated via SSE
-  const session = createMemo(() => {
-    const id = params.id;
-    if (!id) return null;
-    return sync.session.get(id) ?? null;
   });
 
   // Refetch is now just re-syncing


### PR DESCRIPTION
## Summary

- Fixes `ReferenceError: can't access lexical declaration 'session' before initialization` crash on page load
- The `session` createMemo was declared at line 794 but referenced inside `baseSlashCommands` at line 384, causing a temporal dead zone (TDZ) error
- Moved the declaration before its first usage — no functional changes