### PR TITLE
feat: add global vs project scope for saved prompts

### DIFF
--- a/app-prefixable/src/context/saved-prompts.tsx
+++ b/app-prefixable/src/context/saved-prompts.tsx
@@ -81,11 +81,10 @@ function saveToStorage(key: string, prompts: SavedPrompt[]) {
 const sortNewest = (a: SavedPrompt, b: SavedPrompt) => b.createdAt - a.createdAt
 
 /**
- * One-time migration: if the project key doesn't exist yet but the global key
- * does, copy old global prompts so they appear under the project (as they did
- * in the previous single-key implementation).  This is non-destructive.
+ * Migration helper that backfills missing `scope` tags in both stores.
  *
- * Also tag any un-tagged prompts with the correct scope field.
+ * We intentionally keep legacy prompts in the global store and do not copy
+ * them into project storage.
  */
 function migrateIfNeeded(directory: string) {
   try {
@@ -104,10 +103,7 @@ function migrateIfNeeded(directory: string) {
         }
         if (needsWrite) localStorage.setItem(pKey, JSON.stringify(parsed))
       }
-      return
     }
-    // No project key — nothing to migrate for project-scoped prompts
-    // (old prompts in legacy key become global automatically via loadFromStorage)
   } catch {
     // Ignore storage errors during migration
   }
@@ -143,6 +139,10 @@ function mergePrompts(global: SavedPrompt[], project: SavedPrompt[]): SavedPromp
   const projectIds = new Set(project.map((p) => p.id))
   const dedupedGlobal = global.filter((p) => !projectIds.has(p.id))
   return [...dedupedGlobal, ...project].sort(sortNewest)
+}
+
+function isPrompt(p: SavedPrompt | undefined): p is SavedPrompt {
+  return p !== undefined
 }
 
 export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor<string | undefined> }) {
@@ -192,8 +192,9 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
   const [globalPrompts, setGlobalPrompts] = createSignal<SavedPrompt[]>(
     loadFromStorage(GLOBAL_KEY, "global").sort(sortNewest),
   )
+  const initialPKey = pKey()
   const [projectPrompts, setProjectPrompts] = createSignal<SavedPrompt[]>(
-    pKey() ? loadFromStorage(pKey()!, "project").sort(sortNewest) : [],
+    initialPKey ? loadFromStorage(initialPKey, "project").sort(sortNewest) : [],
   )
 
   // Merged view: global + project (deduplicated)
@@ -290,7 +291,7 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
     // Reorder only applies to the merged view — split back by scope and persist
     const merged = allPrompts()
     const map = new Map(merged.map((p) => [p.id, p]))
-    const reordered = ids.map((id) => map.get(id)).filter(Boolean) as SavedPrompt[]
+    const reordered = ids.map((id) => map.get(id)).filter(isPrompt)
     const remaining = merged.filter((p) => !ids.includes(p.id))
     const all = [...reordered, ...remaining]
 

--- a/app-prefixable/src/context/saved-prompts.tsx
+++ b/app-prefixable/src/context/saved-prompts.tsx
@@ -261,7 +261,11 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
         saveToStorage(k, updated)
         return updated
       })
-      addGlobal({ ...project, scope: "global" as const })
+      setGlobalPrompts((prev) => {
+        const updated = [{ ...project, scope: "global" as const }, ...prev.filter((p) => p.id !== id)]
+        saveToStorage(GLOBAL_KEY, updated)
+        return updated
+      })
       return
     }
 
@@ -278,7 +282,7 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
       return updated
     })
     setProjectPrompts((prev) => {
-      const updated = [{ ...global, scope: "project" as const }, ...prev]
+      const updated = [{ ...global, scope: "project" as const }, ...prev.filter((p) => p.id !== id)]
       saveToStorage(k, updated)
       return updated
     })

--- a/app-prefixable/src/context/saved-prompts.tsx
+++ b/app-prefixable/src/context/saved-prompts.tsx
@@ -1,45 +1,70 @@
-import { createContext, useContext, createSignal, createEffect, on, type ParentProps, type Accessor } from "solid-js"
+import { createContext, useContext, createSignal, createEffect, createMemo, on, type ParentProps, type Accessor } from "solid-js"
 import { deriveDirectoryFromPathname } from "../utils/path"
 
