### PR TITLE
fix: remove 600px max-height cap on terminal panel drag resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Clear chat input text when switching sessions (#167)
+- Remove 600px max-height cap on terminal panel drag resize, use viewport-based limit instead (#169)
 
 ### Removed
 

--- a/app-prefixable/src/pages/home-layout.tsx
+++ b/app-prefixable/src/pages/home-layout.tsx
@@ -256,7 +256,8 @@ export function HomeLayout(props: ParentProps) {
 
                         function onMouseMove(e: MouseEvent) {
                           const delta = startY - e.clientY
-                          const newHeight = Math.max(100, Math.min(600, startHeight + delta))
+                          const maxHeight = window.innerHeight - 100
+                          const newHeight = Math.max(100, Math.min(maxHeight, startHeight + delta))
                           setTerminalHeight(newHeight)
                         }
 

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -2756,9 +2756,10 @@ export function Layout(props: ParentProps) {
 
                   function onMouseMove(e: MouseEvent) {
                     const delta = startY - e.clientY;
+                    const maxHeight = window.innerHeight - 100;
                     const newHeight = Math.max(
                       100,
-                      Math.min(600, startHeight + delta),
+                      Math.min(maxHeight, startHeight + delta),
                     );
                     terminal.setHeight(newHeight);
                   }


### PR DESCRIPTION
## Summary

- Replace hardcoded 600px maximum height cap on terminal panel drag resize with a dynamic viewport-based limit (`window.innerHeight - 100`), allowing the terminal to grow to fill most of the screen while preserving at least 100px for the header/chat area above.

## Changes

- **`app-prefixable/src/pages/layout.tsx`** — session layout resize handler: replaced `Math.min(600, ...)` with `Math.min(window.innerHeight - 100, ...)`
- **`app-prefixable/src/pages/home-layout.tsx`** — home layout resize handler: same change
- **`CHANGELOG.md`** — added entry under `### Fixed`

## Acceptance criteria

- [x] Terminal can be dragged to fill most of the viewport (no fixed px cap)
- [x] Terminal minimum height of 100px is preserved
- [x] Content above the terminal remains minimally visible when terminal is maximized
- [x] xterm.js properly reflows to the new size (works automatically via FitAddon)
- [x] Works in both session and home layouts

Closes #169