### PR TITLE
fix: review panel tabs unreadable in dark mode

### DIFF
--- a/app-prefixable/src/components/review-panel.tsx
+++ b/app-prefixable/src/components/review-panel.tsx
@@ -365,7 +365,10 @@ export function ReviewPanel(props: ReviewPanelProps) {
             >
               <div
                 class="px-2 py-2"
-                style={{ "border-bottom": "1px solid var(--border-base)" }}
+                style={{
+                  "border-bottom": "1px solid var(--border-base)",
+                  color: "var(--text-base)",
+                }}
               >
                 <Tabs.List class="flex gap-1">
                   <Tabs.Trigger


### PR DESCRIPTION
## Summary

- The "Changes" and "All Files" tab triggers in the review panel had no explicit text color
- They inherited from the parent, which made them invisible (dark text on dark background) in dark mode
- Added `color: var(--text-base)` to the tabs container div