### PR TITLE
feat: add server-side proxy for remote server connections

### DIFF
--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -1,5 +1,6 @@
 import { watch } from "fs"
 import { handleExtendedEndpoint, isApiPath } from "../shared/extended-api"
+import { handleProxyRequest } from "../shared/proxy"
 
 const BASE_PATH = process.env.BASE_PATH || "/"
 const PORT = parseInt(process.env.PORT || "3000", 10)
@@ -62,6 +63,15 @@ const server = Bun.serve<{ target: string }>({
       })
       if (upgraded) return undefined
       return new Response("WebSocket upgrade failed", { status: 500 })
+    }
+
+    // Proxy requests to remote servers (avoids CORS)
+    if (strippedPath.startsWith("/__proxy/")) {
+      const proxyPath = strippedPath.slice("/__proxy".length)
+      return handleProxyRequest(proxyPath, req)
+    }
+    if (strippedPath === "/__proxy") {
+      return handleProxyRequest("/", req)
     }
 
     // Extended API endpoints (handled locally, not proxied)

--- a/app-prefixable/src/context/server.tsx
+++ b/app-prefixable/src/context/server.tsx
@@ -185,11 +185,23 @@ export function ServerProvider(props: ParentProps) {
   }
 
   function authHeaders() {
-    return getAuthHeaders(activeServer().auth)
+    const s = activeServer()
+    const auth = getAuthHeaders(s.auth)
+    // For remote servers, add proxy target header so the local server
+    // can forward the request to the correct remote URL
+    if (!s.isDefault) {
+      return { ...auth, "X-Proxy-Target": s.url }
+    }
+    return auth
   }
 
   function serverUrl() {
-    return activeServer().url
+    const s = activeServer()
+    // Remote servers go through the local proxy to avoid CORS issues
+    if (!s.isDefault) {
+      return getServerUrl() + "/__proxy"
+    }
+    return s.url
   }
 
   function activeServerKey() {

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -10,6 +10,7 @@
  */
 
 import { handleExtendedEndpoint, isApiPath } from "../shared/extended-api"
+import { handleProxyRequest } from "../shared/proxy"
 
 const BASE_PATH = process.env.NB_PREFIX || process.env.BASE_PATH || "/"
 const PORT = parseInt(process.env.PORT || "8080", 10)
@@ -128,6 +129,15 @@ const server = Bun.serve<{ path: string; search: string }>({
         }
         return new Response("WebSocket upgrade failed", { status: 500 })
       }
+    }
+
+    // Proxy requests to remote servers (avoids CORS)
+    if (path.startsWith("/__proxy/")) {
+      const proxyPath = path.slice("/__proxy".length)
+      return handleProxyRequest(proxyPath, req)
+    }
+    if (path === "/__proxy") {
+      return handleProxyRequest("/", req)
     }
 
     // Extended API endpoints (handled locally, not proxied)

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared proxy handler for remote OpenCode server connections.
+ *
+ * Reads `X-Proxy-Target` header to determine the remote base URL,
+ * then forwards the request (including auth headers) to the target.
+ * Handles both regular API requests and SSE streaming.
+ */
+
+/**
+ * Handle a proxied request to a remote server.
+ * @param path - The API path after /__proxy (e.g. "/session", "/event?directory=...")
+ * @param req - The incoming request
+ * @returns Response or null if not a proxy request
+ */
+export async function handleProxyRequest(path: string, req: Request): Promise<Response> {
+  const target = req.headers.get("x-proxy-target")
+  if (!target) {
+    return new Response(JSON.stringify({ error: "Missing X-Proxy-Target header" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    })
+  }
+
+  // Build target URL: append path to the target base (preserving target's own path)
+  let targetUrl: URL
+  try {
+    const base = target.endsWith("/") ? target.slice(0, -1) : target
+    const suffix = path.startsWith("/") ? path : "/" + path
+    targetUrl = new URL(base + suffix + (new URL(req.url).search || ""))
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid proxy target URL" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    })
+  }
+
+  // Forward headers, removing hop-by-hop and proxy-specific ones
+  const headers = new Headers(req.headers)
+  headers.delete("x-proxy-target")
+  headers.delete("host")
+  headers.delete("connection")
+
+  const isSSE = path.startsWith("/event")
+
+  try {
+    console.log(`[Proxy] ${isSSE ? "SSE" : req.method} -> ${targetUrl.toString()}`)
+
+    const response = await fetch(targetUrl.toString(), {
+      method: req.method,
+      headers,
+      body: req.method !== "GET" && req.method !== "HEAD" ? req.body : undefined,
+    })
+
+    if (isSSE) {
+      if (!response.ok) {
+        console.error("[Proxy] SSE error:", response.status, response.statusText)
+        return new Response(response.body, { status: response.status })
+      }
+
+      return new Response(response.body, {
+        status: response.status,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          "Connection": "keep-alive",
+          "X-Accel-Buffering": "no",
+        },
+      })
+    }
+
+    // Forward the response with CORS-safe headers
+    const responseHeaders = new Headers(response.headers)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    })
+  } catch (e) {
+    console.error("[Proxy] Connection error:", e)
+    return new Response(JSON.stringify({ error: "Proxy connection failed" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Add `/__proxy/` endpoint to dev and production servers that forwards requests to remote OpenCode servers
- Solves CORS issues when connecting to remote servers from the browser
- Stateless design: frontend sends `X-Proxy-Target` header with the remote URL
- Handles both regular API requests and SSE streaming

## Test plan
- [x] Verified proxy works with `curl` against remote prokube.ai sandbox
- [ ] Test full UI flow with remote server connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)