### PR TITLE
fix: pin OpenCode CLI version in Kubeflow Dockerfile

### DIFF
--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -75,6 +75,7 @@ jobs:
             -t $LATEST_TAG \
             -f docker/kubeflow/Dockerfile \
             --platform linux/amd64 \
+            --build-arg OPENCODE_VERSION=1.2.6 \
             --build-arg S6_OVERLAY_VERSION=3.1.6.2 \
             --build-arg KF_EXAMPLES_REPO=https://github.com/prokube-ai/kubeflow-examples.git \
             --label "org.opencontainers.image.title=OpenCode Prefixable UI" \

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -50,8 +50,11 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
     rm -rf /root/.bun
 
 # Install OpenCode CLI
+# Pin version to ensure reproducible builds. Update by changing OPENCODE_VERSION.
+# Check releases at: https://github.com/anomalyco/opencode/releases
+ARG OPENCODE_VERSION=1.2.6
 ENV SHELL=/bin/bash
-RUN curl -fsSL https://opencode.ai/install | bash && \
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --version "${OPENCODE_VERSION}" && \
     mv /root/.opencode/bin/opencode /usr/local/bin/opencode && \
     rm -rf /root/.opencode
 

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -50,7 +50,9 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
     rm -rf /root/.bun
 
 # Install OpenCode CLI
-# Pin version to ensure reproducible builds. Update by changing OPENCODE_VERSION.
+# Pin version to ensure reproducible builds.
+# NOTE: CI overrides this default with `--build-arg OPENCODE_VERSION=...` in
+# `.github/workflows/pk-opencode.yml`, so upgrades must keep both values in sync.
 # Check releases at: https://github.com/anomalyco/opencode/releases
 ARG OPENCODE_VERSION=1.2.6
 ENV SHELL=/bin/bash


### PR DESCRIPTION
## Summary

- Add `ARG OPENCODE_VERSION=1.2.6` to `docker/kubeflow/Dockerfile` and pass `--version "${OPENCODE_VERSION}"` to the install script, matching the pattern already used in `docker/Dockerfile`
- Add `--build-arg OPENCODE_VERSION=1.2.6` to the CI workflow's docker build command
- Add comments explaining how to upgrade the CLI version

Closes #215