### PR TITLE
docs: remove per-PR changelog entry requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,20 +174,6 @@ git commit -m "fix: description of what changed"
 - For local development, commit locally but wait for user approval before pushing
 - If unsure, ask the user: "Should I push these changes now?"
 
-### Changelog
-
-Every PR must include a single bullet-point entry (one line) in `CHANGELOG.md` under the existing `## [Unreleased]` section. Add your bullet under the appropriate subheading (creating it only if it does not already exist):
-
-- `### Added` for new features
-- `### Fixed` for bug fixes
-- `### Changed` for changes to existing functionality
-- `### Removed` for removed features
-
-Example entry (add this bullet under the appropriate `### Added`/`### Fixed`/... subsection beneath `## [Unreleased]`):
-```markdown
-- Prevent permission toggle from reverting after refresh (#161)
-```
-
 ## Required GitHub CLI Extensions
 
 The workflow requires the `gh-copilot-review` extension for requesting Copilot code reviews on PRs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add drag-to-resize handle for chat input textarea (#170)
 - Add timestamp display and expandable details panel to message turns (#176)
 
-### Changed
-
 ### Fixed
 - Fix saved prompts written to wrong localStorage key during navigation (#187)
 - Fix session unarchive not working due to undefined being stripped by JSON.stringify (#189)
@@ -23,8 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Preserve per-session draft input text, file context, and image attachments across session switches (#173)
 - Clear chat input text when switching sessions (#167)
 - Remove 600px max-height cap on terminal panel drag resize, use viewport-based limit instead (#169)
-
-### Removed
 
 ## [0.8.2] - 2026-03-11
 


### PR DESCRIPTION
## Summary

- Remove the "Changelog" subsection from AGENTS.md that required every PR to add a bullet to CHANGELOG.md
- Remove empty placeholder subsection headers from CHANGELOG.md
- The project is moving to auto-generated release notes (#186), so per-PR entries are no longer needed

Closes #185