### PR TITLE
fix: namespace model selection localStorage key by project directory

### DIFF
--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -110,30 +110,28 @@ export function ProviderProvider(props: ParentProps) {
 
   // Load models from localStorage (directory-scoped key, with migration from legacy global key)
   onMount(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
+    const stored = localStorage.getItem(storageKey)
+    if (stored) {
+      try {
         const parsed = JSON.parse(stored)
         if (isValidModelsByAgent(parsed)) {
           setStore("modelsByAgent", parsed)
           return
         }
-        localStorage.removeItem(storageKey)
-      }
-      // Migrate: if no per-directory data exists, copy from legacy global key
-      if (directory) {
-        const legacy = localStorage.getItem(LEGACY_MODELS_KEY)
-        if (legacy) {
-          const parsed = JSON.parse(legacy)
-          if (isValidModelsByAgent(parsed)) {
-            setStore("modelsByAgent", parsed)
-            localStorage.setItem(storageKey, legacy)
-          }
-        }
-      }
-    } catch (e) {
-      console.error("Failed to load models from storage:", e)
+      } catch (_) { /* invalid JSON, fall through to remove */ }
+      localStorage.removeItem(storageKey)
     }
+    // Migrate: if no per-directory data exists, copy from legacy global key
+    if (!directory) return
+    const legacy = localStorage.getItem(LEGACY_MODELS_KEY)
+    if (!legacy) return
+    try {
+      const parsed = JSON.parse(legacy)
+      if (isValidModelsByAgent(parsed)) {
+        setStore("modelsByAgent", parsed)
+        localStorage.setItem(storageKey, legacy)
+      }
+    } catch (_) { /* legacy key corrupted, ignore */ }
   })
 
   // Save models to localStorage whenever they change (directory-scoped).

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -3,8 +3,16 @@ import { createStore } from "solid-js/store"
 import { useSDK } from "./sdk"
 import { useConfig } from "./config"
 
-// Storage key
-const MODELS_BY_AGENT_KEY = "opencode.modelsByAgent"
+// Storage key prefix — scoped per project directory
+const MODELS_BY_AGENT_PREFIX = "opencode.modelsByAgent"
+// Legacy key (pre-namespacing) used for migration
+const LEGACY_MODELS_KEY = "opencode.modelsByAgent"
+
+function modelsStorageKey(directory?: string): string {
+  if (!directory) return LEGACY_MODELS_KEY
+  const normalized = directory.replace(/[\\/]+$/, "")
+  return `${MODELS_BY_AGENT_PREFIX}:${normalized}`
+}
 
 // Fallback defaults when no config is available
 const FALLBACK_PROVIDER = "opencode"
