### PR TITLE
fix: track model selection per session instead of globally

### DIFF
--- a/app-prefixable/src/components/session-info.tsx
+++ b/app-prefixable/src/components/session-info.tsx
@@ -6,10 +6,16 @@ import { useProviders } from "../context/providers"
 import { getContextTokens } from "../utils/tokens"
 import { Zap, CornerDownLeft, Square } from "lucide-solid"
 
+interface ModelKey {
+  providerID: string
+  modelID: string
+}
+
 interface SessionInfoProps {
   input: () => string
   loading: () => boolean
   processing: () => boolean
+  sessionModel: () => ModelKey | null
   onAbort: () => void
   onAgentClick: () => void
   onModelClick: () => void
@@ -129,7 +135,7 @@ export function SessionInfo(props: SessionInfoProps) {
 
   // Resolve friendly model name from providers
   const modelLabel = createMemo(() => {
-    const selected = providers.selectedModel
+    const selected = props.sessionModel()
     if (!selected) return null
     const provider = providers.providers.find((p: { id: string }) => p.id === selected.providerID)
     const model = provider?.models[selected.modelID]
@@ -209,7 +215,7 @@ export function SessionInfo(props: SessionInfoProps) {
         </Show>
 
         {/* Model */}
-        <Show when={providers.selectedModel}>
+        <Show when={props.sessionModel()}>
           <button
             type="button"
             class="flex items-center gap-1 min-w-0 hover:opacity-80 cursor-pointer"
@@ -345,13 +351,13 @@ export function SessionInfo(props: SessionInfoProps) {
         </Show>
 
         {/* No provider warning */}
-        <Show when={!providers.selectedModel && providers.connected.length === 0}>
+        <Show when={!props.sessionModel() && providers.connected.length === 0}>
           <a href={`/${dirSlug()}/settings`} style={{ color: "var(--text-interactive-base)" }} class="hover:underline">
             Connect a provider to start
           </a>
         </Show>
 
-        <Show when={!providers.selectedModel && providers.connected.length > 0}>
+        <Show when={!props.sessionModel() && providers.connected.length > 0}>
           <span style={{ color: "var(--status-warning-text)" }}>No model selected</span>
         </Show>
       </div>

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -87,6 +87,8 @@ interface ProviderContextValue {
   modelsByAgent: Record<string, ModelKey>
   setSelectedModel: (model: ModelKey | null) => void
   setSelectedAgent: (agent: string) => void
+  getSessionModel: (sessionID: string) => ModelKey | null
+  setSessionModel: (sessionID: string, model: ModelKey | null) => void
   refetch: () => void
   connectProvider: (providerID: string, apiKey: string) => Promise<boolean>
   startOAuth: (providerID: string, methodIndex: number) => Promise<OAuthAuthorization | undefined>
@@ -103,6 +105,7 @@ export function ProviderProvider(props: ParentProps) {
   const [store, setStore] = createStore({
     modelsByAgent: {} as Record<string, ModelKey>,
     selectedAgent: FALLBACK_AGENT,
+    sessionModels: {} as Record<string, ModelKey>,
   })
 
   // Track whether the user has manually changed the agent via setSelectedAgent
@@ -285,6 +288,16 @@ export function ProviderProvider(props: ParentProps) {
     setStore("selectedAgent", agent)
   }
 
+  function getSessionModel(sessionID: string): ModelKey | null {
+    return store.sessionModels[sessionID] ?? null
+  }
+
+  function setSessionModel(sessionID: string, model: ModelKey | null) {
+    if (model) {
+      setStore("sessionModels", sessionID, model)
+    }
+  }
+
   async function connectProvider(providerID: string, apiKey: string): Promise<boolean> {
     try {
       await client.auth.set({
@@ -368,6 +381,8 @@ export function ProviderProvider(props: ParentProps) {
     },
     setSelectedModel,
     setSelectedAgent,
+    getSessionModel,
+    setSessionModel,
     refetch,
     connectProvider,
     startOAuth,

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -98,6 +98,13 @@ export function Session() {
   const terminal = useTerminal();
   const appConfig = useConfig();
 
+  // Per-session model: reads from providers.sessionModels, falls back to global default
+  const sessionModel = createMemo(() => {
+    const id = sessionId();
+    if (!id) return providers.selectedModel;
+    return providers.getSessionModel(id) ?? providers.selectedModel;
+  });
+
   // Unified toast system — only one toast visible at a time
   const [toastMessage, setToastMessage] = createSignal<string | null>(null);
   const [toastVariant, setToastVariant] = createSignal<"default" | "hint">("default");
@@ -370,6 +377,17 @@ export function Session() {
       setProcessing(false); // Reset processing state for new session
       sync.session.sync(id).then(() => {
         setLoadingHistory(false);
+        // Initialize per-session model from existing messages if not already set
+        if (!providers.getSessionModel(id)) {
+          const msgs = sync.messages(id);
+          for (let i = msgs.length - 1; i >= 0; i--) {
+            const info = msgs[i].info;
+            if (info.role === "assistant" && info.providerID && info.modelID) {
+              providers.setSessionModel(id, { providerID: info.providerID, modelID: info.modelID });
+              break;
+            }
+          }
+        }
       });
 
       // Check if this session is actually busy
@@ -428,14 +446,15 @@ export function Session() {
     // runs after createEffect. Skip without removing the sessionStorage item so
     // the effect re-runs once providers finish loading.
     if (providers.loading || providers.providers.length === 0) return;
-    if (!providers.selectedModel) {
+    const model = sessionModel();
+    if (!model) {
       sessionStorage.removeItem(key);
       setError("Please select a model before sending messages. Click the model button in the header.");
       return;
     }
-    if (!providers.connected.includes(providers.selectedModel.providerID)) {
+    if (!providers.connected.includes(model.providerID)) {
       sessionStorage.removeItem(key);
-      setError(`Provider "${providers.selectedModel.providerID}" is not connected. Please configure it in Settings.`);
+      setError(`Provider "${model.providerID}" is not connected. Please configure it in Settings.`);
       return;
     }
     // All validation passed — mark as sent, clear storage, and send
@@ -447,7 +466,7 @@ export function Session() {
       sessionID: id,
       parts: [{ type: "text", text }],
       agent: providers.selectedAgent || "build",
-      model: providers.selectedModel,
+      model,
     }).catch((err: unknown) => {
       setError(`Failed to send saved prompt: ${err instanceof Error ? err.message : String(err)}`);
       setProcessing(false);
@@ -629,7 +648,7 @@ export function Session() {
     ];
 
     // /compact — requires a session with messages and a selected model
-    if (id && hasMessages && !isProcessing && providers.selectedModel) {
+    if (id && hasMessages && !isProcessing && sessionModel()) {
       commands.push({
         id: "session.compact",
         title: "Compact Session",
@@ -637,7 +656,7 @@ export function Session() {
         slash: "compact",
         onSelect: async () => {
           if (!id) return;
-          const model = providers.selectedModel;
+          const model = sessionModel();
           if (!model) {
             showToast("Select a model before compacting");
             return;
@@ -1282,7 +1301,8 @@ export function Session() {
       return;
 
     // Require explicit model selection to avoid OpenCode auto-selecting a broken provider
-    if (!providers.selectedModel) {
+    const model = sessionModel();
+    if (!model) {
       setError(
         "Please select a model before sending messages. Click the model button in the header.",
       );
@@ -1290,9 +1310,9 @@ export function Session() {
     }
 
     // Check if the selected model's provider is connected
-    if (!providers.connected.includes(providers.selectedModel.providerID)) {
+    if (!providers.connected.includes(model.providerID)) {
       setError(
-        `Provider "${providers.selectedModel.providerID}" is not connected. Please configure it in Settings.`,
+        `Provider "${model.providerID}" is not connected. Please configure it in Settings.`,
       );
       return;
     }
@@ -1339,6 +1359,8 @@ export function Session() {
         id = createRes.data.id;
         setSessionId(id);
         navigate(`/${dirSlug()}/session/${id}`, { replace: true });
+        // Store the model for the new session
+        providers.setSessionModel(id, model);
       }
 
       // Build parts array with text and file attachments
@@ -1392,8 +1414,8 @@ export function Session() {
         agent: providers.selectedAgent || "build",
       };
 
-      if (providers.selectedModel) {
-        promptPayload.model = providers.selectedModel;
+      if (model) {
+        promptPayload.model = model;
       }
 
       const promptRes = await client.session.promptAsync(promptPayload);
@@ -1412,12 +1434,13 @@ export function Session() {
   }
 
   async function createSessionAndSendPrompt(text: string) {
-    if (!providers.selectedModel) {
+    const model = sessionModel();
+    if (!model) {
       setError("Please select a model before sending messages. Click the model button in the header.");
       return;
     }
-    if (!providers.connected.includes(providers.selectedModel.providerID)) {
-      setError(`Provider "${providers.selectedModel.providerID}" is not connected. Please configure it in Settings.`);
+    if (!providers.connected.includes(model.providerID)) {
+      setError(`Provider "${model.providerID}" is not connected. Please configure it in Settings.`);
       return;
     }
     setError(null);
@@ -1427,11 +1450,13 @@ export function Session() {
       const sid = res.data.id;
       setSessionId(sid);
       navigate(`/${dirSlug()}/session/${sid}`, { replace: true });
+      // Store the model for the new session
+      providers.setSessionModel(sid, model);
       await client.session.promptAsync({
         sessionID: sid,
         parts: [{ type: "text", text }],
         agent: providers.selectedAgent || "build",
-        model: providers.selectedModel,
+        model,
       });
     } catch (err) {
       setError(`Failed to send saved prompt: ${err instanceof Error ? err.message : String(err)}`);
@@ -2112,6 +2137,7 @@ export function Session() {
                       input={input}
                       loading={loading}
                       processing={processing}
+                      sessionModel={sessionModel}
                       onAbort={handleAbort}
                       onAgentClick={() => setShowAgentPicker(true)}
                       onModelClick={() => setShowModelPicker(true)}
@@ -2164,7 +2190,11 @@ export function Session() {
               const parts = item.id.split(":");
               const providerID = parts[0];
               const modelID = parts.slice(1).join(":");
-              providers.setSelectedModel({ providerID, modelID });
+              const model = { providerID, modelID };
+              // Store per-session and update global default
+              const id = sessionId();
+              if (id) providers.setSessionModel(id, model);
+              providers.setSelectedModel(model);
             }}
             onClose={() => setShowModelPicker(false)}
           />


### PR DESCRIPTION
## Summary

- Adds per-session model tracking to `ProviderProvider` via a `sessionModels` reactive store
- When switching sessions, the model picker now reflects the model last used in that session
- New sessions inherit the global default; existing sessions infer their model from the last assistant message
- Model picker updates both per-session and global state, so new sessions always get the latest choice

## Changes

| File | Change |
|------|--------|
| `app-prefixable/src/context/providers.tsx` | Added `sessionModels` store, `getSessionModel()`, `setSessionModel()` |
| `app-prefixable/src/pages/session.tsx` | Added `sessionModel` memo; replaced all `providers.selectedModel` reads with per-session model; stores model on session create and model pick |
| `app-prefixable/src/components/session-info.tsx` | Accepts `sessionModel` prop; displays per-session model instead of global |

## Testing

1. Open Session A, set model to `anthropic/claude-sonnet-4-5`
2. Open Session B, set model to `openai/gpt-4o`
3. Switch back to Session A — model should still show `anthropic/claude-sonnet-4-5`
4. Prompts in each session should use their respective models

Closes #206