### PR TITLE
fix: clear chat input text when switching sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- Clear chat input text when switching sessions (#167)
 
 ### Removed
 

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -307,6 +307,8 @@ export function Session() {
     setPendingUserMessageText(null); // Clear pending text on session change
     setFileContext([]); // Clear file context on session change
     setImageAttachments([]); // Clear image attachments on session change
+    setInput(""); // Clear draft text on session change
+    if (inputRef) inputRef.style.height = ""; // Reset textarea auto-grow height
     setPromptSent(false); // Reset so pending prompts fire in the new session
     wasProcessing.value = false; // Reset to avoid false notifications
     if (id) {


### PR DESCRIPTION
## Summary
- Reset the `input` signal and textarea height in the session-switch effect so that draft text doesn't carry over when the user switches sessions
- Closes #167