### PR TITLE
feat: build Telegram bridge service for OpenCode chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ bun install && bun run dev
 | `BRANDING_NAME` | _(empty)_ | Branding text shown as "Powered by {name}" |
 | `BRANDING_URL` | _(empty)_ | URL for the branding link |
 | `BRANDING_ICON` | _(empty)_ | Custom icon URL (HTTP, relative path, or data URI) |
+| `TELEGRAM_BRIDGE_ENABLED` | `false` | Enable optional Telegram bridge service (Kubeflow image) |
+| `TELEGRAM_BOT_TOKEN` | _(required for bridge)_ | Telegram bot token |
+| `TELEGRAM_MODE` | `polling` | Telegram bridge mode (`polling` or `webhook`) |
+| `OPENCODE_API_URL` | `API_URL` or `http://127.0.0.1:4096` | OpenCode API URL for bridge |
+| `OPENCODE_DIRECTORY` | _(empty)_ | Optional directory for bridge session API calls |
 
 ## Deployment
 
@@ -200,6 +205,15 @@ See [docker/kubeflow/README.md](docker/kubeflow/README.md) for Kubeflow deployme
 ### Reverse Proxy Examples
 
 See [examples/](examples/) for nginx and Traefik configurations.
+
+### Telegram Bridge (optional)
+
+This repository includes a Telegram bridge service (`docker/telegram-bridge.ts`) that:
+- receives Telegram bot text messages,
+- forwards prompts to OpenCode session APIs,
+- sends assistant responses back to Telegram.
+
+The bridge is opt-in and only starts in the Kubeflow image when `TELEGRAM_BRIDGE_ENABLED=true`.
 
 ## Architecture
 

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   cacheSession,
   extractReply,
+  joinOpenCodeUrl,
   parseConfig,
   parseMode,
   queueChatUpdate,
