### PR TITLE
fix: prevent QuestionPrompt global keydown handler from intercepting textarea input

### DIFF
--- a/app-prefixable/src/components/question-prompt.tsx
+++ b/app-prefixable/src/components/question-prompt.tsx
@@ -127,6 +127,12 @@ export function QuestionPrompt(props: Props) {
   }
 
   function handleKeyDown(e: KeyboardEvent) {
+    // Ignore when focus is on input elements
+    const target = e.target as HTMLElement
+    if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
+      return
+    }
+
     if (editing()) {
       if (e.key === "Escape") {
         e.preventDefault()


### PR DESCRIPTION
## Summary

- Adds an input-target guard to `QuestionPrompt`'s global `keydown` handler, matching the existing pattern in `PermissionPrompt` (`permission-prompt.tsx:50-54`)
- When `e.target` is an `INPUT`, `TEXTAREA`, or `contentEditable` element, the handler returns early instead of intercepting the keyboard event

## Problem

When a question prompt is active, the global `document.addEventListener("keydown", ...)` handler intercepts keyboard events intended for the main textarea — Enter, Escape, arrows, j/k, Tab, and number keys 1-9 are all captured by the question handler instead of reaching the textarea.

## Fix

Added an early return at the top of `handleKeyDown` in `question-prompt.tsx`:

```typescript
const target = e.target as HTMLElement
if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
  return
}
```

This is the same pattern already used in `permission-prompt.tsx:50-54`.

Closes #117