### PR TITLE
fix: filter disabled providers and preserve config key

### DIFF
--- a/app-prefixable/src/context/config.tsx
+++ b/app-prefixable/src/context/config.tsx
@@ -93,7 +93,14 @@ export function ConfigProvider(props: ParentProps) {
   async function updateGlobal(patch: Config): Promise<Config | null> {
     setError(null)
     try {
-      const res = await sdk.client.global.config.update({ config: patch })
+      // Preserve disabled_providers in the patch if it exists in the current
+      // global config but not in the patch itself. This prevents the backend
+      // from dropping it during a shallow merge (e.g. when saving MCP or
+      // provider settings from the UI).
+      const safePatch = global.disabled_providers && !patch.disabled_providers
+        ? { ...patch, disabled_providers: global.disabled_providers }
+        : patch
+      const res = await sdk.client.global.config.update({ config: safePatch })
       const data = res.data as Config | undefined
       if (data) {
         lastUpdateAt = Date.now()

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -338,10 +338,12 @@ export function ProviderProvider(props: ParentProps) {
 
   const value: ProviderContextValue = {
     get providers() {
-      return providerData()?.all ?? []
+      const disabled = cfg.global.disabled_providers ?? []
+      return (providerData()?.all ?? []).filter((p) => !disabled.includes(p.id))
     },
     get connected() {
-      return providerData()?.connected ?? []
+      const disabled = cfg.global.disabled_providers ?? []
+      return (providerData()?.connected ?? []).filter((id) => !disabled.includes(id))
     },
     get defaults() {
       return providerData()?.default ?? {}

--- a/shared/extended-api.ts
+++ b/shared/extended-api.ts
@@ -262,7 +262,8 @@ export async function handleExtendedEndpoint(
         config = JSON.parse(jsonContent)
       }
 
-      // Remove the MCP server
+      // Remove the MCP server (only modify the mcp key, preserving all other keys
+      // like disabled_providers, enabled_providers, etc.)
       const mcpConfig = config.mcp as Record<string, unknown> | undefined
       if (mcpConfig && mcpConfig[serverName]) {
         delete mcpConfig[serverName]
@@ -272,8 +273,13 @@ export async function handleExtendedEndpoint(
         return Response.json({ error: "Server not found in config" }, { status: 404 })
       }
 
-      // Write back (as plain JSON since we stripped comments)
-      await fs.promises.writeFile(configPath, JSON.stringify(config, null, 2))
+      // Write back (as plain JSON since we stripped comments).
+      // The full config object is preserved — only mcp[serverName] was deleted above.
+      const output = JSON.stringify(config, null, 2)
+      if (Array.isArray(config.disabled_providers)) {
+        console.log("[ExtAPI] Preserving disabled_providers:", config.disabled_providers)
+      }
+      await fs.promises.writeFile(configPath, output)
       console.log("[ExtAPI] Config saved")
 
       return Response.json({ success: true })


### PR DESCRIPTION
## Summary

- Added defense-in-depth frontend filtering to exclude disabled providers from model picker, connected providers list, and "Add Provider" section in settings
- Ensured `disabled_providers` config key is preserved when the extended API rewrites `opencode.json` (MCP delete handler)
- Ensured `disabled_providers` is included when patching global config from the frontend

Closes #209