### PR TITLE
fix: Alt+1-9 session jump shortcuts on macOS

### DIFF
--- a/app-prefixable/src/components/command-palette.tsx
+++ b/app-prefixable/src/components/command-palette.tsx
@@ -102,7 +102,7 @@ export function CommandPalette() {
         title: cmd.title,
         description: cmd.description,
         category: "command",
-        keybind: cmd.keybind,
+        keybind: cmd.keybindDisplay ?? cmd.keybind,
         icon: "command",
         onSelect: cmd.onSelect,
       })

--- a/app-prefixable/src/components/shortcut-reference.tsx
+++ b/app-prefixable/src/components/shortcut-reference.tsx
@@ -101,7 +101,7 @@ export function ShortcutReference() {
                       border: "1px solid var(--border-base)",
                     }}
                   >
-                    {formatKeybind(command.keybind!)}
+                    {formatKeybind(command.keybindDisplay ?? command.keybind!)}
                   </kbd>
                 </div>
               )}

--- a/app-prefixable/src/context/command.tsx
+++ b/app-prefixable/src/context/command.tsx
@@ -7,6 +7,8 @@ export interface Command {
   description?: string
   slash?: string
   keybind?: string
+  /** Display-only keybind shown in shortcut reference but not registered with tinykeys */
+  keybindDisplay?: string
   /** When true, the shortcut fires even from inputs, textareas, and terminals */
   global?: boolean
   /** When true, preventDefault is NOT called automatically — the handler receives the event */
@@ -131,7 +133,7 @@ export function CommandProvider(props: ParentProps) {
   }
 
   function getKeyboardShortcuts() {
-    return commands().filter((c) => c.keybind && !c.hidden)
+    return commands().filter((c) => (c.keybind || c.keybindDisplay) && !c.hidden)
   }
 
   // Reactively bind shortcuts via tinykeys whenever commands change

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1251,15 +1251,22 @@ export function Layout(props: ParentProps) {
         onSelect: () => navigateSessionDelta(-1),
       },
       // Alt+1 through Alt+9: jump to session by position
-      // Alt+1 is visible in the cheat sheet as representative; Alt+2-9 are hidden
-      ...Array.from({ length: 9 }, (_, i) => ({
-        id: `session.jump.${i + 1}`,
-        title: i === 0 ? "Jump to Session 1–9" : `Go to Session ${i + 1}`,
-        description: i === 0 ? "Switch to a session by its sidebar position" : undefined,
-        keybind: `alt+${i + 1}`,
-        global: true,
-        hidden: i > 0,
-        onSelect: () => navigateToSessionIndex(i),
+      // Handled via custom keydown listener (not tinykeys) because macOS Option+number
+      // produces special characters (e.g. ¡, ™) and tinykeys matches on event.key.
+      // Only Alt+1 is visible in the cheat sheet as representative; Alt+2-9 are hidden.
+      {
+        id: "session.jump.1",
+        title: "Jump to Session 1–9",
+        description: "Switch to a session by its sidebar position",
+        keybindDisplay: "alt+1",
+        hidden: false,
+        onSelect: () => navigateToSessionIndex(0),
+      },
+      ...Array.from({ length: 8 }, (_, i) => ({
+        id: `session.jump.${i + 2}`,
+        title: `Go to Session ${i + 2}`,
+        hidden: true,
+        onSelect: () => navigateToSessionIndex(i + 1),
       })),
       {
         id: "palette.projects",
@@ -1381,7 +1388,28 @@ export function Layout(props: ParentProps) {
       },
     ]);
 
+    // Alt+1-9: custom keydown handler using event.code so it works on macOS
+    // (Option+number produces special characters, making tinykeys's event.key matching fail)
+    function handleAltDigit(e: KeyboardEvent) {
+      if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+      const match = e.code.match(/^Digit([1-9])$/);
+      if (!match) return;
+      // Suppress in text inputs, textareas, contenteditable, and terminal
+      const target = e.target;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+        if (target.isContentEditable) return;
+        if (target.closest(".xterm")) return;
+      }
+      if (isDialogOpen()) return;
+      e.preventDefault();
+      navigateToSessionIndex(Number(match[1]) - 1);
+    }
+    window.addEventListener("keydown", handleAltDigit);
+
     onCleanup(() => {
+      window.removeEventListener("keydown", handleAltDigit);
       command.unregister([
         "palette.open",
         "session.new",


### PR DESCRIPTION
## Summary

- Fixes Alt+1-9 session jump shortcuts not working on macOS, where Option+number produces special characters (e.g. `¡`, `™`) instead of digit keys, causing tinykeys to fail matching
- Replaces tinykeys keybindings with a custom `keydown` handler that checks `event.code` (`Digit1`–`Digit9`) + `event.altKey`, which works across all platforms
- Adds `keybindDisplay` field to the `Command` interface for shortcuts that need display in the shortcut reference and command palette without being registered in tinykeys

## Changes

- `app-prefixable/src/context/command.tsx` — Added `keybindDisplay` property to `Command` interface; updated `getKeyboardShortcuts()` to include commands with display-only keybinds
- `app-prefixable/src/pages/layout.tsx` — Replaced `keybind` with `keybindDisplay` on Alt+1-9 commands; added custom `keydown` event listener using `event.code` matching
- `app-prefixable/src/components/shortcut-reference.tsx` — Uses `keybindDisplay` when available for display
- `app-prefixable/src/components/command-palette.tsx` — Uses `keybindDisplay` when available for display

Closes #122