### PR TITLE
fix: filter sub-agent sessions from project activity badges

### DIFF
--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -147,7 +147,7 @@ export function GlobalEventsProvider(props: ParentProps & {
       // session.created includes the full Session object with parentID.
       if (event.type === "session.created") {
         const info = (event.properties as { info?: { id?: string; parentID?: string } })?.info
-        if (info?.parentID && info?.id) {
+        if (info?.id && info?.parentID) {
           const sid = info.id
           tracking.subAgents.add(sid)
           // Retroactively clean up tracking sets in case out-of-order events
@@ -158,6 +158,10 @@ export function GlobalEventsProvider(props: ParentProps & {
           if (tracking.questionSessions.delete(sid)) changed = true
           if (tracking.busySessions.delete(sid)) changed = true
           if (changed) recalcAlerts(dir)
+        }
+        // Keep rootSessions up to date for new root sessions created after seeding
+        if (info?.id && !info?.parentID && tracking.rootSessions) {
+          tracking.rootSessions.add(info.id)
         }
         return
       }
@@ -194,7 +198,11 @@ export function GlobalEventsProvider(props: ParentProps & {
         if (existing) clearTimeout(existing)
         permReseedTimers.set(dir, setTimeout(() => {
           permReseedTimers.delete(dir)
-          fetchRootSessionIds(dir).then((roots) => seedPermissions(dir, roots))
+          fetchRootSessionIds(dir).then((roots) => {
+            const tracking = perDir.get(dir)
+            if (tracking && roots) tracking.rootSessions = roots
+            seedPermissions(dir, roots)
+          })
         }, 300))
         return
       }


### PR DESCRIPTION
## Summary

Fixes project avatar badges in the sidebar to only count top-level (root) sessions, excluding sub-agent sessions that inflated badge counts.

- **SSE filtering**: Listens for `session.created` events to build a `subAgents` set of known child session IDs. `permission.asked`, `question.asked`, and `session.status` event handlers now skip sessions in this set.
- **Seed filtering**: New `fetchRootSessionIds()` fetches `/session?roots=true` to get root-only session IDs. `seedPermissions()`, `seedQuestions()`, and `seedStatuses()` now only track sessions present in the root set.
- **Permission reseed**: The debounced `permission.replied` handler also fetches root IDs before reseeding.

### Before
A project with 1 busy root + 3 sub-agents showed badge count **4**.

### After
Same scenario shows badge count **1**.

## Files changed
- `app-prefixable/src/context/global-events.tsx` — All changes in this single file

Closes #155