### PR TITLE
feat: add /api/kernels endpoint for Kubeflow idle culling support

### DIFF
--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -276,6 +276,7 @@ const server = Bun.serve<{ path: string; search: string }>({
 
     message(ws, message) {
       // Forward client messages to backend
+      lastActivity = Date.now()
       const backend = backendConnections.get(ws)
       if (backend?.readyState === WebSocket.OPEN) {
         backend.send(message)


### PR DESCRIPTION
## Summary

- Adds a synthetic `/api/kernels` endpoint that Kubeflow's notebook-controller polls to determine idle/active status for notebook culling
- Tracks last non-polling request timestamp at module level; reports `"busy"` if activity within last 60 seconds, `"idle"` otherwise
- Requests to `/api/kernels` itself do not count as activity, preventing the polling from keeping the notebook alive indefinitely

## Changes

**`docker/serve-ui.ts`**:
- Added `lastActivity` module-level timestamp variable
- Added `GET /api/kernels` handler (before API proxy) that returns a JSON array with a synthetic kernel entry containing `id`, `name`, `last_activity` (ISO 8601), `execution_state`, and `connections`
- All non-`/api/kernels` requests update the activity timestamp
- Works correctly with NB_PREFIX path stripping

Closes #157