### PR TITLE
fix: filter out sub-sessions from command palette session list

### DIFF
--- a/app-prefixable/src/components/command-palette.tsx
+++ b/app-prefixable/src/components/command-palette.tsx
@@ -44,7 +44,7 @@ export function CommandPalette() {
     const result: PaletteItem[] = []
 
     // Sessions from current project
-    const sessions = sync.sessions().filter((s) => s.directory === directory && !s.time?.archived)
+    const sessions = sync.sessions().filter((s) => s.directory === directory && !s.time?.archived && !s.parentID)
     const dirSlug = directory ? base64Encode(directory) : ""
 
     for (const s of sessions) {


### PR DESCRIPTION
## Summary

- Filter out sub-sessions (those with a `parentID`) from the command palette session list, matching the sidebar's existing behavior

## Changes

- `app-prefixable/src/components/command-palette.tsx`: Added `!s.parentID` to the session filter on line 47

Closes #118