### PR TITLE
feat: support multi-step undo and /undo N

### DIFF
--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -138,6 +138,17 @@ export function Session() {
   const [loadingHistory, setLoadingHistory] = createSignal(false);
   const [sessionId, setSessionId] = createSignal(params.id);
 
+  // Find the Nth-from-last user message (1-indexed: 1 = last, 2 = second-to-last)
+  function getNthLastUserMsg(msgs: DisplayMessage[], n: number) {
+    let count = 0;
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i].role !== "user") continue;
+      count++;
+      if (count === n) return msgs[i];
+    }
+    return undefined;
+  }
+
   // Extract text content from message parts with optional separator and truncation
   function textFromParts(parts: Part[], separator = " ", maxLen?: number) {
     const text = parts
@@ -447,17 +458,7 @@ export function Session() {
     const msgs = syncMessages();
     const hasMessages = msgs.length > 0;
     const isProcessing = processing();
-    // Find the Nth-from-last user message (1-indexed: 1 = last, 2 = second-to-last)
-    function nthLastUserMsg(n: number) {
-      let count = 0;
-      for (let i = msgs.length - 1; i >= 0; i--) {
-        if (msgs[i].role !== "user") continue;
-        count++;
-        if (count === n) return msgs[i];
-      }
-      return undefined;
-    }
-    const lastUserMsg = nthLastUserMsg(1);
+    const lastUserMsg = getNthLastUserMsg(msgs, 1);
 
     const commands: Command[] = [
       {
@@ -703,21 +704,15 @@ export function Session() {
   // implicitly removes everything after it.
   async function undoTurns(count: number) {
     const id = sessionId();
-    if (!id) return;
-    const msgs = syncMessages();
-    // Find the Nth-from-last user message
-    let found = 0;
-    let target: DisplayMessage | undefined;
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      if (msgs[i].role !== "user") continue;
-      found++;
-      if (found === count) {
-        target = msgs[i];
-        break;
-      }
+    if (!id) {
+      showToast("No active session to undo");
+      return;
     }
+    const msgs = syncMessages();
+    const target = getNthLastUserMsg(msgs, count);
     if (!target) {
-      showToast(count === 1 ? "No user message to undo" : `Only ${found} user message${found === 1 ? "" : "s"} to undo`);
+      const total = msgs.filter((m) => m.role === "user").length;
+      showToast(count === 1 ? "No user message to undo" : `Only ${total} user message${total === 1 ? "" : "s"} to undo`);
       return;
     }
     try {
@@ -783,19 +778,6 @@ export function Session() {
   // Handle input changes to detect slash commands
   function handleInputChange(value: string) {
     setInput(value);
-
-    // Detect `/undo N` — revert N user turns at once
-    const undoMatch = value.match(/^\/undo\s+(\d+)\s*$/i);
-    if (undoMatch) {
-      const n = parseInt(undoMatch[1], 10);
-      if (n > 0) {
-        setInput("");
-        setShowSlashPopover(false);
-        setSlashQuery("");
-        undoTurns(n);
-        return;
-      }
-    }
 
     // Detect `/prompt <search>` — auto-open prompt picker with filter
     const promptMatch = value.match(/^\/prompt\s+(.*)$/i);
@@ -1212,6 +1194,18 @@ export function Session() {
   async function sendMessage(e: SubmitEvent) {
     e.preventDefault();
     const text = input().trim();
+
+    // Intercept `/undo N` — revert N user turns at once (explicit submit only)
+    const undoMatch = text.match(/^\/undo\s+(\d+)$/i);
+    if (undoMatch) {
+      const n = parseInt(undoMatch[1], 10);
+      if (n > 0) {
+        setInput("");
+        undoTurns(n);
+        return;
+      }
+    }
+
     const files = fileContext();
     const images = imageAttachments();
     if ((!text && files.length === 0 && images.length === 0) || loading() || inputBlocked())


### PR DESCRIPTION
## Summary

- **Chained `/undo`**: After an undo, subsequent `/undo` commands target the new last user message. Works naturally because `syncMessages()` updates reactively via SSE after a revert removes messages.
- **`/undo N` argument**: Parse an optional numeric argument (e.g., `/undo 3`) to revert N user turns at once. Finds the Nth-from-last user message and passes its ID to the backend API, which already supports reverting to any messageID.
- **Toast feedback**: Shows "Undone 1 turn" or "Undone N turns" depending on the count. Gracefully handles cases where N exceeds available user messages.

## Changes

- `app-prefixable/src/pages/session.tsx`:
  - Replaced `lastUserMsg` IIFE with `nthLastUserMsg(n)` function for Nth-from-last user message lookup
  - Extracted `undoTurns(count)` as a reusable async function (used by both `/undo` command and `/undo N` input detection)
  - Added `/undo N` pattern detection in `handleInputChange` (similar to existing `/prompt <search>` pattern)
  - Updated command description to hint at `/undo N` syntax
  - Reuses existing `applyInputAndAutogrow` helper for input restoration

## Testing

- `/undo` (no argument) — reverts last user message, restores text to input (same as before)
- `/undo` repeated — each invocation reverts the next user message back
- `/undo 3` — reverts 3 user turns in one operation
- `/undo 999` — shows toast "Only N user messages to undo" when count exceeds available
- `/redo` — still restores all reverted messages (unchanged)
- No regressions to single `/undo` behavior

Closes #164