### PR TITLE
fix: Remove backdrop-click dismiss from form dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- Remove backdrop-click dismiss from form dialogs to prevent accidental data loss (#171)
 - Clear chat input text when switching sessions (#167)
 
 ### Removed

--- a/app-prefixable/src/components/confirm-dialog.tsx
+++ b/app-prefixable/src/components/confirm-dialog.tsx
@@ -93,9 +93,6 @@ export function ConfirmDialog(props: Props) {
         <div
           class="fixed inset-0 z-[100] flex items-center justify-center"
           style={{ background: "rgba(0,0,0,0.5)" }}
-          onClick={(e) => {
-            if (e.target === e.currentTarget && !props.cancelDisabled) props.onCancel()
-          }}
           role="presentation"
         >
           <div

--- a/app-prefixable/src/components/mcp-add-dialog.tsx
+++ b/app-prefixable/src/components/mcp-add-dialog.tsx
@@ -122,9 +122,6 @@ export function MCPAddDialog(props: Props) {
     <div
       class="fixed inset-0 z-50 flex items-center justify-center"
       style={{ background: "rgba(0,0,0,0.5)" }}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) props.onClose()
-      }}
     >
       <div
         class="w-full max-w-lg max-h-[90vh] rounded-lg shadow-xl overflow-hidden flex flex-col"

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -2325,9 +2325,6 @@ function SavePromptDialog(props: {
       <div
         class="fixed inset-0 z-[100] flex items-center justify-center"
         style={{ background: "rgba(0,0,0,0.5)" }}
-        onClick={(e) => {
-          if (e.target === e.currentTarget) props.onClose();
-        }}
         role="presentation"
       >
         <div

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -3097,9 +3097,6 @@ function PromptDialog(props: {
       <div
         class="fixed inset-0 z-[100] flex items-center justify-center"
         style={{ background: "rgba(0,0,0,0.5)" }}
-        onClick={(e) => {
-          if (e.target === e.currentTarget) props.onClose()
-        }}
         role="presentation"
       >
         <div


### PR DESCRIPTION
## Summary

- Remove `onClick` backdrop-dismiss handler from PromptDialog, SavePromptDialog, ConfirmDialog, and MCPAddDialog to prevent accidental data loss when users drag or click outside form dialogs
- Dialogs still close via Escape key and Cancel/X buttons; the dimmed backdrop overlay remains visible

Closes #171