### PR TITLE
fix: resolve sessionId temporal dead zone error on session page

### DIFF
--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -98,6 +98,8 @@ export function Session() {
   const terminal = useTerminal();
   const appConfig = useConfig();
 
+  const [sessionId, setSessionId] = createSignal(params.id);
+
   // Per-session model: reads from providers.sessionModels, falls back to global default
   const sessionModel = createMemo(() => {
     const id = sessionId();
@@ -157,8 +159,6 @@ export function Session() {
   const [loading, setLoading] = createSignal(false);
   const [processing, setProcessing] = createSignal(false);
   const [loadingHistory, setLoadingHistory] = createSignal(false);
-  const [sessionId, setSessionId] = createSignal(params.id);
-
   // Find the Nth-from-last user message (1-indexed: 1 = last, 2 = second-to-last)
   function getNthLastUserMsg(msgs: DisplayMessage[], n: number) {
     let count = 0;

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -159,6 +159,7 @@ export function Session() {
   const [loading, setLoading] = createSignal(false);
   const [processing, setProcessing] = createSignal(false);
   const [loadingHistory, setLoadingHistory] = createSignal(false);
+
   // Find the Nth-from-last user message (1-indexed: 1 = last, 2 = second-to-last)
   function getNthLastUserMsg(msgs: DisplayMessage[], n: number) {
     let count = 0;


### PR DESCRIPTION
## Summary

- Fixes `ReferenceError: Cannot access 'sessionId' before initialization` when navigating to a session page
- The `sessionId` signal was declared on line 160, but the `sessionModel` memo (line 102) called `sessionId()` eagerly during component initialization, hitting the temporal dead zone
- Moved the `sessionId` declaration before the `sessionModel` memo that depends on it