### PR TITLE
fix: scroll active session into view on navigation/session creation

### DIFF
--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -3,6 +3,7 @@ import {
   createSignal,
   For,
   Show,
+  on,
   onMount,
   createMemo,
   onCleanup,
@@ -1409,6 +1410,20 @@ export function Layout(props: ParentProps) {
 
     onCleanup(unsub);
   });
+
+  // When the active session changes (navigation, new session creation, etc.),
+  // scroll it into view in the sidebar. Uses `on()` with defer so it only fires
+  // on actual changes, not on initial mount or unrelated re-renders.
+  createEffect(
+    on(
+      () => currentSessionId(),
+      (id) => {
+        if (!id) return;
+        scrollFocusedIntoView(id);
+      },
+      { defer: true },
+    ),
+  );
 
   // --- Global alarm monitoring for ALL sessions with bell enabled ---
   // NOTE: Currently scoped to the active directory's SSE stream (EventProvider connects


### PR DESCRIPTION
## Summary

- Adds a reactive `createEffect` that watches `currentSessionId()` and scrolls the active session into view in the sidebar whenever the session changes
- Fixes the bug where creating a session via the saved-prompt dropdown causes the sidebar to scroll to an old session instead of the new one

## Details

The root cause was a race between navigation, SSE events, and session list re-rendering. When a new session was created (especially via the saved-prompt dropdown), the SSE `session.created` event would trigger `loadSessions()`, which replaces the entire session list. After re-rendering, there was no code to scroll the newly active session into view.

The fix uses SolidJS `on()` with `{ defer: true }` to:
- Only fire when `currentSessionId()` actually changes (not on every re-render)
- Skip the initial mount (deferred)
- Reuse the existing `scrollFocusedIntoView()` helper, which uses `block: "nearest"` to avoid interfering with manual scrolling

## Acceptance Criteria

- [x] After creating a new session via "New Session" button, the new session is visible and highlighted in sidebar
- [x] After creating via saved-prompt dropdown, same behavior
- [x] After clicking a session, it remains visible (no unexpected scroll jump after SSE re-render)
- [x] Manual scrolling in sidebar is not interfered with (`block: "nearest"` + deferred effect)
- [x] No regressions in keyboard navigation scroll behavior (existing `scrollFocusedIntoView` calls unchanged)

Closes #114