@@ -78,8 +86,9 @@ interface ProviderContextValue {
 const ProviderContext = createContext<ProviderContextValue>()
 
 export function ProviderProvider(props: ParentProps) {
-  const { client } = useSDK()
+  const { client, directory } = useSDK()
   const cfg = useConfig()
+  const storageKey = modelsStorageKey(directory)
 
   const [store, setStore] = createStore({
     modelsByAgent: {} as Record<string, ModelKey>,
@@ -89,23 +98,32 @@ export function ProviderProvider(props: ParentProps) {
   // Track whether the user has manually changed the agent via setSelectedAgent
   let userChangedAgent = false
 
-  // Load models from localStorage
+  // Load models from localStorage (directory-scoped key, with migration from legacy global key)
   onMount(() => {
     try {
-      const stored = localStorage.getItem(MODELS_BY_AGENT_KEY)
+      const stored = localStorage.getItem(storageKey)
       if (stored) {
-        const parsed = JSON.parse(stored)
-        setStore("modelsByAgent", parsed)
+        setStore("modelsByAgent", JSON.parse(stored))
+        return
+      }
+      // Migrate: if no per-directory data exists, copy from legacy global key
+      if (directory) {
+        const legacy = localStorage.getItem(LEGACY_MODELS_KEY)
+        if (legacy) {
+          const parsed = JSON.parse(legacy)
+          setStore("modelsByAgent", parsed)
+          localStorage.setItem(storageKey, legacy)
+        }
       }
     } catch (e) {
       console.error("Failed to load models from storage:", e)
     }
   })
 
-  // Save models to localStorage whenever they change
+  // Save models to localStorage whenever they change (directory-scoped)
   createEffect(() => {
     try {
-      localStorage.setItem(MODELS_BY_AGENT_KEY, JSON.stringify(store.modelsByAgent))
+      localStorage.setItem(storageKey, JSON.stringify(store.modelsByAgent))
     } catch (e) {
       console.error("Failed to save models to storage:", e)
     }

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -134,6 +134,8 @@ export function ProviderProvider(props: ParentProps) {
         if (isValidModelsByAgent(parsed)) {
           setStore("modelsByAgent", parsed)
           localStorage.setItem(storageKey, legacy)
+          // Remove legacy key so other projects fall through to their opencode.json defaults
+          localStorage.removeItem(LEGACY_MODELS_KEY)
         }
       } catch (_) { /* legacy key corrupted, ignore */ }
     } catch (e) {

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, createResource, createEffect, on, type ParentProps, onMount } from "solid-js"
+import { createContext, useContext, createResource, createEffect, type ParentProps, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useSDK } from "./sdk"
 import { useConfig } from "./config"
@@ -107,42 +107,52 @@ export function ProviderProvider(props: ParentProps) {
 
   // Track whether the user has manually changed the agent via setSelectedAgent
   let userChangedAgent = false
+  // Track whether localStorage has been hydrated (prevents saving the initial empty store)
+  let hydrated = false
 
   // Load models from localStorage (directory-scoped key, with migration from legacy global key)
   onMount(() => {
-    const stored = localStorage.getItem(storageKey)
-    if (stored) {
+    try {
+      const stored = localStorage.getItem(storageKey)
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored)
+          if (isValidModelsByAgent(parsed)) {
+            setStore("modelsByAgent", parsed)
+            hydrated = true
+            return
+          }
+        } catch (_) { /* invalid JSON, fall through to remove */ }
+        localStorage.removeItem(storageKey)
+      }
+      // Migrate: if no per-directory data exists, copy from legacy global key
+      if (!directory) { hydrated = true; return }
+      const legacy = localStorage.getItem(LEGACY_MODELS_KEY)
+      if (!legacy) { hydrated = true; return }
       try {
-        const parsed = JSON.parse(stored)
+        const parsed = JSON.parse(legacy)
         if (isValidModelsByAgent(parsed)) {
           setStore("modelsByAgent", parsed)
-          return
+          localStorage.setItem(storageKey, legacy)
         }
-      } catch (_) { /* invalid JSON, fall through to remove */ }
-      localStorage.removeItem(storageKey)
+      } catch (_) { /* legacy key corrupted, ignore */ }
+    } catch (e) {
+      console.error("Failed to load models from storage:", e)
     }
-    // Migrate: if no per-directory data exists, copy from legacy global key
-    if (!directory) return
-    const legacy = localStorage.getItem(LEGACY_MODELS_KEY)
-    if (!legacy) return
-    try {
-      const parsed = JSON.parse(legacy)
-      if (isValidModelsByAgent(parsed)) {
-        setStore("modelsByAgent", parsed)
-        localStorage.setItem(storageKey, legacy)
-      }
-    } catch (_) { /* legacy key corrupted, ignore */ }
+    hydrated = true
   })
 
   // Save models to localStorage whenever they change (directory-scoped).
-  // Deferred so the initial empty store doesn't overwrite persisted data before onMount hydrates.
-  createEffect(on(() => store.modelsByAgent, (models) => {
+  // The hydrated guard prevents the initial empty store from overwriting persisted data.
+  createEffect(() => {
+    const serialized = JSON.stringify(store.modelsByAgent)
+    if (!hydrated) return
     try {
-      localStorage.setItem(storageKey, JSON.stringify(models))
+      localStorage.setItem(storageKey, serialized)
     } catch (e) {
       console.error("Failed to save models to storage:", e)
     }
-  }, { defer: true }))
+  })
 
   // Fetch providers
   const [providerData, { refetch: refetchProviders }] = createResource(async () => {

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -11,7 +11,17 @@ const LEGACY_MODELS_KEY = "opencode.modelsByAgent"
 function modelsStorageKey(directory?: string): string {
   if (!directory) return LEGACY_MODELS_KEY
   const normalized = directory.replace(/[\\/]+$/, "")
-  return `${MODELS_BY_AGENT_PREFIX}:${normalized}`
+  return `${MODELS_BY_AGENT_PREFIX}.${normalized}`
+}
+
+// Validate that parsed localStorage data is a Record<string, ModelKey>
+function isValidModelsByAgent(value: unknown): value is Record<string, ModelKey> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  for (const v of Object.values(value)) {
+    if (!v || typeof v !== "object") return false
+    if (typeof (v as ModelKey).providerID !== "string" || typeof (v as ModelKey).modelID !== "string") return false
+  }
+  return true
 }
 
 // Fallback defaults when no config is available
@@ -103,16 +113,22 @@ export function ProviderProvider(props: ParentProps) {
     try {
       const stored = localStorage.getItem(storageKey)
       if (stored) {
-        setStore("modelsByAgent", JSON.parse(stored))
-        return
+        const parsed = JSON.parse(stored)
+        if (isValidModelsByAgent(parsed)) {
+          setStore("modelsByAgent", parsed)
+          return
+        }
+        localStorage.removeItem(storageKey)
       }
       // Migrate: if no per-directory data exists, copy from legacy global key
       if (directory) {
         const legacy = localStorage.getItem(LEGACY_MODELS_KEY)
         if (legacy) {
           const parsed = JSON.parse(legacy)
-          setStore("modelsByAgent", parsed)
-          localStorage.setItem(storageKey, legacy)
+          if (isValidModelsByAgent(parsed)) {
+            setStore("modelsByAgent", parsed)
+            localStorage.setItem(storageKey, legacy)
+          }
         }
       }
     } catch (e) {

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, createResource, createEffect, type ParentProps, onMount } from "solid-js"
+import { createContext, useContext, createResource, createEffect, on, type ParentProps, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useSDK } from "./sdk"
 import { useConfig } from "./config"
@@ -120,14 +120,15 @@ export function ProviderProvider(props: ParentProps) {
     }
   })
 
-  // Save models to localStorage whenever they change (directory-scoped)
-  createEffect(() => {
+  // Save models to localStorage whenever they change (directory-scoped).
+  // Deferred so the initial empty store doesn't overwrite persisted data before onMount hydrates.
+  createEffect(on(() => store.modelsByAgent, (models) => {
     try {
-      localStorage.setItem(storageKey, JSON.stringify(store.modelsByAgent))
+      localStorage.setItem(storageKey, JSON.stringify(models))
     } catch (e) {
       console.error("Failed to save models to storage:", e)
     }
-  })
+  }, { defer: true }))
 
   // Fetch providers
   const [providerData, { refetch: refetchProviders }] = createResource(async () => {


### PR DESCRIPTION
## Summary

- Scopes the `modelsByAgent` localStorage key per project directory (e.g., `opencode.modelsByAgent:/home/user/project`) so switching between projects no longer carries model selections across
- Each project's configured default model from `opencode.json` is now respected when no prior selection exists for that project
- Includes migration: on first load, if no per-directory data exists, copies from the legacy global `opencode.modelsByAgent` key

## Changes

**`app-prefixable/src/context/providers.tsx`**:
- Added `modelsStorageKey(directory)` helper that appends the normalized directory path to the storage key
- Updated `onMount` to load from the directory-scoped key with fallback migration from the legacy global key
- Updated `createEffect` save to write to the directory-scoped key
- Follows the same pattern already used in `saved-prompts.tsx` for per-project localStorage scoping

## Testing

- Production build passes (`bun run build`)
- Migration path: existing users get their current global selection copied to the first project they open, then each project tracks independently

Closes #205