@@ -102,6 +103,15 @@ describe("telegram bridge config and cache", () => {
 
     setEnv({ TELEGRAM_BOT_TOKEN: "token", TELEGRAM_MODE: "bad-mode", OPENCODE_API_URL: "http://127.0.0.1:4096" });
     expect(() => parseConfig()).toThrow("Invalid TELEGRAM_MODE");
+  });
+
+  test("joinOpenCodeUrl keeps configured base path with leading slash paths", () => {
+    expect(joinOpenCodeUrl("http://127.0.0.1:4096/notebook/ns/name", "/session").toString()).toBe(
+      "http://127.0.0.1:4096/notebook/ns/name/session",
+    );
+    expect(joinOpenCodeUrl("http://127.0.0.1:4096/proxy/", "/session/abc/message").toString()).toBe(
+      "http://127.0.0.1:4096/proxy/session/abc/message",
+    );
   });
 
   test("extractReply returns fallback text when no text parts exist", () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4,6 +4,7 @@ import {
   extractReply,
   parseConfig,
   parseMode,
+  queueChatUpdate,
   resetSessionCacheForTest,
   sessionFromCache,
 } from "../../shared/telegram-bridge";
@@ -60,7 +61,39 @@ describe("telegram bridge config and cache", () => {
   test("parseMode accepts known values and rejects unknown", () => {
     expect(parseMode("polling")).toBe("polling");
     expect(parseMode("WEBHOOK")).toBe("webhook");
+    expect(parseMode("  WebHook  ")).toBe("webhook");
     expect(() => parseMode("invalid")).toThrow("Invalid TELEGRAM_MODE");
+  });
+
+  test("queueChatUpdate serializes tasks per chat", async () => {
+    const order: string[] = [];
+    let unlock = () => {};
+    const gate = new Promise<void>((resolve) => {
+      unlock = resolve;
+    });
+
+    const first = queueChatUpdate("chat-1", async () => {
+      order.push("first:start");
+      await gate;
+      order.push("first:end");
+    });
+    const second = queueChatUpdate("chat-1", async () => {
+      order.push("second:start");
+      order.push("second:end");
+    });
+    const other = queueChatUpdate("chat-2", async () => {
+      order.push("other:start");
+      order.push("other:end");
+    });
+
+    await Promise.resolve();
+    expect(order.includes("second:start")).toBe(false);
+
+    unlock();
+    await Promise.all([first, second, other]);
+
+    expect(order.indexOf("first:end")).toBeLessThan(order.indexOf("second:start"));
+    expect(order.includes("other:start")).toBe(true);
   });
 
   test("parseConfig uses polling default and rejects invalid TELEGRAM_MODE", () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  cacheSession,
+  extractReply,
+  parseConfig,
+  parseMode,
+  resetSessionCacheForTest,
+  sessionFromCache,
+} from "../../shared/telegram-bridge";
+
+const envKeys = [
+  "TELEGRAM_BOT_TOKEN",
+  "TELEGRAM_MODE",
+  "OPENCODE_API_URL",
+  "API_URL",
+  "OPENCODE_DIRECTORY",
+  "TELEGRAM_SESSION_CACHE_MAX",
+  "TELEGRAM_SESSION_CACHE_TTL_MS",
+  "TELEGRAM_BRIDGE_PORT",
+  "TELEGRAM_WEBHOOK_PATH",
+  "TELEGRAM_WEBHOOK_SECRET",
+  "TELEGRAM_WEBHOOK_URL",
+] as const;
+
+const envSnapshot = new Map<string, string | undefined>();
+
+function setEnv(next: Partial<Record<(typeof envKeys)[number], string | undefined>>) {
+  for (const key of envKeys) {
+    const value = next[key];
+    if (value === undefined) {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] = value;
+  }
+}
+
+describe("telegram bridge config and cache", () => {
+  beforeEach(() => {
+    resetSessionCacheForTest();
+    for (const key of envKeys) {
+      envSnapshot.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    resetSessionCacheForTest();
+    for (const key of envKeys) {
+      const value = envSnapshot.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+        continue;
+      }
+      process.env[key] = value;
+    }
+    envSnapshot.clear();
+  });
+
+  test("parseMode accepts known values and rejects unknown", () => {
+    expect(parseMode("polling")).toBe("polling");
+    expect(parseMode("WEBHOOK")).toBe("webhook");
+    expect(() => parseMode("invalid")).toThrow("Invalid TELEGRAM_MODE");
+  });
+
+  test("parseConfig uses polling default and rejects invalid TELEGRAM_MODE", () => {
+    setEnv({ TELEGRAM_BOT_TOKEN: "token", OPENCODE_API_URL: "http://127.0.0.1:4096" });
+    expect(parseConfig().mode).toBe("polling");
+
+    setEnv({ TELEGRAM_BOT_TOKEN: "token", TELEGRAM_MODE: "bad-mode", OPENCODE_API_URL: "http://127.0.0.1:4096" });
+    expect(() => parseConfig()).toThrow("Invalid TELEGRAM_MODE");
+  });
+
+  test("extractReply returns fallback text when no text parts exist", () => {
+    expect(extractReply({ parts: [{ type: "tool" }] })).toBe(
+      "I finished processing your request, but there was no text response.",
+    );
+  });
+
+  test("cacheSession evicts oldest entries when max size is exceeded", () => {
+    const config = {
+      mode: "polling" as const,
+      token: "token",
+      openCodeUrl: "http://127.0.0.1:4096",
+      sessionCacheMax: 2,
+      sessionCacheTtlMs: 10_000,
+      port: 4097,
+      webhookPath: "/webhook",
+    };
+
+    cacheSession(config, "chat-a", "session-a");
+    cacheSession(config, "chat-b", "session-b");
+    cacheSession(config, "chat-c", "session-c");
+
+    expect(sessionFromCache(config, "chat-a")).toBeUndefined();
+    expect(sessionFromCache(config, "chat-b")).toBe("session-b");
+    expect(sessionFromCache(config, "chat-c")).toBe("session-c");
+  });
+});

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,7 @@ COPY --from=builder /app/app-prefixable/dist /opt/opencode-ui/dist
 
 # Copy server script
 COPY docker/serve-ui.ts /opt/opencode-ui/serve-ui.ts
+COPY docker/telegram-bridge.ts /opt/opencode-ui/telegram-bridge.ts
 
 # Copy shared modules (for serve-ui.ts imports)
 COPY shared /opt/shared

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,6 +71,26 @@ A full-featured image for Kubeflow Notebooks that includes:
 
 See [kubeflow/README.md](kubeflow/README.md) for details.
 
+## Telegram Bridge (optional)
+
+Both Docker images now include an optional Telegram bridge runtime at `/opt/opencode-ui/telegram-bridge.ts`.
+
+The bridge forwards Telegram text messages to OpenCode sessions and sends responses back to Telegram.
+
+### Bridge environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `TELEGRAM_BRIDGE_ENABLED` | `false` | Enable bridge process (Kubeflow s6 service only) |
+| `TELEGRAM_BOT_TOKEN` | _(required)_ | Telegram bot token from BotFather |
+| `TELEGRAM_MODE` | `polling` | Bridge mode: `polling` or `webhook` |
+| `OPENCODE_API_URL` | `API_URL` or `http://127.0.0.1:4096` | OpenCode API base URL |
+| `OPENCODE_DIRECTORY` | _(empty)_ | Optional OpenCode directory for session requests |
+| `TELEGRAM_BRIDGE_PORT` | `4097` | Webhook listener port (webhook mode only) |
+| `TELEGRAM_WEBHOOK_PATH` | `/webhook` | Webhook endpoint path |
+| `TELEGRAM_WEBHOOK_URL` | _(empty)_ | Public webhook URL to register with Telegram |
+| `TELEGRAM_WEBHOOK_SECRET` | _(empty)_ | Secret token validated from Telegram webhook header |
+
 ### Build
 
 ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -91,6 +91,15 @@ The bridge forwards Telegram text messages to OpenCode sessions and sends respon
 | `TELEGRAM_WEBHOOK_URL` | _(empty)_ | Public webhook URL to register with Telegram |
 | `TELEGRAM_WEBHOOK_SECRET` | _(empty)_ | Secret token validated from Telegram webhook header |
 
+### Webhook deployment notes
+
+When `TELEGRAM_MODE=webhook`, the bridge runs an HTTP listener inside the container and Telegram must be able to reach it from the public internet.
+
+- Expose `TELEGRAM_BRIDGE_PORT` through your platform ingress/load balancer.
+- Route the public webhook path to the bridge service, including any path prefix from your gateway.
+- Set `TELEGRAM_WEBHOOK_URL` to the full public URL Telegram should call (for example, `https://example.com/telegram/webhook`).
+- Use `TELEGRAM_WEBHOOK_SECRET` and configure your proxy to forward `x-telegram-bot-api-secret-token` unchanged.
+
 ### Build
 
 ```bash

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -104,6 +104,7 @@ COPY --from=builder /app/app-prefixable/dist /opt/opencode-ui/dist
 
 # Copy server script (path relative to repo root)
 COPY docker/serve-ui.ts /opt/opencode-ui/serve-ui.ts
+COPY docker/telegram-bridge.ts /opt/opencode-ui/telegram-bridge.ts
 
 # Copy shared modules (for serve-ui.ts imports)
 COPY shared /opt/shared
@@ -116,7 +117,7 @@ COPY docker/kubeflow/start-server.sh /usr/local/bin/start-server.sh
 
 # Set permissions
 # /run must be owned by jovyan for s6-overlay rootless mode
-RUN chmod -R 755 /etc/services.d/opencode /etc/cont-init.d/ && \
+RUN chmod -R 755 /etc/services.d/opencode /etc/services.d/telegram-bridge /etc/cont-init.d/ && \
     chmod +x /usr/local/bin/start-server.sh && \
     chown -R jovyan:jovyan /home/jovyan /tmp_home /opt/opencode-ui /run
 

--- a/docker/kubeflow/README.md
+++ b/docker/kubeflow/README.md
@@ -164,6 +164,13 @@ Optional:
 - `TELEGRAM_WEBHOOK_URL` (auto-register webhook if set)
 - `TELEGRAM_WEBHOOK_SECRET` (validated from `x-telegram-bot-api-secret-token` header)
 
+Webhook mode deployment notes:
+- Expose `TELEGRAM_BRIDGE_PORT` on the Notebook service or sidecar Service, then publish it through your cluster ingress.
+- Route incoming traffic to `TELEGRAM_WEBHOOK_PATH` to the same container that runs the `telegram-bridge` s6 service.
+- Set `TELEGRAM_WEBHOOK_URL` to the externally reachable HTTPS URL Telegram can call.
+- If your ingress rewrites paths, keep the external path in `TELEGRAM_WEBHOOK_URL` aligned with the internal `TELEGRAM_WEBHOOK_PATH` target.
+- Set `TELEGRAM_WEBHOOK_SECRET` and ensure your ingress preserves `x-telegram-bot-api-secret-token`.
+
 ## Development
 
 To iterate on the UI:

--- a/docker/kubeflow/README.md
+++ b/docker/kubeflow/README.md
@@ -142,9 +142,27 @@ The container uses s6-overlay with the following structure:
 │   ├── 02-clone-examples       # Clone examples repository (optional)
 │   └── 03-fix-ssh-permissions  # Fix SSH key permissions for mounted keys
 └── services.d/
-    └── opencode/
-        └── run                 # Start API + UI servers
+    ├── opencode/
+    │   └── run                 # Start API + UI servers
+    └── telegram-bridge/
+        └── run                 # Optional Telegram bridge process
 ```
+
+### Telegram bridge (optional)
+
+Set `TELEGRAM_BRIDGE_ENABLED=true` to enable the Telegram bridge service.
+
+Required when enabled:
+- `TELEGRAM_BOT_TOKEN`
+
+Optional:
+- `TELEGRAM_MODE` (`polling` or `webhook`, default `polling`)
+- `OPENCODE_API_URL` (defaults to `API_URL` or `http://127.0.0.1:4096`)
+- `OPENCODE_DIRECTORY`
+- `TELEGRAM_BRIDGE_PORT` (webhook mode)
+- `TELEGRAM_WEBHOOK_PATH` (webhook mode)
+- `TELEGRAM_WEBHOOK_URL` (auto-register webhook if set)
+- `TELEGRAM_WEBHOOK_SECRET` (validated from `x-telegram-bot-api-secret-token` header)
 
 ## Development
 

--- a/docker/kubeflow/s6/services.d/telegram-bridge/run
+++ b/docker/kubeflow/s6/services.d/telegram-bridge/run
@@ -1,0 +1,14 @@
+#!/command/with-contenv sh
+
+if [ "${TELEGRAM_BRIDGE_ENABLED:-false}" != "true" ]; then
+  echo "INFO: Telegram bridge disabled (set TELEGRAM_BRIDGE_ENABLED=true to enable)"
+  exec sleep infinity
+fi
+
+if [ -z "${TELEGRAM_BOT_TOKEN:-}" ]; then
+  echo "ERROR: TELEGRAM_BRIDGE_ENABLED=true but TELEGRAM_BOT_TOKEN is not set"
+  exit 1
+fi
+
+cd /opt/opencode-ui
+exec bun run telegram-bridge.ts

--- a/docker/kubeflow/s6/services.d/telegram-bridge/run
+++ b/docker/kubeflow/s6/services.d/telegram-bridge/run
@@ -2,7 +2,9 @@
 
 if [ "${TELEGRAM_BRIDGE_ENABLED:-false}" != "true" ]; then
   echo "INFO: Telegram bridge disabled (set TELEGRAM_BRIDGE_ENABLED=true to enable)"
-  exec sleep infinity
+  while true; do
+    sleep 3600
+  done
 fi
 
 if [ -z "${TELEGRAM_BOT_TOKEN:-}" ]; then

--- a/docker/telegram-bridge.ts
+++ b/docker/telegram-bridge.ts
@@ -1,0 +1,8 @@
+import { startTelegramBridge } from "../shared/telegram-bridge"
+
+console.log("[TelegramBridge] starting")
+
+startTelegramBridge().catch((error) => {
+  console.error("[TelegramBridge] fatal error", error)
+  process.exit(1)
+})

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -156,8 +156,16 @@ async function telegramRequest(config: BridgeConfig, method: string, body: Recor
   return retry(`telegram:${method}`, run)
 }
 
+export function joinOpenCodeUrl(openCodeUrl: string, path: string): URL {
+  const url = new URL(openCodeUrl)
+  const basePath = url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`
+  const nextPath = path.startsWith("/") ? path.slice(1) : path
+  url.pathname = `${basePath}${nextPath}`
+  return url
+}
+
 function opencodeUrl(config: BridgeConfig, path: string): URL {
-  return new URL(path, config.openCodeUrl.endsWith("/") ? config.openCodeUrl : `${config.openCodeUrl}/`)
+  return joinOpenCodeUrl(config.openCodeUrl, path)
 }
 
 async function createSession(config: BridgeConfig): Promise<string> {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1,0 +1,297 @@
+type TelegramUpdate = {
+  update_id: number
+  message?: {
+    message_id: number
+    text?: string
+    chat?: {
+      id: number
+    }
+  }
+}
+
+type BridgeConfig = {
+  mode: "polling" | "webhook"
+  token: string
+  openCodeUrl: string
+  directory?: string
+  port: number
+  webhookPath: string
+  webhookSecret?: string
+  webhookUrl?: string
+}
+
+const sessions = new Map<string, string>()
+
+function env(name: string): string {
+  return process.env[name]?.trim() || ""
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function parseMode(value: string): "polling" | "webhook" {
+  if (value.toLowerCase() === "webhook") return "webhook"
+  return "polling"
+}
+
+function parsePort(value: string): number {
+  const n = Number.parseInt(value, 10)
+  if (Number.isNaN(n) || n <= 0) return 4097
+  return n
+}
+
+function parseConfig(): BridgeConfig {
+  const token = env("TELEGRAM_BOT_TOKEN")
+  if (!token) {
+    throw new Error("TELEGRAM_BOT_TOKEN is required")
+  }
+
+  const mode = parseMode(env("TELEGRAM_MODE") || "polling")
+  const openCodeUrl = env("OPENCODE_API_URL") || env("API_URL") || "http://127.0.0.1:4096"
+  const webhookPath = env("TELEGRAM_WEBHOOK_PATH") || "/webhook"
+
+  return {
+    mode,
+    token,
+    openCodeUrl,
+    directory: env("OPENCODE_DIRECTORY") || undefined,
+    port: parsePort(env("TELEGRAM_BRIDGE_PORT") || "4097"),
+    webhookPath: webhookPath.startsWith("/") ? webhookPath : `/${webhookPath}`,
+    webhookSecret: env("TELEGRAM_WEBHOOK_SECRET") || undefined,
+    webhookUrl: env("TELEGRAM_WEBHOOK_URL") || undefined,
+  }
+}
+
+async function retry<T>(name: string, fn: () => Promise<T>, retries = 2, delayMs = 400): Promise<T> {
+  try {
+    return await fn()
+  } catch (error) {
+    if (retries <= 0) throw error
+    console.warn(`[TelegramBridge] ${name} failed, retrying in ${delayMs}ms`, error)
+    await sleep(delayMs)
+    return retry(name, fn, retries - 1, Math.min(delayMs * 2, 4000))
+  }
+}
+
+async function telegramRequest(config: BridgeConfig, method: string, body: Record<string, unknown>, timeoutMs = 10_000) {
+  const run = async () => {
+    const url = `https://api.telegram.org/bot${config.token}/${method}`
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    const data = (await res.json().catch(() => ({}))) as {
+      ok?: boolean
+      result?: unknown
+      description?: string
+    }
+
+    if (!res.ok || !data.ok) {
+      const detail = data.description || `HTTP ${res.status}`
+      throw new Error(`Telegram ${method} failed: ${detail}`)
+    }
+
+    return data.result
+  }
+
+  return retry(`telegram:${method}`, run)
+}
+
+function opencodeUrl(config: BridgeConfig, path: string): URL {
+  return new URL(path, config.openCodeUrl.endsWith("/") ? config.openCodeUrl : `${config.openCodeUrl}/`)
+}
+
+async function createSession(config: BridgeConfig): Promise<string> {
+  const url = opencodeUrl(config, "/session")
+  if (config.directory) {
+    url.searchParams.set("directory", config.directory)
+  }
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+    signal: AbortSignal.timeout(12_000),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`OpenCode session create failed (${res.status}): ${body.slice(0, 300)}`)
+  }
+
+  const data = (await res.json()) as { id?: string }
+  if (!data.id) {
+    throw new Error("OpenCode session create returned no id")
+  }
+
+  return data.id
+}
+
+async function sessionForChat(config: BridgeConfig, chatId: string): Promise<string> {
+  const cached = sessions.get(chatId)
+  if (cached) return cached
+
+  const id = await createSession(config)
+  sessions.set(chatId, id)
+  return id
+}
+
+function extractReply(payload: unknown): string {
+  const data = payload as {
+    parts?: Array<{ type?: string; text?: string }>
+  }
+
+  const parts = Array.isArray(data.parts) ? data.parts : []
+  const text = parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text || "")
+    .join("")
+    .trim()
+
+  if (text) return text
+  return "I finished processing your request, but there was no text response."
+}
+
+async function sendPrompt(config: BridgeConfig, sessionID: string, text: string): Promise<string> {
+  const url = opencodeUrl(config, `/session/${sessionID}/message`)
+  if (config.directory) {
+    url.searchParams.set("directory", config.directory)
+  }
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      parts: [{ type: "text", text }],
+    }),
+    signal: AbortSignal.timeout(60_000),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`OpenCode prompt failed (${res.status}): ${body.slice(0, 300)}`)
+  }
+
+  const data = await res.json().catch(() => ({}))
+  return extractReply(data)
+}
+
+function chunks(input: string, size: number): string[] {
+  if (input.length <= size) return [input]
+  const output: string[] = []
+  for (const i of Array.from({ length: Math.ceil(input.length / size) }, (_, idx) => idx)) {
+    output.push(input.slice(i * size, (i + 1) * size))
+  }
+  return output
+}
+
+async function sendTelegramMessage(config: BridgeConfig, chatId: number, text: string) {
+  const safe = text || "I could not produce a response."
+  for (const part of chunks(safe, 3900)) {
+    await telegramRequest(config, "sendMessage", {
+      chat_id: chatId,
+      text: part,
+    })
+  }
+}
+
+async function handleTextUpdate(config: BridgeConfig, update: TelegramUpdate) {
+  const message = update.message
+  const chatId = message?.chat?.id
+  const text = message?.text?.trim()
+
+  if (!chatId || !text) return
+
+  try {
+    const sessionID = await sessionForChat(config, String(chatId))
+    const reply = await sendPrompt(config, sessionID, text)
+    await sendTelegramMessage(config, chatId, reply)
+  } catch (error) {
+    console.error("[TelegramBridge] request handling failed", { chatId, error })
+    await sendTelegramMessage(config, chatId, "Sorry, I ran into an internal error. Please try again in a moment.")
+  }
+}
+
+async function runPolling(config: BridgeConfig) {
+  console.log("[TelegramBridge] mode=polling")
+  let offset = 0
+
+  while (true) {
+    try {
+      const result = (await telegramRequest(
+        config,
+        "getUpdates",
+        {
+          offset,
+          timeout: 30,
+          allowed_updates: ["message"],
+        },
+        35_000,
+      )) as TelegramUpdate[]
+
+      for (const update of result || []) {
+        offset = Math.max(offset, update.update_id + 1)
+        await handleTextUpdate(config, update)
+      }
+    } catch (error) {
+      console.error("[TelegramBridge] polling error", error)
+      await sleep(1500)
+    }
+  }
+}
+
+async function runWebhook(config: BridgeConfig) {
+  if (config.webhookUrl) {
+    await telegramRequest(config, "setWebhook", {
+      url: config.webhookUrl,
+      secret_token: config.webhookSecret,
+      allowed_updates: ["message"],
+    })
+    console.log(`[TelegramBridge] webhook registered: ${config.webhookUrl}`)
+  }
+
+  Bun.serve({
+    port: config.port,
+    hostname: "0.0.0.0",
+    async fetch(req) {
+      const url = new URL(req.url)
+      if (req.method !== "POST" || url.pathname !== config.webhookPath) {
+        return new Response("Not Found", { status: 404 })
+      }
+
+      if (config.webhookSecret) {
+        const secret = req.headers.get("x-telegram-bot-api-secret-token")
+        if (secret !== config.webhookSecret) {
+          return new Response("Unauthorized", { status: 401 })
+        }
+      }
+
+      const update = (await req.json().catch(() => null)) as TelegramUpdate | null
+      if (!update) {
+        return new Response("Bad Request", { status: 400 })
+      }
+
+      await handleTextUpdate(config, update)
+      return Response.json({ ok: true })
+    },
+  })
+
+  console.log(`[TelegramBridge] mode=webhook port=${config.port} path=${config.webhookPath}`)
+}
+
+export async function startTelegramBridge() {
+  const config = parseConfig()
+  console.log(`[TelegramBridge] OpenCode API: ${config.openCodeUrl}`)
+  if (config.directory) {
+    console.log(`[TelegramBridge] OpenCode directory: ${config.directory}`)
+  }
+  if (config.mode === "polling") {
+    await runPolling(config)
+    return
+  }
+
+  await runWebhook(config)
+}

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -37,8 +37,17 @@ function parseMode(value: string): "polling" | "webhook" {
 
 function parsePort(value: string): number {
   const n = Number.parseInt(value, 10)
-  if (Number.isNaN(n) || n <= 0) return 4097
+  if (Number.isNaN(n) || n <= 0 || n > 65535) return 4097
   return n
+}
+
+function parseOpenCodeUrl(value: string): string {
+  try {
+    const url = new URL(value)
+    return url.toString()
+  } catch {
+    throw new Error(`Invalid OPENCODE_API_URL: ${value}`)
+  }
 }
 
 function parseConfig(): BridgeConfig {
@@ -48,7 +57,7 @@ function parseConfig(): BridgeConfig {
   }
 
   const mode = parseMode(env("TELEGRAM_MODE") || "polling")
-  const openCodeUrl = env("OPENCODE_API_URL") || env("API_URL") || "http://127.0.0.1:4096"
+  const openCodeUrl = parseOpenCodeUrl(env("OPENCODE_API_URL") || env("API_URL") || "http://127.0.0.1:4096")
   const webhookPath = env("TELEGRAM_WEBHOOK_PATH") || "/webhook"
 
   return {
@@ -61,6 +70,13 @@ function parseConfig(): BridgeConfig {
     webhookSecret: env("TELEGRAM_WEBHOOK_SECRET") || undefined,
     webhookUrl: env("TELEGRAM_WEBHOOK_URL") || undefined,
   }
+}
+
+function isMissingSession(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  if (error.message.startsWith("OpenCode prompt failed (404):")) return true
+  if (error.message.startsWith("OpenCode prompt failed (410):")) return true
+  return false
 }
 
 async function retry<T>(name: string, fn: () => Promise<T>, retries = 2, delayMs = 400): Promise<T> {
@@ -206,12 +222,24 @@ async function handleTextUpdate(config: BridgeConfig, update: TelegramUpdate) {
   if (!chatId || !text) return
 
   try {
-    const sessionID = await sessionForChat(config, String(chatId))
-    const reply = await sendPrompt(config, sessionID, text)
+    const key = String(chatId)
+    const sessionID = await sessionForChat(config, key)
+    const reply = await sendPrompt(config, sessionID, text).catch(async (error) => {
+      if (!isMissingSession(error)) {
+        throw error
+      }
+      sessions.delete(key)
+      const next = await sessionForChat(config, key)
+      return sendPrompt(config, next, text)
+    })
     await sendTelegramMessage(config, chatId, reply)
   } catch (error) {
     console.error("[TelegramBridge] request handling failed", { chatId, error })
-    await sendTelegramMessage(config, chatId, "Sorry, I ran into an internal error. Please try again in a moment.")
+    try {
+      await sendTelegramMessage(config, chatId, "Sorry, I ran into an internal error. Please try again in a moment.")
+    } catch (sendError) {
+      console.error("[TelegramBridge] failed to send error response", { chatId, error: sendError })
+    }
   }
 }
 
@@ -274,7 +302,9 @@ async function runWebhook(config: BridgeConfig) {
         return new Response("Bad Request", { status: 400 })
       }
 
-      await handleTextUpdate(config, update)
+      void handleTextUpdate(config, update).catch((error) => {
+        console.error("[TelegramBridge] webhook handling failed", error)
+      })
       return Response.json({ ok: true })
     },
   })

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -29,6 +29,7 @@ type CachedSession = {
 
 const sessions = new Map<string, CachedSession>()
 const creatingSessions = new Map<string, Promise<string>>()
+const chatQueues = new Map<string, Promise<void>>()
 
 function env(name: string): string {
   return process.env[name]?.trim() || ""
@@ -39,10 +40,25 @@ function sleep(ms: number) {
 }
 
 export function parseMode(value: string): "polling" | "webhook" {
-  const mode = value.toLowerCase()
+  const mode = value.trim().toLowerCase()
   if (mode === "polling") return "polling"
   if (mode === "webhook") return "webhook"
   throw new Error(`Invalid TELEGRAM_MODE: ${value}. Expected \"polling\" or \"webhook\"`)
+}
+
+export function queueChatUpdate<T>(chatId: string, fn: () => Promise<T>): Promise<T> {
+  const start = chatQueues.get(chatId) || Promise.resolve()
+  const next = start.catch(() => undefined).then(fn)
+  const tail = next.then(
+    () => undefined,
+    () => undefined,
+  )
+  chatQueues.set(chatId, tail)
+  void tail.finally(() => {
+    if (chatQueues.get(chatId) !== tail) return
+    chatQueues.delete(chatId)
+  })
+  return next
 }
 
 function parsePort(value: string): number {
@@ -370,7 +386,11 @@ async function runWebhook(config: BridgeConfig) {
         return new Response("Bad Request", { status: 400 })
       }
 
-      void handleTextUpdate(config, update).catch((error) => {
+      const chatId = update.message?.chat?.id
+      const run = !chatId
+        ? handleTextUpdate(config, update)
+        : queueChatUpdate(String(chatId), () => handleTextUpdate(config, update))
+      void run.catch((error) => {
         console.error("[TelegramBridge] webhook handling failed", error)
       })
       return Response.json({ ok: true })
@@ -397,4 +417,5 @@ export async function startTelegramBridge() {
 export function resetSessionCacheForTest() {
   sessions.clear()
   creatingSessions.clear()
+  chatQueues.clear()
 }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -14,13 +14,21 @@ type BridgeConfig = {
   token: string
   openCodeUrl: string
   directory?: string
+  sessionCacheMax: number
+  sessionCacheTtlMs: number
   port: number
   webhookPath: string
   webhookSecret?: string
   webhookUrl?: string
 }
 
-const sessions = new Map<string, string>()
+type CachedSession = {
+  id: string
+  expiresAt: number
+}
+
+const sessions = new Map<string, CachedSession>()
+const creatingSessions = new Map<string, Promise<string>>()
 
 function env(name: string): string {
   return process.env[name]?.trim() || ""
@@ -41,12 +49,18 @@ function parsePort(value: string): number {
   return n
 }
 
-function parseOpenCodeUrl(value: string): string {
+function parsePositiveInt(value: string, fallback: number): number {
+  const n = Number.parseInt(value, 10)
+  if (Number.isNaN(n) || n <= 0) return fallback
+  return n
+}
+
+function parseOpenCodeUrl(value: string, source: string): string {
   try {
     const url = new URL(value)
     return url.toString()
   } catch {
-    throw new Error(`Invalid OPENCODE_API_URL: ${value}`)
+    throw new Error(`Invalid OpenCode API URL from ${source}: ${value}`)
   }
 }
 
@@ -57,14 +71,22 @@ function parseConfig(): BridgeConfig {
   }
 
   const mode = parseMode(env("TELEGRAM_MODE") || "polling")
-  const openCodeUrl = parseOpenCodeUrl(env("OPENCODE_API_URL") || env("API_URL") || "http://127.0.0.1:4096")
+  const opencodeApiUrl = env("OPENCODE_API_URL")
+  const apiUrl = env("API_URL")
+  const openCodeUrlValue = opencodeApiUrl || apiUrl || "http://127.0.0.1:4096"
+  const openCodeUrlSource = opencodeApiUrl ? "OPENCODE_API_URL" : apiUrl ? "API_URL" : "default"
+  const openCodeUrl = parseOpenCodeUrl(openCodeUrlValue, openCodeUrlSource)
   const webhookPath = env("TELEGRAM_WEBHOOK_PATH") || "/webhook"
+  const sessionCacheMax = parsePositiveInt(env("TELEGRAM_SESSION_CACHE_MAX") || "", 500)
+  const sessionCacheTtlMs = parsePositiveInt(env("TELEGRAM_SESSION_CACHE_TTL_MS") || "", 6 * 60 * 60 * 1000)
 
   return {
     mode,
     token,
     openCodeUrl,
     directory: env("OPENCODE_DIRECTORY") || undefined,
+    sessionCacheMax,
+    sessionCacheTtlMs,
     port: parsePort(env("TELEGRAM_BRIDGE_PORT") || "4097"),
     webhookPath: webhookPath.startsWith("/") ? webhookPath : `/${webhookPath}`,
     webhookSecret: env("TELEGRAM_WEBHOOK_SECRET") || undefined,
@@ -146,13 +168,54 @@ async function createSession(config: BridgeConfig): Promise<string> {
   return data.id
 }
 
-async function sessionForChat(config: BridgeConfig, chatId: string): Promise<string> {
+function cacheSession(config: BridgeConfig, chatId: string, sessionId: string) {
+  const expiresAt = Date.now() + config.sessionCacheTtlMs
+  sessions.delete(chatId)
+  sessions.set(chatId, { id: sessionId, expiresAt })
+  for (const key of sessions.keys()) {
+    if (sessions.size <= config.sessionCacheMax) return
+    sessions.delete(key)
+  }
+}
+
+function sessionFromCache(config: BridgeConfig, chatId: string): string | undefined {
+  const now = Date.now()
+  for (const [key, value] of sessions) {
+    if (value.expiresAt > now) continue
+    sessions.delete(key)
+  }
+
   const cached = sessions.get(chatId)
+  if (!cached) return
+  if (cached.expiresAt <= now) {
+    sessions.delete(chatId)
+    return
+  }
+
+  cacheSession(config, chatId, cached.id)
+  return cached.id
+}
+
+async function sessionForChat(config: BridgeConfig, chatId: string): Promise<string> {
+  const cached = sessionFromCache(config, chatId)
   if (cached) return cached
 
-  const id = await createSession(config)
-  sessions.set(chatId, id)
-  return id
+  const creating = creatingSessions.get(chatId)
+  if (creating) return creating
+
+  const created = createSession(config)
+    .then((id) => {
+      cacheSession(config, chatId, id)
+      creatingSessions.delete(chatId)
+      return id
+    })
+    .catch((error) => {
+      creatingSessions.delete(chatId)
+      throw error
+    })
+
+  creatingSessions.set(chatId, created)
+  return created
 }
 
 function extractReply(payload: unknown): string {
@@ -171,8 +234,8 @@ function extractReply(payload: unknown): string {
   return "I finished processing your request, but there was no text response."
 }
 
-async function sendPrompt(config: BridgeConfig, sessionID: string, text: string): Promise<string> {
-  const url = opencodeUrl(config, `/session/${sessionID}/message`)
+async function sendPrompt(config: BridgeConfig, sessionId: string, text: string): Promise<string> {
+  const url = opencodeUrl(config, `/session/${sessionId}/message`)
   if (config.directory) {
     url.searchParams.set("directory", config.directory)
   }
@@ -223,8 +286,8 @@ async function handleTextUpdate(config: BridgeConfig, update: TelegramUpdate) {
 
   try {
     const key = String(chatId)
-    const sessionID = await sessionForChat(config, key)
-    const reply = await sendPrompt(config, sessionID, text).catch(async (error) => {
+    const sessionId = await sessionForChat(config, key)
+    const reply = await sendPrompt(config, sessionId, text).catch(async (error) => {
       if (!isMissingSession(error)) {
         throw error
       }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -279,8 +279,8 @@ async function sendPrompt(config: BridgeConfig, sessionId: string, text: string)
 function chunks(input: string, size: number): string[] {
   if (input.length <= size) return [input]
   const output: string[] = []
-  for (const i of Array.from({ length: Math.ceil(input.length / size) }, (_, idx) => idx)) {
-    output.push(input.slice(i * size, (i + 1) * size))
+  for (let i = 0; i < input.length; i += size) {
+    output.push(input.slice(i, i + size))
   }
   return output
 }
@@ -344,9 +344,17 @@ async function runPolling(config: BridgeConfig) {
         35_000,
       )) as TelegramUpdate[]
 
+      const runs: Promise<void>[] = []
       for (const update of result || []) {
         offset = Math.max(offset, update.update_id + 1)
-        await handleTextUpdate(config, update)
+        const chatId = update.message?.chat?.id
+        const run = !chatId
+          ? handleTextUpdate(config, update)
+          : queueChatUpdate(String(chatId), () => handleTextUpdate(config, update))
+        runs.push(run)
+      }
+      if (runs.length) {
+        await Promise.allSettled(runs)
       }
     } catch (error) {
       console.error("[TelegramBridge] polling error", error)

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -38,9 +38,11 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-function parseMode(value: string): "polling" | "webhook" {
-  if (value.toLowerCase() === "webhook") return "webhook"
-  return "polling"
+export function parseMode(value: string): "polling" | "webhook" {
+  const mode = value.toLowerCase()
+  if (mode === "polling") return "polling"
+  if (mode === "webhook") return "webhook"
+  throw new Error(`Invalid TELEGRAM_MODE: ${value}. Expected \"polling\" or \"webhook\"`)
 }
 
 function parsePort(value: string): number {
@@ -64,7 +66,7 @@ function parseOpenCodeUrl(value: string, source: string): string {
   }
 }
 
-function parseConfig(): BridgeConfig {
+export function parseConfig(): BridgeConfig {
   const token = env("TELEGRAM_BOT_TOKEN")
   if (!token) {
     throw new Error("TELEGRAM_BOT_TOKEN is required")
@@ -168,7 +170,7 @@ async function createSession(config: BridgeConfig): Promise<string> {
   return data.id
 }
 
-function cacheSession(config: BridgeConfig, chatId: string, sessionId: string) {
+export function cacheSession(config: BridgeConfig, chatId: string, sessionId: string) {
   const expiresAt = Date.now() + config.sessionCacheTtlMs
   sessions.delete(chatId)
   sessions.set(chatId, { id: sessionId, expiresAt })
@@ -178,7 +180,7 @@ function cacheSession(config: BridgeConfig, chatId: string, sessionId: string) {
   }
 }
 
-function sessionFromCache(config: BridgeConfig, chatId: string): string | undefined {
+export function sessionFromCache(config: BridgeConfig, chatId: string): string | undefined {
   const now = Date.now()
   for (const [key, value] of sessions) {
     if (value.expiresAt > now) continue
@@ -218,7 +220,7 @@ async function sessionForChat(config: BridgeConfig, chatId: string): Promise<str
   return created
 }
 
-function extractReply(payload: unknown): string {
+export function extractReply(payload: unknown): string {
   const data = payload as {
     parts?: Array<{ type?: string; text?: string }>
   }
@@ -308,6 +310,9 @@ async function handleTextUpdate(config: BridgeConfig, update: TelegramUpdate) {
 
 async function runPolling(config: BridgeConfig) {
   console.log("[TelegramBridge] mode=polling")
+  await telegramRequest(config, "deleteWebhook", {
+    drop_pending_updates: false,
+  })
   let offset = 0
 
   while (true) {
@@ -387,4 +392,9 @@ export async function startTelegramBridge() {
   }
 
   await runWebhook(config)
+}
+
+export function resetSessionCacheForTest() {
+  sessions.clear()
+  creatingSessions.clear()
 }


### PR DESCRIPTION
## Summary
- add a Telegram bridge runtime that supports polling or webhook mode
- forward Telegram text prompts to OpenCode session APIs and reply back in chat
- wire bridge into Docker/Kubeflow images with opt-in s6 service config and docs

Closes #249