### PR TITLE
fix: strip Content-Encoding from proxy responses

### DIFF
--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -84,8 +84,12 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
       })
     }
 
-    // Forward the response with CORS headers
+    // Forward the response with CORS headers.
+    // Remove Content-Encoding because fetch() already decompresses the body,
+    // so passing gzip/br encoding to the browser causes double-decode failures.
     const responseHeaders = new Headers(response.headers)
+    responseHeaders.delete("content-encoding")
+    responseHeaders.delete("content-length") // length no longer matches after decompression
     responseHeaders.set("Access-Control-Allow-Origin", "*")
     return new Response(response.body, {
       status: response.status,


### PR DESCRIPTION
## Summary
- fetch() auto-decompresses gzip responses but forwards the original Content-Encoding header
- Browser tries to double-decode, causing "Decoding failed" errors
- Remove Content-Encoding and Content-Length from proxied responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)