### PR TITLE
feat: add GitHub Release creation with auto-generated notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -158,3 +158,18 @@ jobs:
                 body: summary
               });
             }
+
+  create-release:
+    needs: build-prefixable-image
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes --title "${{ github.ref_name }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Add GitHub Release creation with auto-generated notes to tag workflow (#186)
 - Pass message timing, token, and model data through to DisplayMessage and Turn types (#175)
 - Add CHANGELOG.md and require changelog entries in PRs (#165)
 - Add drag-to-resize handle for chat input textarea (#170)


### PR DESCRIPTION
## Summary

- Add a `create-release` job to the existing CI workflow that creates a GitHub Release with auto-generated notes when a `v*` tag is pushed
- Add `.github/release.yml` to categorize PRs in release notes by label (features, bugs, docs)
- The release is only created after the Docker build succeeds
- Add CHANGELOG entry

Closes #186