### PR TITLE
fix: let Ctrl+1-4 panel shortcuts pass through xterm to browser

### DIFF
--- a/app-prefixable/src/components/terminal.tsx
+++ b/app-prefixable/src/components/terminal.tsx
@@ -10,6 +10,7 @@ import type { ITheme } from "@xterm/xterm"
 type TerminalColorScheme = "auto" | "light" | "dark"
 
 const TERMINAL_THEME_KEY = "opencode.terminal-theme"
+const PANEL_FOCUS_KEYS = new Set(["1", "2", "3", "4"])
 
 const lightTheme: ITheme = {
   background: "#ffffff",
@@ -214,7 +215,7 @@ export function Terminal(props: TerminalProps) {
     // Let plain Ctrl+1-4 pass through to the browser for panel focus shortcuts
     // Exclude AltGr (reports as Ctrl+Alt) to avoid breaking locale-specific input
     term.attachCustomKeyEventHandler((event) => {
-      if (event.ctrlKey && !event.altKey && !event.metaKey && ["1", "2", "3", "4"].includes(event.key))
+      if (event.ctrlKey && !event.altKey && !event.metaKey && PANEL_FOCUS_KEYS.has(event.key))
         return false
       return true
     })


### PR DESCRIPTION
## Summary

- Registers a `customKeyEventHandler` on the xterm Terminal instance that returns `false` for Ctrl+1 through Ctrl+4, letting the browser handle these keypresses as panel focus shortcuts instead of xterm consuming them as control sequences.
- All other Ctrl+key sequences (Ctrl+C, Ctrl+D, etc.) continue to work normally in the terminal.

Closes #123