### PR TITLE
fix: persist MCP server enabled state to config on toggle

### DIFF
--- a/app-prefixable/src/context/mcp.tsx
+++ b/app-prefixable/src/context/mcp.tsx
@@ -154,7 +154,7 @@ export function MCPProvider(props: ParentProps) {
   async function connect(name: string) {
     try {
       await client.mcp.connect({ name })
-      await client.global.config.update({ config: { mcp: { [name]: { enabled: true } } } }).catch(() => {})
+      await client.global.config.update({ config: { mcp: { [name]: { enabled: true } } } }).catch((e) => console.warn("[MCP] Failed to persist config for", name, e))
     } catch (e) {
       console.error("[MCP] Failed to connect:", name, e)
     }
@@ -164,7 +164,7 @@ export function MCPProvider(props: ParentProps) {
   async function disconnect(name: string) {
     try {
       await client.mcp.disconnect({ name })
-      await client.global.config.update({ config: { mcp: { [name]: { enabled: false } } } }).catch(() => {})
+      await client.global.config.update({ config: { mcp: { [name]: { enabled: false } } } }).catch((e) => console.warn("[MCP] Failed to persist config for", name, e))
     } catch (e) {
       console.error("[MCP] Failed to disconnect:", name, e)
     }


### PR DESCRIPTION
## Summary

Fixes the MCP server toggle reverting after ~1 second by persisting the `enabled` state to the global config file.

**Root cause:** `connect()` and `disconnect()` in `mcp.tsx` only changed runtime state via API calls but did not update the config file. The backend auto-reconnects servers where `enabled` is `true` (or absent) in the config, and SSE events triggered a refresh that reverted the toggle.

**Fix:** After calling `client.mcp.connect()`/`client.mcp.disconnect()`, also call `client.global.config.update()` to persist `enabled: true`/`false` in the global config for that server. This uses the same deep-merge config update pattern already used by `add()` in the same file.

## Changes

- `app-prefixable/src/context/mcp.tsx`:
  - `connect()`: Added `client.global.config.update()` call to set `enabled: true`
  - `disconnect()`: Added `client.global.config.update()` call to set `enabled: false`

Closes #152