### PR TITLE
feat: install gh and copilot-review in Kubeflow image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add CHANGELOG.md and require changelog entries in PRs (#165)
 - Add drag-to-resize handle for chat input textarea (#170)
 - Add timestamp display and expandable details panel to message turns (#176)
+- Preinstall GitHub CLI and pinned `gh-copilot-review` extension in the Kubeflow image (#194)
 
 ### Fixed
 - Fix saved prompts written to wrong localStorage key during navigation (#187)

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -81,7 +81,8 @@ RUN mkdir -p /home/jovyan/.config/opencode \
              /run
 
 RUN printf 'git_protocol: https\nversion: "1"\n' > /home/jovyan/.config/gh/config.yml && \
-    printf 'github.com:\n    git_protocol: https\n' > /home/jovyan/.config/gh/hosts.yml
+    printf 'github.com:\n    git_protocol: https\n' > /home/jovyan/.config/gh/hosts.yml && \
+    chmod 600 /home/jovyan/.config/gh/hosts.yml
 
 # Install GitHub Copilot review extension for the runtime user.
 # The extension has no tags/releases, so pin to an audited commit for reproducibility.

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -78,16 +78,19 @@ RUN mkdir -p /home/jovyan/.config/opencode \
              /home/jovyan/.s6-runtime \
              /opt/opencode-ui \
              /tmp_home \
-              /run
+             /run
 
 RUN printf 'git_protocol: https\nprompt: disabled\nversion: "1"\n' > /home/jovyan/.config/gh/config.yml && \
-    printf 'github.com:\n    user: jovyan\n    oauth_token: ""\n    git_protocol: https\n' > /home/jovyan/.config/gh/hosts.yml
+    printf 'github.com:\n    git_protocol: https\n' > /home/jovyan/.config/gh/hosts.yml
 
 # Install GitHub Copilot review extension for the runtime user.
 # The extension has no tags/releases, so pin to an audited commit for reproducibility.
 ARG GH_COPILOT_REVIEW_REF=1dfe6cd4abf66f8d45cbc0b3de26cf202fd27910
-RUN git clone https://github.com/ChrisCarini/gh-copilot-review /home/jovyan/.local/share/gh/extensions/gh-copilot-review && \
-    git -C /home/jovyan/.local/share/gh/extensions/gh-copilot-review checkout "${GH_COPILOT_REVIEW_REF}"
+RUN mkdir -p /home/jovyan/.local/share/gh/extensions/gh-copilot-review && \
+    git -C /home/jovyan/.local/share/gh/extensions/gh-copilot-review init && \
+    git -C /home/jovyan/.local/share/gh/extensions/gh-copilot-review remote add origin https://github.com/ChrisCarini/gh-copilot-review && \
+    git -C /home/jovyan/.local/share/gh/extensions/gh-copilot-review fetch --depth 1 origin "${GH_COPILOT_REVIEW_REF}" && \
+    git -C /home/jovyan/.local/share/gh/extensions/gh-copilot-review checkout FETCH_HEAD
 
 # Copy default OpenCode config (disables amazon-bedrock to avoid S3/MinIO credential confusion)
 COPY docker/kubeflow/opencode-default-config.json /home/jovyan/.config/opencode/opencode.json

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -30,6 +30,7 @@ FROM alpine:3.21
 RUN apk add --no-cache \
     bash \
     git \
+    github-cli \
     curl \
     openssh-client \
     neovim \
@@ -71,11 +72,22 @@ RUN addgroup -g 1000 jovyan && \
 # Create directories (including s6 runtime directory for rootless mode)
 # /run must be writable by jovyan for s6-overlay's preinit writability test
 RUN mkdir -p /home/jovyan/.config/opencode \
+             /home/jovyan/.config/gh \
+             /home/jovyan/.local/share/gh \
              /home/jovyan/.local/share/opencode \
              /home/jovyan/.s6-runtime \
              /opt/opencode-ui \
              /tmp_home \
-             /run
+              /run
+
+RUN printf 'git_protocol: https\nprompt: disabled\nversion: "1"\n' > /home/jovyan/.config/gh/config.yml && \
+    printf 'github.com:\n    user: jovyan\n    oauth_token: ""\n    git_protocol: https\n' > /home/jovyan/.config/gh/hosts.yml
+
+# Install GitHub Copilot review extension for the runtime user.
+# The extension has no tags/releases, so pin to an audited commit for reproducibility.
+ARG GH_COPILOT_REVIEW_REF=1dfe6cd4abf66f8d45cbc0b3de26cf202fd27910
+RUN git clone https://github.com/ChrisCarini/gh-copilot-review /home/jovyan/.local/share/gh/extensions/gh-copilot-review && \
+    git -C /home/jovyan/.local/share/gh/extensions/gh-copilot-review checkout "${GH_COPILOT_REVIEW_REF}"
 
 # Copy default OpenCode config (disables amazon-bedrock to avoid S3/MinIO credential confusion)
 COPY docker/kubeflow/opencode-default-config.json /home/jovyan/.config/opencode/opencode.json

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -80,7 +80,7 @@ RUN mkdir -p /home/jovyan/.config/opencode \
              /tmp_home \
              /run
 
-RUN printf 'git_protocol: https\nprompt: disabled\nversion: "1"\n' > /home/jovyan/.config/gh/config.yml && \
+RUN printf 'git_protocol: https\nversion: "1"\n' > /home/jovyan/.config/gh/config.yml && \
     printf 'github.com:\n    git_protocol: https\n' > /home/jovyan/.config/gh/hosts.yml
 
 # Install GitHub Copilot review extension for the runtime user.

--- a/docker/kubeflow/README.md
+++ b/docker/kubeflow/README.md
@@ -8,6 +8,7 @@ This image combines:
 
 - **OpenCode API Server** (runs on internal port 4096)
 - **Prefix-Aware Web UI** (serves on port 8888, proxies to API)
+- **GitHub CLI and Copilot Review extension** (`gh` + `gh-copilot-review`)
 
 The UI automatically adapts to any URL prefix set by Kubeflow's `NB_PREFIX` environment variable.
 
@@ -115,6 +116,12 @@ spec:
 | `KF_EXAMPLES_REPO` | (empty)                 | Git repo to clone on startup      |
 | `BRANDING_NAME`    | (empty)                 | Optional branding name shown in UI|
 | `BRANDING_URL`     | (empty)                 | Optional URL for branding link    |
+
+## Preinstalled Developer Tooling
+
+- `gh` is preinstalled in the image and available to the runtime user (`jovyan`).
+- `gh-copilot-review` is preinstalled for `jovyan` and can be used with `gh copilot-review <pr-number>`.
+- The extension is pinned in `docker/kubeflow/Dockerfile` via `GH_COPILOT_REVIEW_REF` for reproducible builds.
 
 ## Configuration Directories
 


### PR DESCRIPTION
## Summary
- install GitHub CLI (`gh`) in the Kubeflow runtime image
- preinstall `gh-copilot-review` for the `jovyan` runtime user and pin it to a commit for reproducible builds
- document the preinstalled tooling in Kubeflow image docs and add an Unreleased changelog entry

## Validation
- docker build -f docker/kubeflow/Dockerfile -t opencode-web-kubeflow:issue-194 .
- docker run --rm --user jovyan opencode-web-kubeflow:issue-194 gh --version
- docker run --rm --user jovyan --entrypoint gh opencode-web-kubeflow:issue-194 extension list
- docker run --rm --user jovyan --entrypoint sh opencode-web-kubeflow:issue-194 -lc "gh extension list"

Closes #194