### PR TITLE
fix: prevent navigation from clobbering in-memory saved prompts signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Remove backdrop-click dismiss from form dialogs to prevent accidental data loss (#171)
 - Fix drag-to-dismiss bug on non-form dialogs (#172)
+- Fix newly created saved prompt not appearing in prompt list until page refresh (#174)
 - Clear chat input text when switching sessions (#167)
 - Remove 600px max-height cap on terminal panel drag resize, use viewport-based limit instead (#169)
 

--- a/app-prefixable/src/context/saved-prompts.tsx
+++ b/app-prefixable/src/context/saved-prompts.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, createSignal, createEffect, type ParentProps, type Accessor } from "solid-js"
+import { createContext, useContext, createSignal, createEffect, on, type ParentProps, type Accessor } from "solid-js"
 
 interface SavedPrompt {
   id: string
@@ -79,12 +79,16 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
     loadFromStorage(key()).sort((a, b) => b.createdAt - a.createdAt),
   )
 
-  // Reload prompts (with migration) when the directory changes
-  createEffect(() => {
+  // Reload prompts (with migration) only when the storage key actually changes
+  // (i.e. when switching projects). Using `on()` with `defer: true` prevents
+  // this effect from running on initial mount (data is already loaded above)
+  // and avoids clobbering in-memory signal updates from add/update/remove
+  // during same-project navigation.
+  createEffect(on(key, (k) => {
     const d = dir()
     if (d) migrateIfNeeded(d)
-    setPrompts(loadFromStorage(key()).sort((a, b) => b.createdAt - a.createdAt))
-  })
+    setPrompts(loadFromStorage(k).sort((a, b) => b.createdAt - a.createdAt))
+  }, { defer: true }))
 
   function add(title: string, text: string) {
     setPrompts((prev) => {


### PR DESCRIPTION
## Summary

Closes #174

- Replace unconditional `createEffect` in `SavedPromptsProvider` with `on(key, ..., { defer: true })` so the effect only fires when the storage key actually changes (i.e. when switching projects), not on every navigation event
- This prevents in-memory signal updates from `add()`/`update()`/`remove()`/`reorder()` from being overwritten by a redundant `loadFromStorage()` call during same-project route transitions

## Root Cause

The `createEffect` at `saved-prompts.tsx:83-87` tracked both `dir()` and `key()` reactively. During navigation (e.g. settings -> session), `useActiveDirectory` fires `setDir(derive())` via the patched `history.pushState`. Even though the directory string is identical, SolidJS re-evaluates the reactive graph and the effect re-runs, calling `loadFromStorage()` and `setPrompts()` — overwriting any prompts that were just added in-memory.

## Fix

Use SolidJS `on()` helper to explicitly track only the `key` accessor with `defer: true`:
- `defer: true` prevents double-loading on mount (data is already loaded synchronously)
- Explicit `key` tracking means the effect only fires when the storage key string actually changes (project switch), not on same-project navigation

## Testing

- Build passes (`bun run build` in `app-prefixable/`)
- The fix is a targeted change to one reactive effect; all existing `add`/`update`/`remove`/`reorder` functions are unchanged