### PR TITLE
feat: add Servers tab to Settings, API Key field for MCP, skip GlobalEvents for remote servers

### DIFF
--- a/app-prefixable/src/components/mcp-add-dialog.tsx
+++ b/app-prefixable/src/components/mcp-add-dialog.tsx
@@ -21,6 +21,9 @@ export function MCPAddDialog(props: Props) {
   const [loading, setLoading] = createSignal(false)
   const [showAdvanced, setShowAdvanced] = createSignal(false)
 
+  // API Key (convenience field — adds Authorization header automatically)
+  const [apiKey, setApiKey] = createSignal("")
+
   // Advanced options
   const [timeout, setTimeout] = createSignal("")
   const [headers, setHeaders] = createSignal<Header[]>([])
@@ -70,6 +73,9 @@ export function MCPAddDialog(props: Props) {
 
     // Build headers object
     const headersObj: Record<string, string> = {}
+    if (apiKey().trim()) {
+      headersObj["Authorization"] = `Bearer ${apiKey().trim()}`
+    }
     for (const h of headers()) {
       if (h.key.trim()) {
         headersObj[h.key.trim()] = h.value
@@ -192,6 +198,24 @@ export function MCPAddDialog(props: Props) {
             />
             <p class="text-xs mt-1" style={{ color: "var(--text-weak)" }}>
               The URL of the remote MCP server (SSE or HTTP endpoint)
+            </p>
+          </div>
+
+          {/* API Key (optional) */}
+          <div>
+            <label class="block text-sm font-medium mb-1" style={{ color: "var(--text-base)" }}>
+              API Key <span class="text-xs font-normal" style={{ color: "var(--text-weak)" }}>(optional)</span>
+            </label>
+            <input
+              type="password"
+              value={apiKey()}
+              onInput={(e) => setApiKey(e.currentTarget.value)}
+              placeholder="Bearer token or API key"
+              class="w-full px-3 py-2 rounded-md text-sm font-mono"
+              style={inputStyle}
+            />
+            <p class="text-xs mt-1" style={{ color: "var(--text-weak)" }}>
+              Sent as Authorization: Bearer header
             </p>
           </div>
 

--- a/app-prefixable/src/components/mcp-add-dialog.tsx
+++ b/app-prefixable/src/components/mcp-add-dialog.tsx
@@ -73,8 +73,11 @@ export function MCPAddDialog(props: Props) {
 
     // Build headers object
     const headersObj: Record<string, string> = {}
-    if (apiKey().trim()) {
-      headersObj["Authorization"] = `Bearer ${apiKey().trim()}`
+    const rawApiKey = apiKey().trim()
+    if (rawApiKey) {
+      headersObj["Authorization"] = rawApiKey.toLowerCase().startsWith("bearer ")
+        ? rawApiKey
+        : `Bearer ${rawApiKey}`
     }
     for (const h of headers()) {
       if (h.key.trim()) {
@@ -215,7 +218,7 @@ export function MCPAddDialog(props: Props) {
               style={inputStyle}
             />
             <p class="text-xs mt-1" style={{ color: "var(--text-weak)" }}>
-              Sent as Authorization: Bearer header
+              Sent as Authorization: Bearer header. Saved to MCP config file.
             </p>
           </div>
 

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -45,7 +45,7 @@ export function GlobalEventsProvider(props: ParentProps & {
   projects: () => { worktree: string }[]
   activeDirectory: () => string | undefined
 }) {
-  const { authHeaders, serverUrl } = useServer()
+  const { authHeaders, serverUrl, activeServer } = useServer()
 
   // Per-directory alert state
   const [alerts, setAlerts] = createStore<Record<string, ProjectAlerts>>({})
@@ -107,6 +107,8 @@ export function GlobalEventsProvider(props: ParentProps & {
 
   function connectToDirectory(dir: string) {
     if (connections.has(dir)) return
+    // Don't connect when a remote server is active
+    if (!activeServer().isDefault) return
 
     // Cancel any pending reconnect timer for this directory
     const pending = reconnectTimers.get(dir)
@@ -283,6 +285,8 @@ export function GlobalEventsProvider(props: ParentProps & {
         const reconnectTimer = setTimeout(() => {
           reconnectTimers.delete(dir)
           if (disposed) return
+          // Don't reconnect when a remote server is active — local projects don't exist there
+          if (!activeServer().isDefault) return
           const active = props.activeDirectory()
           const wanted = props.projects().some((p) => p.worktree === dir)
           if (wanted && dir !== active) {
@@ -452,9 +456,19 @@ export function GlobalEventsProvider(props: ParentProps & {
 
   // Reactively manage connections when projects or active directory change.
   // Active project is excluded — it has its own EventProvider.
+  // Remote servers are skipped — local projects don't exist on remote servers.
   createEffect(on(
-    () => ({ dirs: props.projects().map((p) => p.worktree), active: props.activeDirectory() }),
+    () => ({ dirs: props.projects().map((p) => p.worktree), active: props.activeDirectory(), isRemote: !activeServer().isDefault }),
     (current) => {
+      // When a remote server is active, disconnect all global event connections
+      // since local projects don't exist on the remote server.
+      if (current.isRemote) {
+        for (const dir of [...connections.keys()]) {
+          disconnectDirectory(dir)
+        }
+        return
+      }
+
       const wanted = new Set(current.dirs)
       if (current.active) wanted.delete(current.active)
 

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -466,6 +466,11 @@ export function GlobalEventsProvider(props: ParentProps & {
         for (const dir of [...connections.keys()]) {
           disconnectDirectory(dir)
         }
+        // Cancel any pending reconnect and reseed timers
+        for (const [, timer] of reconnectTimers) clearTimeout(timer)
+        reconnectTimers.clear()
+        for (const [, timer] of permReseedTimers) clearTimeout(timer)
+        permReseedTimers.clear()
         return
       }
 

--- a/app-prefixable/src/pages/home-layout.tsx
+++ b/app-prefixable/src/pages/home-layout.tsx
@@ -13,8 +13,7 @@ import { ProjectDialog } from "../components/project-dialog"
 import { Terminal } from "../components/terminal"
 import { getFilename, OpenCodeLogo, ProjectAvatar, type Project } from "../components/shared"
 import { Spinner } from "../components/ui/spinner"
-import { Plus, X, Settings, Server, SquareTerminal, ChevronDown } from "lucide-solid"
-import { ServerDialog } from "../components/server-dialog"
+import { Plus, X, Settings, SquareTerminal, ChevronDown } from "lucide-solid"
 import { dispatchStorageEvent } from "../utils/storage"
 
 // Storage key
@@ -27,13 +26,10 @@ const PROJECTS_STORAGE_KEY = "opencode.projects"
 export function HomeLayout(props: ParentProps) {
   const navigate = useNavigate()
   const globalEvents = useGlobalEvents()
-  const serverCtx = useServer()
+  const { serverUrl, authHeaders } = useServer()
 
   const [projects, setProjects] = createSignal<Project[]>([])
   const [projectDialogOpen, setProjectDialogOpen] = createSignal(false)
-
-  // Server dialog state
-  const [serverDialogOpen, setServerDialogOpen] = createSignal(false)
 
   // Terminal state
   const [terminalOpen, setTerminalOpen] = createSignal(false)
@@ -42,7 +38,7 @@ export function HomeLayout(props: ParentProps) {
   const [terminalHeight, setTerminalHeight] = createSignal(300)
 
   // Client for PTY operations
-  const client = createOpencodeClient({ baseUrl: serverCtx.serverUrl(), headers: serverCtx.authHeaders(), throwOnError: false })
+  const client = createOpencodeClient({ baseUrl: serverUrl(), headers: authHeaders(), throwOnError: false })
 
   onMount(() => {
     try {
@@ -146,12 +142,6 @@ export function HomeLayout(props: ParentProps) {
           <ProviderProvider>
             <MCPProvider>
             <div class="flex h-screen" style={{ background: "var(--background-stronger)" }}>
-              {/* Server Dialog */}
-              <ServerDialog
-                open={serverDialogOpen()}
-                onClose={() => setServerDialogOpen(false)}
-              />
-
               {/* Project Dialog */}
               <ProjectDialog
                 open={projectDialogOpen()}
@@ -216,23 +206,6 @@ export function HomeLayout(props: ParentProps) {
                   class="flex flex-col items-center gap-2 py-3"
                   style={{ "border-top": "1px solid var(--border-base)" }}
                 >
-                  <button
-                    onClick={() => setServerDialogOpen(true)}
-                    class="w-10 h-10 rounded-lg flex items-center justify-center transition-colors relative"
-                    style={{
-                      color: serverDialogOpen() ? "var(--text-interactive-base)" : "var(--icon-base)",
-                      background: serverDialogOpen() ? "var(--surface-inset)" : "transparent",
-                    }}
-                    title={`Server: ${serverCtx.activeServer().name}`}
-                  >
-                    <Server class="w-5 h-5" />
-                    <Show when={!serverCtx.activeServer().isDefault}>
-                      <div
-                        class="absolute top-1.5 right-1.5 w-2 h-2 rounded-full"
-                        style={{ background: "var(--interactive-base)" }}
-                      />
-                    </Show>
-                  </button>
                   <button
                     onClick={toggleTerminal}
                     class="w-10 h-10 rounded-lg flex items-center justify-center transition-colors"

--- a/app-prefixable/src/pages/home-layout.tsx
+++ b/app-prefixable/src/pages/home-layout.tsx
@@ -201,7 +201,7 @@ export function HomeLayout(props: ParentProps) {
                   </button>
                 </div>
 
-                {/* Bottom: Server, Terminal & Settings */}
+                {/* Bottom: Terminal & Settings */}
                 <div
                   class="flex flex-col items-center gap-2 py-3"
                   style={{ "border-top": "1px solid var(--border-base)" }}

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -21,8 +21,6 @@ import { Spinner } from "../components/ui/spinner";
 import { Button } from "../components/ui/button";
 import { Terminal } from "../components/terminal";
 import { ProjectDialog } from "../components/project-dialog";
-import { ServerDialog } from "../components/server-dialog";
-import { useServer } from "../context/server";
 import {
   getFilename,
   OpenCodeLogo,
@@ -33,7 +31,6 @@ import type { Session } from "../sdk/client";
 import {
   Plus,
   Settings,
-  Server,
   SquareTerminal,
   MessageCircle,
   Loader2,
@@ -255,8 +252,6 @@ export function Layout(props: ParentProps) {
   const [sidebarExpanded, setSidebarExpanded] = createSignal(true);
   const [showArchived, setShowArchived] = createSignal(false);
   const [projectDialogOpen, setProjectDialogOpen] = createSignal(false);
-  const [serverDialogOpen, setServerDialogOpen] = createSignal(false);
-  const serverCtx = useServer();
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [editTitle, setEditTitle] = createSignal("");
   const [windowWidth, setWindowWidth] = createSignal(
@@ -2005,12 +2000,6 @@ export function Layout(props: ParentProps) {
         onSelect={handleProjectSelect}
       />
 
-      {/* Server Dialog */}
-      <ServerDialog
-        open={serverDialogOpen()}
-        onClose={() => setServerDialogOpen(false)}
-      />
-
       {/* Left: Project Icons Strip (always visible) */}
       <div
         class="w-16 shrink-0 flex flex-col items-center"
@@ -2097,28 +2086,6 @@ export function Layout(props: ParentProps) {
           class="flex flex-col items-center gap-2 py-3"
           style={{ "border-top": "1px solid var(--border-base)" }}
         >
-          <button
-            data-hint-target
-            onClick={() => setServerDialogOpen(true)}
-            class="w-10 h-10 rounded-lg flex items-center justify-center transition-colors relative"
-            style={{
-              color: serverDialogOpen()
-                ? "var(--text-interactive-base)"
-                : "var(--icon-base)",
-              background: serverDialogOpen()
-                ? "var(--surface-inset)"
-                : "transparent",
-            }}
-            title={`Server: ${serverCtx.activeServer().name}`}
-          >
-            <Server class="w-5 h-5" />
-            <Show when={!serverCtx.activeServer().isDefault}>
-              <div
-                class="absolute top-1.5 right-1.5 w-2 h-2 rounded-full"
-                style={{ background: "var(--interactive-base)" }}
-              />
-            </Show>
-          </button>
           <button
             data-hint-target
             onClick={() => terminal.toggle(directory)}

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -9,10 +9,12 @@ import { useConfig } from "../context/config"
 import { MCPAddDialog } from "../components/mcp-add-dialog"
 import { ConfirmDialog } from "../components/confirm-dialog"
 import { Button } from "../components/ui/button"
-import { Check, Copy, Plug, GitBranch, Server, ExternalLink, Key, Search, X, Trash2, BookmarkPlus, Pencil, Palette, Sun, Moon, Monitor, BookOpen, Plus, Save, Volume2, Play, Settings2, Code, Shield, Cpu, Wrench, ChevronDown, ChevronRight, Info } from "lucide-solid"
+import { Check, Copy, Plug, GitBranch, Server, Globe, ExternalLink, Key, Search, X, Trash2, BookmarkPlus, Pencil, Palette, Sun, Moon, Monitor, BookOpen, Plus, Save, Volume2, Play, Settings2, Code, Shield, Cpu, Wrench, ChevronDown, ChevronRight, Info } from "lucide-solid"
 import { SOUND_OPTIONS, readSoundSettings, writeSoundSettings, playSound, primeAudioContext, SOUND_STORAGE_KEY, type SoundSettings } from "../utils/sound"
 import { useSavedPrompts } from "../context/saved-prompts"
 import { useTheme } from "../context/theme"
+import { useServer } from "../context/server"
+import { ServerDialog } from "../components/server-dialog"
 import { writeFile } from "../utils/extended-api"
 import type { Config, PermissionActionConfig } from "../sdk/client"
 
@@ -29,11 +31,13 @@ export function Settings() {
   // Initialize tab from URL hash, default to "providers"
   const getInitialTab = () => {
     const hash = window.location.hash.slice(1)
-    const baseTabs = ["providers", "git", "mcp", "prompts", "instructions", "appearance", "sounds"]
+    const baseTabs = ["providers", "servers", "git", "mcp", "prompts", "instructions", "appearance", "sounds"]
     const validTabs = directory ? [...baseTabs, "config"] : baseTabs
     return validTabs.includes(hash) ? hash : "providers"
   }
   const [activeTab, setActiveTab] = createSignal(getInitialTab())
+  const serverCtx = useServer()
+  const [showServerDialog, setShowServerDialog] = createSignal(false)
   const [showMCPAddDialog, setShowMCPAddDialog] = createSignal(false)
   const [mcpLoading, setMcpLoading] = createSignal<string | null>(null)
   const [mcpDeleting, setMcpDeleting] = createSignal<string | null>(null)
@@ -638,6 +642,7 @@ Add your project-specific instructions here.
   const tabs = createMemo(() => {
     const base: Array<{ id: string; label: string; icon: () => JSX.Element; scope: ScopeBadge }> = [
       { id: "providers", label: "Providers", icon: () => <Plug class="w-4 h-4" />, scope: "Global" },
+      { id: "servers", label: "Servers", icon: () => <Globe class="w-4 h-4" />, scope: "Global" },
       { id: "git", label: "Git", icon: () => <GitBranch class="w-4 h-4" />, scope: "Global" },
       { id: "mcp", label: "MCP Servers", icon: () => <Server class="w-4 h-4" />, scope: "Global + Project" },
       { id: "prompts", label: "Prompts", icon: () => <BookmarkPlus class="w-4 h-4" />, scope: directory ? "Project" : null },
@@ -732,6 +737,61 @@ Add your project-specific instructions here.
               <span>
                 Project: <span style={{ color: "var(--text-base)" }}>{directory}</span>
               </span>
+            </div>
+          </Show>
+
+          {/* Servers Tab */}
+          <Show when={activeTab() === "servers"}>
+            <div class="space-y-6">
+              <header>
+                <h1 class="text-lg font-medium" style={{ color: "var(--text-strong)" }}>
+                  Servers
+                </h1>
+                <p class="text-sm mt-1" style={{ color: "var(--text-weak)" }}>
+                  Connect to multiple OpenCode servers. Remote servers are proxied through the local server to avoid CORS issues.
+                </p>
+              </header>
+
+              {/* Server list */}
+              <div class="space-y-2">
+                <For each={serverCtx.servers()}>
+                  {(s) => {
+                    const isActive = () => s.id === serverCtx.activeServerId()
+                    return (
+                      <div
+                        class="flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors"
+                        style={{
+                          background: isActive() ? "color-mix(in srgb, var(--interactive-base) 15%, transparent)" : "var(--surface-inset)",
+                          border: isActive() ? "1px solid var(--interactive-base)" : "1px solid transparent",
+                        }}
+                        onClick={() => serverCtx.setActiveServer(s.id)}
+                      >
+                        <Globe class="w-5 h-5 shrink-0" style={{ color: isActive() ? "var(--interactive-base)" : "var(--icon-weak)" }} />
+                        <div class="flex-1 min-w-0">
+                          <div class="flex items-center gap-2">
+                            <span class="font-medium text-sm truncate" style={{ color: "var(--text-strong)" }}>{s.name}</span>
+                            <Show when={isActive()}>
+                              <span class="text-xs px-1.5 py-0.5 rounded" style={{ background: "var(--interactive-base)", color: "white" }}>active</span>
+                            </Show>
+                            <Show when={s.auth.type !== "none"}>
+                              <span class="text-xs px-1.5 py-0.5 rounded" style={{ background: "var(--surface-strong)", color: "var(--text-weak)" }}>
+                                {s.auth.type === "api-key" ? "API Key" : s.auth.type === "basic" ? "Basic Auth" : ""}
+                              </span>
+                            </Show>
+                          </div>
+                          <div class="text-xs truncate mt-0.5" style={{ color: "var(--text-weak)" }}>{s.url}</div>
+                        </div>
+                      </div>
+                    )
+                  }}
+                </For>
+              </div>
+
+              <Button onClick={() => setShowServerDialog(true)} variant="primary">
+                <Plus class="w-4 h-4" /> Manage Servers
+              </Button>
+
+              <ServerDialog open={showServerDialog()} onClose={() => setShowServerDialog(false)} />
             </div>
           </Show>
 

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -791,9 +791,10 @@ Add your project-specific instructions here.
                 <Plus class="w-4 h-4" /> Manage Servers
               </Button>
 
-              <ServerDialog open={showServerDialog()} onClose={() => setShowServerDialog(false)} />
             </div>
           </Show>
+
+          <ServerDialog open={showServerDialog()} onClose={() => setShowServerDialog(false)} />
 
           {/* Providers Tab */}
           <Show when={activeTab() === "providers"}>

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -758,8 +758,8 @@ Add your project-specific instructions here.
                   {(s) => {
                     const isActive = () => s.id === serverCtx.activeServerId()
                     return (
-                      <div
-                        class="flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors"
+                      <button
+                        class="w-full flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors text-left"
                         style={{
                           background: isActive() ? "color-mix(in srgb, var(--interactive-base) 15%, transparent)" : "var(--surface-inset)",
                           border: isActive() ? "1px solid var(--interactive-base)" : "1px solid transparent",
@@ -781,7 +781,7 @@ Add your project-specific instructions here.
                           </div>
                           <div class="text-xs truncate mt-0.5" style={{ color: "var(--text-weak)" }}>{s.url}</div>
                         </div>
-                      </div>
+                      </button>
                     )
                   }}
                 </For>


### PR DESCRIPTION
## Summary
- Add "Servers" tab to Settings page showing configured servers with switch/manage functionality
- Remove standalone server button from sidebar (both layout.tsx and home-layout.tsx)
- Add dedicated "API Key" field to MCP Add Server dialog (creates Authorization: Bearer header)
- Skip GlobalEvents SSE connections when a remote server is active (local projects don't exist on remote servers)

## Test plan
- [ ] Verify "Servers" tab appears in Settings between Providers and Git
- [ ] Verify server button is gone from sidebar
- [ ] Verify MCP Add Server dialog has API Key field
- [ ] Verify no 401 SSE spam when connected to remote server

🤖 Generated with [Claude Code](https://claude.com/claude-code)