### PR TITLE
fix: prevent chat input helper text from wrapping when panels are open

### DIFF
--- a/app-prefixable/src/components/session-info.tsx
+++ b/app-prefixable/src/components/session-info.tsx
@@ -102,7 +102,7 @@ export function SessionInfo(props: SessionInfoProps) {
   return (
     <div class="flex items-center px-4 py-1.5 text-xs" style={{ color: "var(--text-weak)" }}>
       {/* Left group - info text, truncatable */}
-      <div class="flex flex-1 items-center gap-3 min-w-0 overflow-hidden whitespace-nowrap">
+      <div class="flex flex-1 items-center gap-3 min-w-0 overflow-hidden whitespace-nowrap [&_button:focus-visible]:outline-offset-[-2px] [&_a:focus-visible]:outline-offset-[-2px]">
         {/* Agent */}
         <Show when={providers.selectedAgent}>
           <button


### PR DESCRIPTION
## Summary

- Replaces `flex-wrap` with `overflow-hidden` on the session info bar so helper text stays on a single line regardless of how many side panels are open
- Makes the model ID truncate with ellipsis when space is tight (instead of pushing content to wrap)
- Ensures action buttons (Enter hint, Stop) always remain visible with `shrink-0`

## Changes

**`app-prefixable/src/components/session-info.tsx`**:
- Container: `flex-wrap` → `overflow-hidden` to prevent line wrapping
- Model span: removed `shrink-0`, added `min-w-0` + `truncate` so long model IDs gracefully truncate
- Action buttons div: added `shrink-0` to keep Enter/Stop always visible

Closes #124