-interface SavedPrompt {
+export type PromptScope = "global" | "project"
+
+export interface SavedPrompt {
   id: string
   title: string
   text: string
   createdAt: number
+  scope: PromptScope
+}
+
+/** Shape stored in localStorage (scope is optional for backwards compat). */
+interface StoredPrompt {
+  id: string
+  title: string
+  text: string
+  createdAt: number
+  scope?: PromptScope
 }
 
 interface SavedPromptsContextValue {
+  /** All visible prompts (global + project-scoped, sorted newest first). */
   prompts: () => SavedPrompt[]
-  add: (title: string, text: string) => void
+  /** Only global prompts. */
+  globalPrompts: () => SavedPrompt[]
+  /** Only project-scoped prompts. */
+  projectPrompts: () => SavedPrompt[]
+  /** Whether there is an active project directory. */
+  hasProject: () => boolean
+  add: (title: string, text: string, scope?: PromptScope) => void
   update: (id: string, fields: Partial<Pick<SavedPrompt, "title" | "text">>) => void
   remove: (id: string) => void
   reorder: (ids: string[]) => void
 }
 
-const LEGACY_KEY = "opencode.savedPrompts"
+const GLOBAL_KEY = "opencode.savedPrompts"
 
-function storageKey(directory?: string): string {
-  if (!directory) return LEGACY_KEY
-  // Normalize trailing separators so "/path/to/project" and "/path/to/project/" share the same key
+function projectKey(directory: string): string {
   const normalized = directory.replace(/[\\/]+$/, "")
   return `opencode.savedPrompts.${normalized}`
 }
 
 const SavedPromptsContext = createContext<SavedPromptsContextValue>()
 
-function loadFromStorage(key: string): SavedPrompt[] {
+function loadFromStorage(key: string, defaultScope: PromptScope): SavedPrompt[] {
   try {
     const stored = localStorage.getItem(key)
     if (!stored) return []
     const parsed = JSON.parse(stored)
     if (!Array.isArray(parsed)) return []
-    return parsed.filter(
-      (p): p is SavedPrompt =>
-        typeof p.id === "string" &&
-        typeof p.title === "string" &&
-        typeof p.text === "string" &&
-        typeof p.createdAt === "number",
-    )
+    return (parsed as StoredPrompt[])
+      .filter(
+        (p) =>
+          typeof p.id === "string" &&
+          typeof p.title === "string" &&
+          typeof p.text === "string" &&
+          typeof p.createdAt === "number",
+      )
+      .map((p) => ({
+        id: p.id,
+        title: p.title,
+        text: p.text,
+        createdAt: p.createdAt,
+        scope: p.scope === "global" || p.scope === "project" ? p.scope : defaultScope,
+      }))
   } catch {
     return []
   }
@@ -53,34 +78,80 @@ function saveToStorage(key: string, prompts: SavedPrompt[]) {
   }
 }
 
-/** Migrate legacy prompts to the project-scoped key (one-time, non-destructive). */
+const sortNewest = (a: SavedPrompt, b: SavedPrompt) => b.createdAt - a.createdAt
+
+/**
+ * One-time migration: if the project key doesn't exist yet but the global key
+ * does, copy old global prompts so they appear under the project (as they did
+ * in the previous single-key implementation).  This is non-destructive.
+ *
+ * Also tag any un-tagged prompts with the correct scope field.
+ */
 function migrateIfNeeded(directory: string) {
   try {
-    const projectKey = storageKey(directory)
-    // Already has project-scoped data — no migration needed
-    if (localStorage.getItem(projectKey)) return
-    const legacy = localStorage.getItem(LEGACY_KEY)
-    if (!legacy) return
-    // Copy legacy data to project-scoped key; do NOT delete old key
-    localStorage.setItem(projectKey, legacy)
+    const pKey = projectKey(directory)
+    // Already has project-scoped data — just ensure scope tags exist
+    const existing = localStorage.getItem(pKey)
+    if (existing) {
+      const parsed = JSON.parse(existing)
+      if (Array.isArray(parsed)) {
+        let needsWrite = false
+        for (const p of parsed) {
+          if (!p.scope) {
+            p.scope = "project"
+            needsWrite = true
+          }
+        }
+        if (needsWrite) localStorage.setItem(pKey, JSON.stringify(parsed))
+      }
+      return
+    }
+    // No project key — nothing to migrate for project-scoped prompts
+    // (old prompts in legacy key become global automatically via loadFromStorage)
   } catch {
     // Ignore storage errors during migration
   }
+
+  // Ensure global key entries have scope tag
+  try {
+    const raw = localStorage.getItem(GLOBAL_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) {
+        let needsWrite = false
+        for (const p of parsed) {
+          if (!p.scope) {
+            p.scope = "global"
+            needsWrite = true
+          }
+        }
+        if (needsWrite) localStorage.setItem(GLOBAL_KEY, JSON.stringify(parsed))
+      }
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+/**
+ * Deduplicate prompts that exist in both the global and project stores
+ * (artefact of the old migration that copied everything).  When duplicate
+ * IDs are found, keep the project-scoped copy and drop the global one from
+ * the merged view — the global store itself is left untouched.
+ */
+function mergePrompts(global: SavedPrompt[], project: SavedPrompt[]): SavedPrompt[] {
+  const projectIds = new Set(project.map((p) => p.id))
+  const dedupedGlobal = global.filter((p) => !projectIds.has(p.id))
+  return [...dedupedGlobal, ...project].sort(sortNewest)
 }
 
 export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor<string | undefined> }) {
   // Keep a "sticky" directory that survives transient undefined flickers
   // during SolidJS router transitions (e.g. project → project settings).
-  //
-  // Initialise from the prop, falling back to the URL-derived directory.
-  // This avoids starting with undefined when the prop signal hasn't
-  // settled yet but the URL already encodes the directory.
   const [sticky, setSticky] = createSignal<string | undefined>(
     props.directory?.() ?? deriveDirectoryFromPathname(),
   )
 
-  // Track a pending clear so we can cancel it if the directory reappears
-  // before the microtask fires (avoids stale-closure clears).
   let pendingClear = false
 
   createEffect(() => {
@@ -90,14 +161,8 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
       setSticky(d)
       return
     }
-    // Directory became undefined — check whether the URL still indicates a
-    // project route.  If the URL also shows no directory, schedule a
-    // microtask-delayed clear to confirm the state is stable (the pathname
-    // can briefly flash to `/` during SolidJS router transitions).
     const fromUrl = deriveDirectoryFromPathname()
     if (fromUrl) {
-      // URL still has a directory even though the prop is undefined;
-      // keep the sticky value (may be a transient prop flicker).
       pendingClear = false
       setSticky(fromUrl)
       return
@@ -114,75 +179,147 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
   })
 
   const dir = sticky
-  const key = () => storageKey(dir())
+  const pKey = () => {
+    const d = dir()
+    return d ? projectKey(d) : undefined
+  }
 
   // Run migration synchronously before initial load so first render has data
   const initialDir = dir()
   if (initialDir) migrateIfNeeded(initialDir)
 
-  const initialKey = key()
-  const [prompts, setPrompts] = createSignal<SavedPrompt[]>(
-    loadFromStorage(initialKey).sort((a, b) => b.createdAt - a.createdAt),
+  // Load initial data from both stores
+  const [globalPrompts, setGlobalPrompts] = createSignal<SavedPrompt[]>(
+    loadFromStorage(GLOBAL_KEY, "global").sort(sortNewest),
+  )
+  const [projectPrompts, setProjectPrompts] = createSignal<SavedPrompt[]>(
+    pKey() ? loadFromStorage(pKey()!, "project").sort(sortNewest) : [],
   )
 
-  // Reload prompts (with migration) when the storage key changes (e.g.
-  // switching projects or the sticky directory settling after mount).
-  // We track the previous key to skip redundant reloads — this replaces
-  // the old `defer: true` approach that could miss corrections when the
-  // provider remounted with a stale initial key.
-  let prevKey = initialKey
-  createEffect(on(key, (k) => {
-    if (k === prevKey) return
-    prevKey = k
+  // Merged view: global + project (deduplicated)
+  const allPrompts = createMemo(() => mergePrompts(globalPrompts(), projectPrompts()))
+
+  // Reload project prompts when the project key changes
+  let prevPKey = pKey()
+  createEffect(on(pKey, (k) => {
+    if (k === prevPKey) return
+    prevPKey = k
     const d = dir()
     if (d) migrateIfNeeded(d)
-    setPrompts(loadFromStorage(k).sort((a, b) => b.createdAt - a.createdAt))
+    setProjectPrompts(k ? loadFromStorage(k, "project").sort(sortNewest) : [])
   }))
 
-  function add(title: string, text: string) {
-    setPrompts((prev) => {
-      const prompt: SavedPrompt = {
-        id: crypto.randomUUID(),
-        title,
-        text,
-        createdAt: Date.now(),
+  // Also reload global prompts when the project key changes (migration may
+  // have tagged previously-unscoped prompts)
+  createEffect(on(pKey, () => {
+    setGlobalPrompts(loadFromStorage(GLOBAL_KEY, "global").sort(sortNewest))
+  }))
+
+  function add(title: string, text: string, scope: PromptScope = "global") {
+    const prompt: SavedPrompt = {
+      id: crypto.randomUUID(),
+      title,
+      text,
+      createdAt: Date.now(),
+      scope,
+    }
+    if (scope === "project") {
+      const k = pKey()
+      if (!k) {
+        // Fallback to global if no project context
+        addGlobal(prompt)
+        return
       }
-      const updated = [prompt, ...prev]
-      saveToStorage(key(), updated)
+      setProjectPrompts((prev) => {
+        const updated = [prompt, ...prev]
+        saveToStorage(k, updated)
+        return updated
+      })
+    } else {
+      addGlobal(prompt)
+    }
+  }
+
+  function addGlobal(prompt: SavedPrompt) {
+    setGlobalPrompts((prev) => {
+      const updated = [{ ...prompt, scope: "global" as const }, ...prev]
+      saveToStorage(GLOBAL_KEY, updated)
       return updated
     })
   }
 
   function update(id: string, fields: Partial<Pick<SavedPrompt, "title" | "text">>) {
-    setPrompts((prev) => {
-      const updated = prev.map((p) => (p.id === id ? { ...p, ...fields } : p))
-      saveToStorage(key(), updated)
-      return updated
-    })
+    // Find which store the prompt belongs to
+    if (projectPrompts().some((p) => p.id === id)) {
+      const k = pKey()
+      if (!k) return
+      setProjectPrompts((prev) => {
+        const updated = prev.map((p) => (p.id === id ? { ...p, ...fields } : p))
+        saveToStorage(k, updated)
+        return updated
+      })
+    } else {
+      setGlobalPrompts((prev) => {
+        const updated = prev.map((p) => (p.id === id ? { ...p, ...fields } : p))
+        saveToStorage(GLOBAL_KEY, updated)
+        return updated
+      })
+    }
   }
 
   function remove(id: string) {
-    setPrompts((prev) => {
-      const filtered = prev.filter((p) => p.id !== id)
-      saveToStorage(key(), filtered)
-      return filtered
-    })
+    // Remove from whichever store contains it
+    if (projectPrompts().some((p) => p.id === id)) {
+      const k = pKey()
+      if (!k) return
+      setProjectPrompts((prev) => {
+        const filtered = prev.filter((p) => p.id !== id)
+        saveToStorage(k, filtered)
+        return filtered
+      })
+    } else {
+      setGlobalPrompts((prev) => {
+        const filtered = prev.filter((p) => p.id !== id)
+        saveToStorage(GLOBAL_KEY, filtered)
+        return filtered
+      })
+    }
   }
 
   function reorder(ids: string[]) {
-    setPrompts((prev) => {
-      const map = new Map(prev.map((p) => [p.id, p]))
-      const reordered = ids.map((id) => map.get(id)).filter(Boolean) as SavedPrompt[]
-      // Append any prompts not in the ids list (shouldn't happen, but be safe)
-      const remaining = prev.filter((p) => !ids.includes(p.id))
-      const updated = [...reordered, ...remaining]
-      saveToStorage(key(), updated)
-      return updated
-    })
+    // Reorder only applies to the merged view — split back by scope and persist
+    const merged = allPrompts()
+    const map = new Map(merged.map((p) => [p.id, p]))
+    const reordered = ids.map((id) => map.get(id)).filter(Boolean) as SavedPrompt[]
+    const remaining = merged.filter((p) => !ids.includes(p.id))
+    const all = [...reordered, ...remaining]
+
+    const newGlobal = all.filter((p) => p.scope === "global")
+    const newProject = all.filter((p) => p.scope === "project")
+
+    setGlobalPrompts(newGlobal)
+    saveToStorage(GLOBAL_KEY, newGlobal)
+
+    const k = pKey()
+    if (k) {
+      setProjectPrompts(newProject)
+      saveToStorage(k, newProject)
+    }
   }
 
   return (
-    <SavedPromptsContext.Provider value={{ prompts, add, update, remove, reorder }}>
+    <SavedPromptsContext.Provider
+      value={{
+        prompts: allPrompts,
+        globalPrompts,
+        projectPrompts,
+        hasProject: () => !!dir(),
+        add,
+        update,
+        remove,
+        reorder,
+      }}
+    >
       {props.children}
     </SavedPromptsContext.Provider>
   )

--- a/app-prefixable/src/context/saved-prompts.tsx
+++ b/app-prefixable/src/context/saved-prompts.tsx
@@ -30,6 +30,7 @@ interface SavedPromptsContextValue {
   /** Whether there is an active project directory. */
   hasProject: () => boolean
   add: (title: string, text: string, scope?: PromptScope) => void
+  move: (id: string, scope: PromptScope) => void
   update: (id: string, fields: Partial<Pick<SavedPrompt, "title" | "text">>) => void
   remove: (id: string) => void
   reorder: (ids: string[]) => void
@@ -249,6 +250,40 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
     })
   }
 
+  function move(id: string, scope: PromptScope) {
+    const project = projectPrompts().find((p) => p.id === id)
+    if (project) {
+      if (scope === "project") return
+      const k = pKey()
+      if (!k) return
+      setProjectPrompts((prev) => {
+        const updated = prev.filter((p) => p.id !== id)
+        saveToStorage(k, updated)
+        return updated
+      })
+      addGlobal({ ...project, scope: "global" as const })
+      return
+    }
+
+    const global = globalPrompts().find((p) => p.id === id)
+    if (!global) return
+    if (scope === "global") return
+
+    const k = pKey()
+    if (!k) return
+
+    setGlobalPrompts((prev) => {
+      const updated = prev.filter((p) => p.id !== id)
+      saveToStorage(GLOBAL_KEY, updated)
+      return updated
+    })
+    setProjectPrompts((prev) => {
+      const updated = [{ ...global, scope: "project" as const }, ...prev]
+      saveToStorage(k, updated)
+      return updated
+    })
+  }
+
   function update(id: string, fields: Partial<Pick<SavedPrompt, "title" | "text">>) {
     // Find which store the prompt belongs to
     if (projectPrompts().some((p) => p.id === id)) {
@@ -288,21 +323,38 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
   }
 
   function reorder(ids: string[]) {
-    // Reorder only applies to the merged view — split back by scope and persist
+    // Reorder only applies to visible merged prompts.
+    // Persist per-store ordering without dropping hidden duplicate entries.
     const merged = allPrompts()
     const map = new Map(merged.map((p) => [p.id, p]))
     const reordered = ids.map((id) => map.get(id)).filter(isPrompt)
     const remaining = merged.filter((p) => !ids.includes(p.id))
-    const all = [...reordered, ...remaining]
+    const visible = [...reordered, ...remaining]
+    const rank = new Map(visible.map((p, i) => [p.id, i]))
 
-    const newGlobal = all.filter((p) => p.scope === "global")
-    const newProject = all.filter((p) => p.scope === "project")
+    const reorderStore = (items: SavedPrompt[]) => {
+      const indexed = items.map((p, i) => ({ p, i }))
+      indexed.sort((a, b) => {
+        const ar = rank.get(a.p.id)
+        const br = rank.get(b.p.id)
+        if (ar !== undefined && br !== undefined) {
+          if (ar !== br) return ar - br
+          return a.i - b.i
+        }
+        if (ar !== undefined) return -1
+        if (br !== undefined) return 1
+        return a.i - b.i
+      })
+      return indexed.map((x) => x.p)
+    }
 
+    const newGlobal = reorderStore(globalPrompts())
     setGlobalPrompts(newGlobal)
     saveToStorage(GLOBAL_KEY, newGlobal)
 
     const k = pKey()
     if (k) {
+      const newProject = reorderStore(projectPrompts())
       setProjectPrompts(newProject)
       saveToStorage(k, newProject)
     }
@@ -316,6 +368,7 @@ export function SavedPromptsProvider(props: ParentProps & { directory?: Accessor
         projectPrompts,
         hasProject: () => !!dir(),
         add,
+        move,
         update,
         remove,
         reorder,

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -55,7 +55,7 @@ import {
 import { useSync } from "../context/sync";
 import { usePermission } from "../context/permission";
 import { useGlobalEvents } from "../context/global-events";
-import { useSavedPrompts } from "../context/saved-prompts";
+import { useSavedPrompts, type PromptScope } from "../context/saved-prompts";
 import { useCommand, isDialogOpen } from "../context/command";
 import { ResizeHandle } from "../components/resize-handle";
 import { ConfirmDialog } from "../components/confirm-dialog";
@@ -122,7 +122,7 @@ export function groupSessionsByDate(
 }
 
 function PromptDropdown(props: {
-  prompts: { id: string; title: string; text: string }[];
+  prompts: { id: string; title: string; text: string; scope: PromptScope }[];
   activeIndex: number;
   onSelect: (text: string) => void;
   onClose: () => void;
@@ -188,7 +188,7 @@ function PromptDropdown(props: {
         <For each={props.prompts}>
           {(prompt, i) => (
             <button
-              class="w-full text-left px-3 py-2 text-sm transition-colors truncate"
+              class="w-full text-left px-3 py-2 text-sm transition-colors flex items-center gap-2"
               style={{
                 background: i() === props.activeIndex ? "var(--surface-inset)" : "transparent",
                 color: i() === props.activeIndex ? "var(--text-interactive-base)" : "var(--text-base)",
@@ -198,7 +198,16 @@ function PromptDropdown(props: {
               onMouseEnter={() => props.onIndexChange(i())}
               onClick={() => props.onSelect(prompt.text)}
             >
-              {prompt.title}
+              <span class="truncate">{prompt.title}</span>
+              <span
+                class="text-[10px] px-1 py-0.5 rounded shrink-0 ml-auto"
+                style={{
+                  background: i() === props.activeIndex ? "rgba(255,255,255,0.15)" : "var(--surface-inset)",
+                  color: i() === props.activeIndex ? "var(--text-interactive-base)" : "var(--text-weak)",
+                }}
+              >
+                {prompt.scope === "project" ? "Project" : "Global"}
+              </span>
             </button>
           )}
         </For>

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -21,7 +21,7 @@ import { useMCP } from "../context/mcp";
 import { usePermission } from "../context/permission";
 import { useLayout } from "../context/layout";
 import { useBranding } from "../context/branding";
-import { useSavedPrompts } from "../context/saved-prompts";
+import { useSavedPrompts, type PromptScope } from "../context/saved-prompts";
 import { useTerminal } from "../context/terminal";
 import { useConfig } from "../context/config";
 import { MessageTimeline } from "../components/message-timeline";
@@ -147,6 +147,7 @@ export function Session() {
       id: p.id,
       title: p.title,
       description: p.text.length > 80 ? p.text.slice(0, 80) + "..." : p.text,
+      group: p.scope === "project" ? "Project" : "Global",
     })),
   );
 
@@ -240,6 +241,7 @@ export function Session() {
   const [showSavePrompt, setShowSavePrompt] = createSignal(false);
   const [savePromptTitle, setSavePromptTitle] = createSignal("");
   const [savePromptBody, setSavePromptBody] = createSignal("");
+  const [savePromptScope, setSavePromptScope] = createSignal<PromptScope>(directory ? "project" : "global");
 
   const [fileContext, setFileContext] = createSignal<FileContext[]>([]);
   const [imageAttachments, setImageAttachments] = createSignal<
@@ -1696,11 +1698,22 @@ export function Session() {
                         e.currentTarget.style.background = "var(--background-base)";
                       }}
                     >
-                      <div
-                        class="text-sm font-medium truncate"
-                        style={{ color: "var(--text-strong)" }}
-                      >
-                        {prompt.title}
+                      <div class="flex items-center gap-2">
+                        <div
+                          class="text-sm font-medium truncate"
+                          style={{ color: "var(--text-strong)" }}
+                        >
+                          {prompt.title}
+                        </div>
+                        <span
+                          class="text-[10px] px-1.5 py-0.5 rounded shrink-0"
+                          style={{
+                            background: "var(--surface-inset)",
+                            color: "var(--text-weak)",
+                          }}
+                        >
+                          {prompt.scope === "project" ? "Project" : "Global"}
+                        </span>
                       </div>
                       <div
                         class="text-xs mt-1 line-clamp-2"
@@ -2070,6 +2083,7 @@ export function Session() {
                           if (!text) return;
                           setSavePromptTitle(text.slice(0, 30));
                           setSavePromptBody(text);
+                          setSavePromptScope(directory ? "project" : "global");
                           setShowSavePrompt(true);
                         }}
                         class="p-1.5 rounded transition-colors"
@@ -2294,11 +2308,14 @@ export function Session() {
           <SavePromptDialog
             title={savePromptTitle}
             setTitle={setSavePromptTitle}
+            scope={savePromptScope}
+            setScope={setSavePromptScope}
+            hasProject={!!directory}
             onSave={() => {
               const title = savePromptTitle().trim();
               const body = savePromptBody();
               if (!title || !body) return;
-              savedPrompts.add(title, body);
+              savedPrompts.add(title, body, savePromptScope());
               setShowSavePrompt(false);
               showToast("Prompt saved");
             }}
@@ -2391,6 +2408,9 @@ export function Session() {
 function SavePromptDialog(props: {
   title: () => string
   setTitle: (v: string) => void
+  scope: () => PromptScope
+  setScope: (v: PromptScope) => void
+  hasProject: boolean
   onSave: () => void
   onClose: () => void
 }) {
@@ -2498,6 +2518,41 @@ function SavePromptDialog(props: {
             <p class="text-xs" style={{ color: "var(--text-weak)" }}>
               The current input text will be saved as the prompt body.
             </p>
+            <div>
+              <label
+                class="block text-xs font-medium mb-1"
+                style={{ color: "var(--text-base)" }}
+              >
+                Scope
+              </label>
+              <div class="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => props.setScope("global")}
+                  class="flex-1 px-2.5 py-1 rounded-md text-xs font-medium transition-colors"
+                  style={{
+                    background: props.scope() === "global" ? "var(--interactive-base)" : "var(--surface-inset)",
+                    color: props.scope() === "global" ? "white" : "var(--text-base)",
+                    border: props.scope() === "global" ? "1px solid var(--interactive-base)" : "1px solid var(--border-base)",
+                  }}
+                >
+                  Global
+                </button>
+                <button
+                  type="button"
+                  onClick={() => props.setScope("project")}
+                  disabled={!props.hasProject}
+                  class="flex-1 px-2.5 py-1 rounded-md text-xs font-medium transition-colors disabled:opacity-40"
+                  style={{
+                    background: props.scope() === "project" ? "var(--interactive-base)" : "var(--surface-inset)",
+                    color: props.scope() === "project" ? "white" : "var(--text-base)",
+                    border: props.scope() === "project" ? "1px solid var(--interactive-base)" : "1px solid var(--border-base)",
+                  }}
+                >
+                  Project
+                </button>
+              </div>
+            </div>
           </div>
           <div
             class="px-4 py-3 flex justify-end gap-2"

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -2525,10 +2525,11 @@ function SavePromptDialog(props: {
               >
                 Scope
               </label>
-              <div class="flex gap-2">
+              <div class="flex gap-2" role="group" aria-label="Prompt scope">
                 <button
                   type="button"
                   onClick={() => props.setScope("global")}
+                  aria-pressed={props.scope() === "global"}
                   class="flex-1 px-2.5 py-1 rounded-md text-xs font-medium transition-colors"
                   style={{
                     background: props.scope() === "global" ? "var(--interactive-base)" : "var(--surface-inset)",
@@ -2542,6 +2543,7 @@ function SavePromptDialog(props: {
                   type="button"
                   onClick={() => props.setScope("project")}
                   disabled={!props.hasProject}
+                  aria-pressed={props.scope() === "project"}
                   class="flex-1 px-2.5 py-1 rounded-md text-xs font-medium transition-colors disabled:opacity-40"
                   style={{
                     background: props.scope() === "project" ? "var(--interactive-base)" : "var(--surface-inset)",
@@ -2589,4 +2591,3 @@ function SavePromptDialog(props: {
     </Portal>
   );
 }
-

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -241,7 +241,7 @@ export function Session() {
   const [showSavePrompt, setShowSavePrompt] = createSignal(false);
   const [savePromptTitle, setSavePromptTitle] = createSignal("");
   const [savePromptBody, setSavePromptBody] = createSignal("");
-  const [savePromptScope, setSavePromptScope] = createSignal<PromptScope>(directory ? "project" : "global");
+  const [savePromptScope, setSavePromptScope] = createSignal<PromptScope>(savedPrompts.hasProject() ? "project" : "global");
 
   const [fileContext, setFileContext] = createSignal<FileContext[]>([]);
   const [imageAttachments, setImageAttachments] = createSignal<
@@ -2083,7 +2083,7 @@ export function Session() {
                           if (!text) return;
                           setSavePromptTitle(text.slice(0, 30));
                           setSavePromptBody(text);
-                          setSavePromptScope(directory ? "project" : "global");
+                          setSavePromptScope(savedPrompts.hasProject() ? "project" : "global");
                           setShowSavePrompt(true);
                         }}
                         class="p-1.5 rounded transition-colors"
@@ -2310,7 +2310,7 @@ export function Session() {
             setTitle={setSavePromptTitle}
             scope={savePromptScope}
             setScope={setSavePromptScope}
-            hasProject={!!directory}
+            hasProject={savedPrompts.hasProject()}
             onSave={() => {
               const title = savePromptTitle().trim();
               const body = savePromptBody();

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -11,7 +11,7 @@ import { ConfirmDialog } from "../components/confirm-dialog"
 import { Button } from "../components/ui/button"
 import { Check, Copy, Plug, GitBranch, Server, Globe, ExternalLink, Key, Search, X, Trash2, BookmarkPlus, Pencil, Palette, Sun, Moon, Monitor, BookOpen, Plus, Save, Volume2, Play, Settings2, Code, Shield, Cpu, Wrench, ChevronDown, ChevronRight, Info } from "lucide-solid"
 import { SOUND_OPTIONS, readSoundSettings, writeSoundSettings, playSound, primeAudioContext, SOUND_STORAGE_KEY, type SoundSettings } from "../utils/sound"
-import { useSavedPrompts } from "../context/saved-prompts"
+import { useSavedPrompts, type PromptScope } from "../context/saved-prompts"
 import { useTheme } from "../context/theme"
 import { useServer } from "../context/server"
 import { ServerDialog } from "../components/server-dialog"
@@ -49,6 +49,7 @@ export function Settings() {
   const [editingPromptId, setEditingPromptId] = createSignal<string | null>(null)
   const [promptTitle, setPromptTitle] = createSignal("")
   const [promptText, setPromptText] = createSignal("")
+  const [promptScope, setPromptScope] = createSignal<PromptScope>("global")
   const [promptToDelete, setPromptToDelete] = createSignal<string | null>(null)
 
   // Sound settings
@@ -601,6 +602,7 @@ Add your project-specific instructions here.
     setEditingPromptId(null)
     setPromptTitle("")
     setPromptText("")
+    setPromptScope(directory ? "project" : "global")
     setPromptDialogOpen(true)
   }
 
@@ -610,6 +612,7 @@ Add your project-specific instructions here.
     setEditingPromptId(id)
     setPromptTitle(prompt.title)
     setPromptText(prompt.text)
+    setPromptScope(prompt.scope)
     setPromptDialogOpen(true)
   }
 
@@ -619,9 +622,16 @@ Add your project-specific instructions here.
     if (!title || !text) return
     const editing = editingPromptId()
     if (editing) {
-      savedPrompts.update(editing, { title, text })
+      const existing = savedPrompts.prompts().find((p) => p.id === editing)
+      if (existing && existing.scope !== promptScope()) {
+        // Scope changed — remove from old store and add to new one
+        savedPrompts.remove(editing)
+        savedPrompts.add(title, text, promptScope())
+      } else {
+        savedPrompts.update(editing, { title, text })
+      }
     } else {
-      savedPrompts.add(title, text)
+      savedPrompts.add(title, text, promptScope())
     }
     setPromptDialogOpen(false)
     setEditingPromptId(null)
@@ -645,7 +655,7 @@ Add your project-specific instructions here.
       { id: "servers", label: "Servers", icon: () => <Globe class="w-4 h-4" />, scope: "Global" },
       { id: "git", label: "Git", icon: () => <GitBranch class="w-4 h-4" />, scope: "Global" },
       { id: "mcp", label: "MCP Servers", icon: () => <Server class="w-4 h-4" />, scope: "Global + Project" },
-      { id: "prompts", label: "Prompts", icon: () => <BookmarkPlus class="w-4 h-4" />, scope: directory ? "Project" : null },
+      { id: "prompts", label: "Prompts", icon: () => <BookmarkPlus class="w-4 h-4" />, scope: directory ? "Global + Project" : "Global" },
       { id: "instructions", label: "Instructions", icon: () => <BookOpen class="w-4 h-4" />, scope: directory ? "Project" : null },
     ]
     // Only show Project Config tab when a project directory is selected
@@ -1760,7 +1770,10 @@ Add your project-specific instructions here.
                   Saved Prompts
                 </h1>
                 <p class="text-sm mt-1" style={{ color: "var(--text-weak)" }}>
-                  Create reusable prompts for quick access from the welcome screen or /prompt command
+                  Create reusable prompts for quick access from the welcome screen or /prompt command.
+                  {directory
+                    ? " Global prompts are available in all projects; project prompts are scoped to this project."
+                    : " Prompts shown here are available in all projects."}
                 </p>
               </header>
 
@@ -1804,8 +1817,19 @@ Add your project-specific instructions here.
                       {(prompt) => (
                         <div class="px-4 py-3 flex items-start justify-between gap-4">
                           <div class="flex-1 min-w-0">
-                            <div class="font-medium text-sm" style={{ color: "var(--text-strong)" }}>
-                              {prompt.title}
+                            <div class="flex items-center gap-2">
+                              <div class="font-medium text-sm truncate" style={{ color: "var(--text-strong)" }}>
+                                {prompt.title}
+                              </div>
+                              <span
+                                class="text-[10px] px-1.5 py-0.5 rounded shrink-0"
+                                style={{
+                                  background: "var(--surface-inset)",
+                                  color: "var(--text-weak)",
+                                }}
+                              >
+                                {prompt.scope === "project" ? "Project" : "Global"}
+                              </span>
                             </div>
                             <p
                               class="text-xs mt-0.5 line-clamp-2"
@@ -2287,6 +2311,9 @@ Add your project-specific instructions here.
           setTitle={setPromptTitle}
           text={promptText}
           setText={setPromptText}
+          scope={promptScope}
+          setScope={setPromptScope}
+          hasProject={!!directory}
           onSave={savePromptDialog}
           onClose={() => setPromptDialogOpen(false)}
         />
@@ -3111,6 +3138,9 @@ function PromptDialog(props: {
   setTitle: (v: string) => void
   text: () => string
   setText: (v: string) => void
+  scope: () => PromptScope
+  setScope: (v: PromptScope) => void
+  hasProject: boolean
   onSave: () => void
   onClose: () => void
 }) {
@@ -3212,6 +3242,43 @@ function PromptDialog(props: {
                   "min-height": "120px",
                 }}
               />
+            </div>
+            <div>
+              <label class="block text-sm font-medium mb-1.5" style={{ color: "var(--text-base)" }}>
+                Scope
+              </label>
+              <div class="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => props.setScope("global")}
+                  class="flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
+                  style={{
+                    background: props.scope() === "global" ? "var(--interactive-base)" : "var(--surface-inset)",
+                    color: props.scope() === "global" ? "white" : "var(--text-base)",
+                    border: props.scope() === "global" ? "1px solid var(--interactive-base)" : "1px solid var(--border-base)",
+                  }}
+                >
+                  Global
+                </button>
+                <button
+                  type="button"
+                  onClick={() => props.setScope("project")}
+                  disabled={!props.hasProject}
+                  class="flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors disabled:opacity-40"
+                  style={{
+                    background: props.scope() === "project" ? "var(--interactive-base)" : "var(--surface-inset)",
+                    color: props.scope() === "project" ? "white" : "var(--text-base)",
+                    border: props.scope() === "project" ? "1px solid var(--interactive-base)" : "1px solid var(--border-base)",
+                  }}
+                >
+                  Project
+                </button>
+              </div>
+              <p class="text-xs mt-1.5" style={{ color: "var(--text-weak)" }}>
+                {props.scope() === "project"
+                  ? "This prompt will only appear in the current project."
+                  : "This prompt will be available in all projects."}
+              </p>
             </div>
           </div>
           <div

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -602,7 +602,7 @@ Add your project-specific instructions here.
     setEditingPromptId(null)
     setPromptTitle("")
     setPromptText("")
-    setPromptScope(directory ? "project" : "global")
+    setPromptScope(savedPrompts.hasProject() ? "project" : "global")
     setPromptDialogOpen(true)
   }
 
@@ -2316,7 +2316,7 @@ Add your project-specific instructions here.
           setText={setPromptText}
           scope={promptScope}
           setScope={setPromptScope}
-          hasProject={!!directory}
+          hasProject={savedPrompts.hasProject()}
           onSave={savePromptDialog}
           onClose={() => setPromptDialogOpen(false)}
         />

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -624,11 +624,14 @@ Add your project-specific instructions here.
     if (editing) {
       const existing = savedPrompts.prompts().find((p) => p.id === editing)
       if (existing && existing.scope !== promptScope()) {
-        // Scope changed — remove from old store and add to new one
-        savedPrompts.remove(editing)
-        savedPrompts.add(title, text, promptScope())
-      } else {
+        // Scope changed — move across stores while preserving id/createdAt
+        savedPrompts.move(editing, promptScope())
+      }
+      if (existing && (existing.title !== title || existing.text !== text)) {
         savedPrompts.update(editing, { title, text })
+      }
+      if (!existing) {
+        savedPrompts.add(title, text, promptScope())
       }
     } else {
       savedPrompts.add(title, text, promptScope())
@@ -3247,10 +3250,11 @@ function PromptDialog(props: {
               <label class="block text-sm font-medium mb-1.5" style={{ color: "var(--text-base)" }}>
                 Scope
               </label>
-              <div class="flex gap-2">
+              <div class="flex gap-2" role="group" aria-label="Prompt scope">
                 <button
                   type="button"
                   onClick={() => props.setScope("global")}
+                  aria-pressed={props.scope() === "global"}
                   class="flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
                   style={{
                     background: props.scope() === "global" ? "var(--interactive-base)" : "var(--surface-inset)",
@@ -3264,6 +3268,7 @@ function PromptDialog(props: {
                   type="button"
                   onClick={() => props.setScope("project")}
                   disabled={!props.hasProject}
+                  aria-pressed={props.scope() === "project"}
                   class="flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors disabled:opacity-40"
                   style={{
                     background: props.scope() === "project" ? "var(--interactive-base)" : "var(--surface-inset)",


### PR DESCRIPTION
## Summary

- Implements global vs project-scoped saved prompts across all UI surfaces (closes #143)
- Rewrites the `saved-prompts` context to support dual localStorage stores (global + per-project) with automatic migration from the legacy single-key format
- Adds a Global/Project scope toggle to the Settings prompt dialog and the Save Prompt dialog in chat
- Shows scope badges ("Global" / "Project") on all prompt surfaces: settings list, welcome screen cards, `/prompt` picker, and sidebar "New Session from Prompt" dropdown
- Handles scope changes during prompt editing by moving prompts between stores

## Changes

| File | What changed |
|---|---|
| `context/saved-prompts.tsx` | Dual-store architecture with `globalPrompts()`, `projectPrompts()`, `hasProject()`. Migration logic tags legacy prompts as global. Deduplication on merge. |
| `pages/settings.tsx` | Scope toggle in PromptDialog, scope badges on list items, scope-change handling on edit (remove + re-add) |
| `pages/session.tsx` | Scope selector in SavePromptDialog, scope badges on welcome screen cards, scope group labels in `/prompt` picker |
| `pages/layout.tsx` | Scope badges in sidebar PromptDropdown |

## Out of scope
- #204 (backend persistence) — this is the localStorage-based scoping step only