### PR TITLE
feat: add Telegram session mapping and chat commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ bun install && bun run dev
 | `TELEGRAM_MODE` | `polling` | Telegram bridge mode (`polling` or `webhook`) |
 | `OPENCODE_API_URL` | `API_URL` or `http://127.0.0.1:4096` | OpenCode API URL for bridge |
 | `OPENCODE_DIRECTORY` | _(empty)_ | Optional directory for bridge session API calls |
-| `TELEGRAM_SESSION_STORE_PATH` | `/tmp/opencode-telegram-sessions.json` | Persistent Telegram chat/user to OpenCode session mapping |
+| `TELEGRAM_SESSION_STORE_PATH` | `/tmp/opencode-telegram-sessions.json` | Telegram chat/user to OpenCode session mapping file; set this to a mounted persistent volume path in Kubernetes for restart-safe persistence |
 
 ## Deployment
 
@@ -215,6 +215,8 @@ This repository includes a Telegram bridge service (`docker/telegram-bridge.ts`)
 - sends assistant responses back to Telegram.
 
 The bridge keeps a default OpenCode session per Telegram chat (and sender in shared chats), persisted to `TELEGRAM_SESSION_STORE_PATH` so mappings survive restarts.
+
+In container/Kubernetes deployments, `/tmp` is often ephemeral, so set `TELEGRAM_SESSION_STORE_PATH` to a mounted persistent volume location if you need mappings to survive pod/container recreation.
 
 Supported bot commands:
 - `/new` creates and switches to a fresh session for the current chat mapping.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ bun install && bun run dev
 | `TELEGRAM_MODE` | `polling` | Telegram bridge mode (`polling` or `webhook`) |
 | `OPENCODE_API_URL` | `API_URL` or `http://127.0.0.1:4096` | OpenCode API URL for bridge |
 | `OPENCODE_DIRECTORY` | _(empty)_ | Optional directory for bridge session API calls |
-| `TELEGRAM_SESSION_STORE_PATH` | `/tmp/opencode-telegram-sessions.json` | Telegram chat/user to OpenCode session mapping file; set this to a mounted persistent volume path in Kubernetes for restart-safe persistence |
+| `TELEGRAM_SESSION_STORE_PATH` | OS temp dir + `/opencode-telegram-sessions.json` | Telegram chat/user to OpenCode session mapping file; set this to a mounted persistent volume path in Kubernetes for restart-safe persistence |
 
 ## Deployment
 
@@ -216,7 +216,7 @@ This repository includes a Telegram bridge service (`docker/telegram-bridge.ts`)
 
 The bridge keeps a default OpenCode session per Telegram chat (and sender in shared chats), persisted to `TELEGRAM_SESSION_STORE_PATH` so mappings survive restarts.
 
-In container/Kubernetes deployments, `/tmp` is often ephemeral, so set `TELEGRAM_SESSION_STORE_PATH` to a mounted persistent volume location if you need mappings to survive pod/container recreation.
+In container/Kubernetes deployments, the default OS temp directory is often ephemeral, so set `TELEGRAM_SESSION_STORE_PATH` to a mounted persistent volume location if you need mappings to survive pod/container recreation.
 
 Supported bot commands:
 - `/new` creates and switches to a fresh session for the current chat mapping.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ bun install && bun run dev
 | `TELEGRAM_MODE` | `polling` | Telegram bridge mode (`polling` or `webhook`) |
 | `OPENCODE_API_URL` | `API_URL` or `http://127.0.0.1:4096` | OpenCode API URL for bridge |
 | `OPENCODE_DIRECTORY` | _(empty)_ | Optional directory for bridge session API calls |
+| `TELEGRAM_SESSION_STORE_PATH` | `/tmp/opencode-telegram-sessions.json` | Persistent Telegram chat/user to OpenCode session mapping |
 
 ## Deployment
 
@@ -212,6 +213,16 @@ This repository includes a Telegram bridge service (`docker/telegram-bridge.ts`)
 - receives Telegram bot text messages,
 - forwards prompts to OpenCode session APIs,
 - sends assistant responses back to Telegram.
+
+The bridge keeps a default OpenCode session per Telegram chat (and sender in shared chats), persisted to `TELEGRAM_SESSION_STORE_PATH` so mappings survive restarts.
+
+Supported bot commands:
+- `/new` creates and switches to a fresh session for the current chat mapping.
+- `/status` shows the current mapped session id.
+- `/help` shows command help.
+- Unknown commands return a short help hint.
+
+Messages from the same chat are handled through a per-chat queue to avoid cross-reply mixups when users send requests quickly.
 
 The bridge is opt-in and only starts in the Kubeflow image when `TELEGRAM_BRIDGE_ENABLED=true`.
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ The bridge keeps a default OpenCode session per Telegram chat (and sender in sha
 
 In container/Kubernetes deployments, the default OS temp directory is often ephemeral, so set `TELEGRAM_SESSION_STORE_PATH` to a mounted persistent volume location if you need mappings to survive pod/container recreation.
 
+The file-backed session store is single-writer/single-replica only (no cross-process locking). For horizontally scaled or multi-replica deployments, use an external coordinated session store instead of sharing one file.
+
 Supported bot commands:
 - `/new` creates and switches to a fresh session for the current chat mapping.
 - `/status` shows the current mapped session id.

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -22,6 +22,7 @@ const envKeys = [
   "TELEGRAM_WEBHOOK_PATH",
   "TELEGRAM_WEBHOOK_SECRET",
   "TELEGRAM_WEBHOOK_URL",
+  "TELEGRAM_SESSION_STORE_PATH",
 ] as const;
 
 const envSnapshot = new Map<string, string | undefined>();
@@ -100,6 +101,10 @@ describe("telegram bridge config and cache", () => {
   test("parseConfig uses polling default and rejects invalid TELEGRAM_MODE", () => {
     setEnv({ TELEGRAM_BOT_TOKEN: "token", OPENCODE_API_URL: "http://127.0.0.1:4096" });
     expect(parseConfig().mode).toBe("polling");
+    expect(parseConfig().sessionStorePath).toBe("/tmp/opencode-telegram-sessions.json");
+
+    setEnv({ TELEGRAM_BOT_TOKEN: "token", TELEGRAM_SESSION_STORE_PATH: "/tmp/custom-store.json" });
+    expect(parseConfig().sessionStorePath).toBe("/tmp/custom-store.json");
 
     setEnv({ TELEGRAM_BOT_TOKEN: "token", TELEGRAM_MODE: "bad-mode", OPENCODE_API_URL: "http://127.0.0.1:4096" });
     expect(() => parseConfig()).toThrow("Invalid TELEGRAM_MODE");
@@ -129,6 +134,7 @@ describe("telegram bridge config and cache", () => {
       sessionCacheTtlMs: 10_000,
       port: 4097,
       webhookPath: "/webhook",
+      sessionStorePath: "/tmp/test-store.json",
     };
 
     cacheSession(config, "chat-a", "session-a");

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   cacheSession,
   extractReply,
+  handleTextUpdate,
   joinOpenCodeUrl,
   parseConfig,
   parseMode,
@@ -144,5 +145,122 @@ describe("telegram bridge config and cache", () => {
     expect(sessionFromCache(config, "chat-a")).toBeUndefined();
     expect(sessionFromCache(config, "chat-b")).toBe("session-b");
     expect(sessionFromCache(config, "chat-c")).toBe("session-c");
+  });
+
+  test("handleTextUpdate parses whitespace and bot-qualified help command", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+      calls.push({ url, body });
+      if (url.includes("/sendMessage")) {
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    };
+
+    const map = new Map<string, string>();
+    const runtime = {
+      config: {
+        mode: "polling" as const,
+        token: "token",
+        openCodeUrl: "http://127.0.0.1:4096",
+        sessionCacheMax: 10,
+        sessionCacheTtlMs: 10_000,
+        port: 4097,
+        webhookPath: "/webhook",
+        sessionStorePath: "/tmp/test-store.json",
+      },
+      store: {
+        get: async (key: string) => map.get(key),
+        set: async (key: string, value: string) => {
+          map.set(key, value);
+        },
+        delete: async (key: string) => {
+          map.delete(key);
+        },
+      },
+    };
+
+    await handleTextUpdate(runtime, {
+      update_id: 1,
+      message: {
+        message_id: 1,
+        text: "/help@prokubebot\nmore",
+        chat: { id: 42 },
+      },
+    });
+
+    globalThis.fetch = originalFetch;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toContain("/sendMessage");
+    expect(String(calls[0]?.body.text || "")).toContain("Available commands:");
+  });
+
+  test("handleTextUpdate routes status, new@botname, and unknown commands", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const createdSessions = ["session-1", "session-2"];
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+      calls.push({ url, body });
+      if (url === "http://127.0.0.1:4096/session") {
+        const id = createdSessions.shift();
+        return new Response(JSON.stringify({ id }), { status: 200 });
+      }
+      if (url.includes("/sendMessage")) {
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    };
+
+    const map = new Map<string, string>();
+    const runtime = {
+      config: {
+        mode: "polling" as const,
+        token: "token",
+        openCodeUrl: "http://127.0.0.1:4096",
+        sessionCacheMax: 10,
+        sessionCacheTtlMs: 10_000,
+        port: 4097,
+        webhookPath: "/webhook",
+        sessionStorePath: "/tmp/test-store.json",
+      },
+      store: {
+        get: async (key: string) => map.get(key),
+        set: async (key: string, value: string) => {
+          map.set(key, value);
+        },
+        delete: async (key: string) => {
+          map.delete(key);
+        },
+      },
+    };
+
+    await handleTextUpdate(runtime, {
+      update_id: 1,
+      message: { message_id: 1, text: "/status", chat: { id: 7 }, from: { id: 9 } },
+    });
+    await handleTextUpdate(runtime, {
+      update_id: 2,
+      message: { message_id: 2, text: "/new@mybot", chat: { id: 7 }, from: { id: 9 } },
+    });
+    await handleTextUpdate(runtime, {
+      update_id: 3,
+      message: { message_id: 3, text: "/wat", chat: { id: 7 }, from: { id: 9 } },
+    });
+
+    globalThis.fetch = originalFetch;
+
+    const sentTexts = calls
+      .filter((x) => x.url.includes("/sendMessage"))
+      .map((x) => String(x.body.text || ""));
+    expect(sentTexts[0]).toBe("Current session: session-1");
+    expect(sentTexts[1]).toBe("Started a new session: session-2");
+    expect(sentTexts[2]).toBe("Unknown command /wat. Use /help.");
+    expect(map.get("chat:7:user:9")).toBe("session-2");
   });
 });

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -150,49 +150,51 @@ describe("telegram bridge config and cache", () => {
   test("handleTextUpdate parses whitespace and bot-qualified help command", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
-      calls.push({ url, body });
-      if (url.includes("/sendMessage")) {
-        return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
-      }
-      throw new Error(`Unexpected fetch ${url}`);
-    };
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
 
-    const map = new Map<string, string>();
-    const runtime = {
-      config: {
-        mode: "polling" as const,
-        token: "token",
-        openCodeUrl: "http://127.0.0.1:4096",
-        sessionCacheMax: 10,
-        sessionCacheTtlMs: 10_000,
-        port: 4097,
-        webhookPath: "/webhook",
-        sessionStorePath: "/tmp/test-store.json",
-      },
-      store: {
-        get: async (key: string) => map.get(key),
-        set: async (key: string, value: string) => {
-          map.set(key, value);
+      const map = new Map<string, string>();
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
         },
-        delete: async (key: string) => {
-          map.delete(key);
+        store: {
+          get: async (key: string) => map.get(key),
+          set: async (key: string, value: string) => {
+            map.set(key, value);
+          },
+          delete: async (key: string) => {
+            map.delete(key);
+          },
         },
-      },
-    };
+      };
 
-    await handleTextUpdate(runtime, {
-      update_id: 1,
-      message: {
-        message_id: 1,
-        text: "/help@prokubebot\nmore",
-        chat: { id: 42 },
-      },
-    });
-
-    globalThis.fetch = originalFetch;
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          text: "/help@prokubebot\nmore",
+          chat: { id: 42 },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.url).toContain("/sendMessage");
@@ -203,64 +205,202 @@ describe("telegram bridge config and cache", () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
     const createdSessions = ["session-1", "session-2"];
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
-      calls.push({ url, body });
-      if (url === "http://127.0.0.1:4096/session") {
-        const id = createdSessions.shift();
-        return new Response(JSON.stringify({ id }), { status: 200 });
-      }
-      if (url.includes("/sendMessage")) {
-        return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
-      }
-      throw new Error(`Unexpected fetch ${url}`);
-    };
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url === "http://127.0.0.1:4096/session") {
+          const id = createdSessions.shift();
+          return new Response(JSON.stringify({ id }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
 
+      const map = new Map<string, string>();
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async (key: string) => map.get(key),
+          set: async (key: string, value: string) => {
+            map.set(key, value);
+          },
+          delete: async (key: string) => {
+            map.delete(key);
+          },
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/status", chat: { id: 7 }, from: { id: 9 } },
+      });
+      await handleTextUpdate(runtime, {
+        update_id: 2,
+        message: { message_id: 2, text: "/new@mybot", chat: { id: 7 }, from: { id: 9 } },
+      });
+      await handleTextUpdate(runtime, {
+        update_id: 3,
+        message: { message_id: 3, text: "/wat", chat: { id: 7 }, from: { id: 9 } },
+      });
+
+      const sentTexts = calls
+        .filter((x) => x.url.includes("/sendMessage"))
+        .map((x) => String(x.body.text || ""));
+      expect(sentTexts[0]).toBe("Current session: session-1");
+      expect(sentTexts[1]).toBe("Started a new session: session-2");
+      expect(sentTexts[2]).toBe("Unknown command /wat. Use /help.");
+      expect(map.get("chat:7:user:9")).toBe("session-2");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("sessionForChat does not cache new session when store set fails", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const createdSessions = ["session-1", "session-2"];
     const map = new Map<string, string>();
-    const runtime = {
-      config: {
-        mode: "polling" as const,
-        token: "token",
-        openCodeUrl: "http://127.0.0.1:4096",
-        sessionCacheMax: 10,
-        sessionCacheTtlMs: 10_000,
-        port: 4097,
-        webhookPath: "/webhook",
-        sessionStorePath: "/tmp/test-store.json",
-      },
-      store: {
-        get: async (key: string) => map.get(key),
-        set: async (key: string, value: string) => {
-          map.set(key, value);
+    let failSet = true;
+
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url === "http://127.0.0.1:4096/session") {
+          const id = createdSessions.shift();
+          return new Response(JSON.stringify({ id }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
         },
-        delete: async (key: string) => {
-          map.delete(key);
+        store: {
+          get: async (key: string) => map.get(key),
+          set: async (key: string, value: string) => {
+            if (failSet) {
+              throw new Error("persist failed");
+            }
+            map.set(key, value);
+          },
+          delete: async (key: string) => {
+            map.delete(key);
+          },
         },
-      },
-    };
+      };
 
-    await handleTextUpdate(runtime, {
-      update_id: 1,
-      message: { message_id: 1, text: "/status", chat: { id: 7 }, from: { id: 9 } },
-    });
-    await handleTextUpdate(runtime, {
-      update_id: 2,
-      message: { message_id: 2, text: "/new@mybot", chat: { id: 7 }, from: { id: 9 } },
-    });
-    await handleTextUpdate(runtime, {
-      update_id: 3,
-      message: { message_id: 3, text: "/wat", chat: { id: 7 }, from: { id: 9 } },
-    });
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/status", chat: { id: 7 }, from: { id: 9 } },
+      });
+      failSet = false;
+      await handleTextUpdate(runtime, {
+        update_id: 2,
+        message: { message_id: 2, text: "/status", chat: { id: 7 }, from: { id: 9 } },
+      });
 
-    globalThis.fetch = originalFetch;
+      const sentTexts = calls
+        .filter((x) => x.url.includes("/sendMessage"))
+        .map((x) => String(x.body.text || ""));
+      expect(sentTexts[0]).toContain("Sorry, I ran into an internal error");
+      expect(sentTexts[1]).toBe("Current session: session-2");
+      expect(map.get("chat:7:user:9")).toBe("session-2");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-    const sentTexts = calls
-      .filter((x) => x.url.includes("/sendMessage"))
-      .map((x) => String(x.body.text || ""));
-    expect(sentTexts[0]).toBe("Current session: session-1");
-    expect(sentTexts[1]).toBe("Started a new session: session-2");
-    expect(sentTexts[2]).toBe("Unknown command /wat. Use /help.");
-    expect(map.get("chat:7:user:9")).toBe("session-2");
+  test("/new does not cache session when store set fails", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const createdSessions = ["session-1", "session-2"];
+    const map = new Map<string, string>();
+    let failSet = true;
+
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url === "http://127.0.0.1:4096/session") {
+          const id = createdSessions.shift();
+          return new Response(JSON.stringify({ id }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async (key: string) => map.get(key),
+          set: async (key: string, value: string) => {
+            if (failSet) {
+              throw new Error("persist failed");
+            }
+            map.set(key, value);
+          },
+          delete: async (key: string) => {
+            map.delete(key);
+          },
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/new", chat: { id: 7 }, from: { id: 9 } },
+      });
+      failSet = false;
+      await handleTextUpdate(runtime, {
+        update_id: 2,
+        message: { message_id: 2, text: "/status", chat: { id: 7 }, from: { id: 9 } },
+      });
+
+      const sentTexts = calls
+        .filter((x) => x.url.includes("/sendMessage"))
+        .map((x) => String(x.body.text || ""));
+      expect(sentTexts[0]).toContain("Sorry, I ran into an internal error");
+      expect(sentTexts[1]).toBe("Current session: session-2");
+      expect(map.get("chat:7:user:9")).toBe("session-2");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   cacheSession,
   extractReply,
@@ -102,10 +104,10 @@ describe("telegram bridge config and cache", () => {
   test("parseConfig uses polling default and rejects invalid TELEGRAM_MODE", () => {
     setEnv({ TELEGRAM_BOT_TOKEN: "token", OPENCODE_API_URL: "http://127.0.0.1:4096" });
     expect(parseConfig().mode).toBe("polling");
-    expect(parseConfig().sessionStorePath).toBe("/tmp/opencode-telegram-sessions.json");
+    expect(parseConfig().sessionStorePath).toBe(join(tmpdir(), "opencode-telegram-sessions.json"));
 
-    setEnv({ TELEGRAM_BOT_TOKEN: "token", TELEGRAM_SESSION_STORE_PATH: "/tmp/custom-store.json" });
-    expect(parseConfig().sessionStorePath).toBe("/tmp/custom-store.json");
+    setEnv({ TELEGRAM_BOT_TOKEN: "token", TELEGRAM_SESSION_STORE_PATH: join(tmpdir(), "custom-store.json") });
+    expect(parseConfig().sessionStorePath).toBe(join(tmpdir(), "custom-store.json"));
 
     setEnv({ TELEGRAM_BOT_TOKEN: "token", TELEGRAM_MODE: "bad-mode", OPENCODE_API_URL: "http://127.0.0.1:4096" });
     expect(() => parseConfig()).toThrow("Invalid TELEGRAM_MODE");

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { chmod, mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { createTelegramSessionStore, telegramSessionKey } from "../../shared/telegram-session-store"
@@ -20,8 +20,10 @@ afterEach(async () => {
 
 describe("telegram session store", () => {
   test("persists mappings across store instances", async () => {
-    const path = `/tmp/telegram-session-store-${Date.now()}-${Math.random().toString(36).slice(2)}.json`
+    const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
+    const path = join(dir, "sessions.json")
     files.push(path)
+    files.push(dir)
     const key = telegramSessionKey(1001, 99)
 
     const first = createTelegramSessionStore(path)
@@ -42,7 +44,11 @@ describe("telegram session store", () => {
   })
 
   test("set rolls back in-memory value when flush fails", async () => {
-    const path = "/dev/null/telegram-session-store.json"
+    const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
+    const blocked = join(dir, "blocked-parent")
+    const path = join(blocked, "telegram-session-store.json")
+    files.push(dir)
+    await Bun.write(blocked, "blocked")
     const store = createTelegramSessionStore(path)
     const key = telegramSessionKey(222, 7)
 
@@ -52,19 +58,19 @@ describe("telegram session store", () => {
 
   test("delete restores in-memory value when flush fails", async () => {
     const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
-    const path = join(dir, "sessions.json")
+    const parent = join(dir, "sessions")
+    const path = join(parent, "store.json")
     files.push(path)
     files.push(dir)
 
     const key = telegramSessionKey(333, 8)
     const store = createTelegramSessionStore(path)
     await store.set(key, "session-a")
-    await chmod(dir, 0o500)
+    await rm(parent, { force: true, recursive: true })
+    await Bun.write(parent, "blocked")
 
     await expect(store.delete(key)).rejects.toThrow()
     expect(await store.get(key)).toBe("session-a")
-
-    await chmod(dir, 0o700)
   })
 
   test("recovers from backup when primary file is missing", async () => {

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { rm } from "node:fs/promises"
+import { createTelegramSessionStore, telegramSessionKey } from "../../shared/telegram-session-store"
+
+const files: string[] = []
+
+async function cleanup(path: string) {
+  await rm(path, { force: true }).catch(() => undefined)
+  await rm(`${path}.tmp`, { force: true }).catch(() => undefined)
+}
+
+afterEach(async () => {
+  for (const file of files) {
+    await cleanup(file)
+  }
+  files.length = 0
+})
+
+describe("telegram session store", () => {
+  test("persists mappings across store instances", async () => {
+    const path = `/tmp/telegram-session-store-${Date.now()}-${Math.random().toString(36).slice(2)}.json`
+    files.push(path)
+    const key = telegramSessionKey(1001, 99)
+
+    const first = createTelegramSessionStore(path)
+    await first.set(key, "session-a")
+    expect(await first.get(key)).toBe("session-a")
+
+    const second = createTelegramSessionStore(path)
+    expect(await second.get(key)).toBe("session-a")
+    await second.delete(key)
+
+    const third = createTelegramSessionStore(path)
+    expect(await third.get(key)).toBeUndefined()
+  })
+
+  test("telegramSessionKey uses chat-only key without user id", () => {
+    expect(telegramSessionKey(123)).toBe("chat:123")
+    expect(telegramSessionKey(123, 456)).toBe("chat:123:user:456")
+  })
+})

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -40,6 +40,7 @@ describe("telegram session store", () => {
 
   test("telegramSessionKey uses chat-only key without user id", () => {
     expect(telegramSessionKey(123)).toBe("chat:123")
+    expect(telegramSessionKey(123, 0)).toBe("chat:123:user:0")
     expect(telegramSessionKey(123, 456)).toBe("chat:123:user:456")
   })
 

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -66,4 +66,39 @@ describe("telegram session store", () => {
 
     await chmod(dir, 0o700)
   })
+
+  test("recovers from backup when primary file is missing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
+    const path = join(dir, "sessions.json")
+    const backup = `${path}.bak.${Date.now()}.recover`
+    files.push(dir)
+
+    await Bun.write(
+      backup,
+      `${JSON.stringify({ version: 1, sessions: { [telegramSessionKey(777, 42)]: "session-recovered" } }, null, 2)}\n`,
+    )
+
+    const store = createTelegramSessionStore(path)
+    expect(await store.get(telegramSessionKey(777, 42))).toBe("session-recovered")
+    expect(await Bun.file(path).exists()).toBe(true)
+    expect(await Bun.file(backup).exists()).toBe(false)
+  })
+
+  test("skips invalid backup and recovers from next valid backup", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
+    const path = join(dir, "sessions.json")
+    const badBackup = `${path}.bak.${Date.now() + 1}.bad`
+    const goodBackup = `${path}.bak.${Date.now()}.good`
+    files.push(dir)
+
+    await Bun.write(badBackup, "{invalid json")
+    await Bun.write(
+      goodBackup,
+      `${JSON.stringify({ version: 1, sessions: { [telegramSessionKey(778, 43)]: "session-good" } }, null, 2)}\n`,
+    )
+
+    const store = createTelegramSessionStore(path)
+    expect(await store.get(telegramSessionKey(778, 43))).toBe("session-good")
+    expect(await Bun.file(path).exists()).toBe(true)
+  })
 })

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, readdir, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { createTelegramSessionStore, telegramSessionKey } from "../../shared/telegram-session-store"
@@ -125,5 +125,9 @@ describe("telegram session store", () => {
     expect(await store.get(key)).toBe("session-recovered")
     expect(await Bun.file(path).exists()).toBe(true)
     expect(await Bun.file(backup).exists()).toBe(false)
+    const stored = JSON.parse(await Bun.file(path).text()) as { sessions?: Record<string, string> }
+    expect(stored.sessions?.[key]).toBe("session-recovered")
+    const leftovers = (await readdir(dir)).filter((entry) => entry.includes("sessions.json.corrupt."))
+    expect(leftovers).toEqual([])
   })
 })

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { rm } from "node:fs/promises"
+import { chmod, mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { createTelegramSessionStore, telegramSessionKey } from "../../shared/telegram-session-store"
 
 const files: string[] = []
 
 async function cleanup(path: string) {
-  await rm(path, { force: true }).catch(() => undefined)
-  await rm(`${path}.tmp`, { force: true }).catch(() => undefined)
+  await rm(path, { force: true, recursive: true }).catch(() => undefined)
+  await rm(`${path}.tmp`, { force: true, recursive: true }).catch(() => undefined)
 }
 
 afterEach(async () => {
@@ -37,5 +39,31 @@ describe("telegram session store", () => {
   test("telegramSessionKey uses chat-only key without user id", () => {
     expect(telegramSessionKey(123)).toBe("chat:123")
     expect(telegramSessionKey(123, 456)).toBe("chat:123:user:456")
+  })
+
+  test("set rolls back in-memory value when flush fails", async () => {
+    const path = "/dev/null/telegram-session-store.json"
+    const store = createTelegramSessionStore(path)
+    const key = telegramSessionKey(222, 7)
+
+    await expect(store.set(key, "session-a")).rejects.toThrow()
+    expect(await store.get(key)).toBeUndefined()
+  })
+
+  test("delete restores in-memory value when flush fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
+    const path = join(dir, "sessions.json")
+    files.push(path)
+    files.push(dir)
+
+    const key = telegramSessionKey(333, 8)
+    const store = createTelegramSessionStore(path)
+    await store.set(key, "session-a")
+    await chmod(dir, 0o500)
+
+    await expect(store.delete(key)).rejects.toThrow()
+    expect(await store.get(key)).toBe("session-a")
+
+    await chmod(dir, 0o700)
   })
 })

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -107,4 +107,23 @@ describe("telegram session store", () => {
     expect(await store.get(telegramSessionKey(778, 43))).toBe("session-good")
     expect(await Bun.file(path).exists()).toBe(true)
   })
+
+  test("recovers from backup when primary file is corrupt JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
+    const path = join(dir, "sessions.json")
+    const backup = `${path}.bak.${Date.now()}.recover`
+    const key = telegramSessionKey(779, 44)
+    files.push(dir)
+
+    await Bun.write(path, "{invalid json")
+    await Bun.write(
+      backup,
+      `${JSON.stringify({ version: 1, sessions: { [key]: "session-recovered" } }, null, 2)}\n`,
+    )
+
+    const store = createTelegramSessionStore(path)
+    expect(await store.get(key)).toBe("session-recovered")
+    expect(await Bun.file(path).exists()).toBe(true)
+    expect(await Bun.file(backup).exists()).toBe(false)
+  })
 })

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1,4 +1,6 @@
 import { createTelegramSessionStore, telegramSessionKey } from "./telegram-session-store"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 type TelegramUpdate = {
   update_id: number
@@ -110,6 +112,10 @@ function parseOpenCodeUrl(value: string, source: string): string {
   }
 }
 
+function defaultSessionStorePath() {
+  return join(tmpdir(), "opencode-telegram-sessions.json")
+}
+
 export function parseConfig(): BridgeConfig {
   const token = env("TELEGRAM_BOT_TOKEN")
   if (!token) {
@@ -125,7 +131,7 @@ export function parseConfig(): BridgeConfig {
   const webhookPath = env("TELEGRAM_WEBHOOK_PATH") || "/webhook"
   const sessionCacheMax = parsePositiveInt(env("TELEGRAM_SESSION_CACHE_MAX") || "", 500)
   const sessionCacheTtlMs = parsePositiveInt(env("TELEGRAM_SESSION_CACHE_TTL_MS") || "", 6 * 60 * 60 * 1000)
-  const sessionStorePath = env("TELEGRAM_SESSION_STORE_PATH") || "/tmp/opencode-telegram-sessions.json"
+  const sessionStorePath = env("TELEGRAM_SESSION_STORE_PATH") || defaultSessionStorePath()
 
   return {
     mode,

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -267,8 +267,8 @@ async function sessionForChat(runtime: Runtime, chatKey: string): Promise<string
 
   const created = createSession(config)
     .then((id) => {
-      cacheSession(config, chatKey, id)
       return runtime.store.set(chatKey, id).then(() => {
+        cacheSession(config, chatKey, id)
         creatingSessions.delete(chatKey)
         return id
       })
@@ -366,8 +366,8 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
     }
     if (command.name === "/new") {
       const next = await createSession(config)
-      cacheSession(config, key, next)
       await runtime.store.set(key, next)
+      cacheSession(config, key, next)
       await sendTelegramMessage(config, chatId, `Started a new session: ${next}`)
       return true
     }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -86,8 +86,8 @@ function parsePositiveInt(value: string, fallback: number): number {
 
 function parseCommand(text: string): { name: string } | undefined {
   if (!text.startsWith("/")) return
-  const [raw] = text.split(" ")
-  const name = raw.split("@")[0]?.toLowerCase()
+  const raw = text.split(/\s+/, 1)[0]?.trim()
+  const name = raw?.split("@")[0]?.trim().toLowerCase()
   if (!name) return
   return { name }
 }
@@ -341,7 +341,7 @@ async function sendTelegramMessage(config: BridgeConfig, chatId: number, text: s
   }
 }
 
-async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate) {
+export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate) {
   const config = runtime.config
   const message = update.message
   const chatId = message?.chat?.id

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1,9 +1,14 @@
+import { createTelegramSessionStore, telegramSessionKey } from "./telegram-session-store"
+
 type TelegramUpdate = {
   update_id: number
   message?: {
     message_id: number
     text?: string
     chat?: {
+      id: number
+    }
+    from?: {
       id: number
     }
   }
@@ -20,6 +25,12 @@ type BridgeConfig = {
   webhookPath: string
   webhookSecret?: string
   webhookUrl?: string
+  sessionStorePath: string
+}
+
+type Runtime = {
+  config: BridgeConfig
+  store: ReturnType<typeof createTelegramSessionStore>
 }
 
 type CachedSession = {
@@ -73,6 +84,23 @@ function parsePositiveInt(value: string, fallback: number): number {
   return n
 }
 
+function parseCommand(text: string): { name: string } | undefined {
+  if (!text.startsWith("/")) return
+  const [raw] = text.split(" ")
+  const name = raw.split("@")[0]?.toLowerCase()
+  if (!name) return
+  return { name }
+}
+
+function helpText(): string {
+  return [
+    "Available commands:",
+    "/new - start and switch to a fresh OpenCode session",
+    "/status - show current session mapping",
+    "/help - show this help message",
+  ].join("\n")
+}
+
 function parseOpenCodeUrl(value: string, source: string): string {
   try {
     const url = new URL(value)
@@ -97,6 +125,7 @@ export function parseConfig(): BridgeConfig {
   const webhookPath = env("TELEGRAM_WEBHOOK_PATH") || "/webhook"
   const sessionCacheMax = parsePositiveInt(env("TELEGRAM_SESSION_CACHE_MAX") || "", 500)
   const sessionCacheTtlMs = parsePositiveInt(env("TELEGRAM_SESSION_CACHE_TTL_MS") || "", 6 * 60 * 60 * 1000)
+  const sessionStorePath = env("TELEGRAM_SESSION_STORE_PATH") || "/tmp/opencode-telegram-sessions.json"
 
   return {
     mode,
@@ -109,6 +138,7 @@ export function parseConfig(): BridgeConfig {
     webhookPath: webhookPath.startsWith("/") ? webhookPath : `/${webhookPath}`,
     webhookSecret: env("TELEGRAM_WEBHOOK_SECRET") || undefined,
     webhookUrl: env("TELEGRAM_WEBHOOK_URL") || undefined,
+    sessionStorePath,
   }
 }
 
@@ -222,25 +252,33 @@ export function sessionFromCache(config: BridgeConfig, chatId: string): string |
   return cached.id
 }
 
-async function sessionForChat(config: BridgeConfig, chatId: string): Promise<string> {
-  const cached = sessionFromCache(config, chatId)
+async function sessionForChat(runtime: Runtime, chatKey: string): Promise<string> {
+  const config = runtime.config
+  const mapped = await runtime.store.get(chatKey)
+  if (mapped) {
+    cacheSession(config, chatKey, mapped)
+  }
+
+  const cached = sessionFromCache(config, chatKey)
   if (cached) return cached
 
-  const creating = creatingSessions.get(chatId)
+  const creating = creatingSessions.get(chatKey)
   if (creating) return creating
 
   const created = createSession(config)
     .then((id) => {
-      cacheSession(config, chatId, id)
-      creatingSessions.delete(chatId)
-      return id
+      cacheSession(config, chatKey, id)
+      return runtime.store.set(chatKey, id).then(() => {
+        creatingSessions.delete(chatKey)
+        return id
+      })
     })
     .catch((error) => {
-      creatingSessions.delete(chatId)
+      creatingSessions.delete(chatKey)
       throw error
     })
 
-  creatingSessions.set(chatId, created)
+  creatingSessions.set(chatKey, created)
   return created
 }
 
@@ -303,22 +341,52 @@ async function sendTelegramMessage(config: BridgeConfig, chatId: number, text: s
   }
 }
 
-async function handleTextUpdate(config: BridgeConfig, update: TelegramUpdate) {
+async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate) {
+  const config = runtime.config
   const message = update.message
   const chatId = message?.chat?.id
+  const userId = message?.from?.id
   const text = message?.text?.trim()
 
   if (!chatId || !text) return
 
+  const key = telegramSessionKey(chatId, userId)
+
+  const runCommand = async () => {
+    const command = parseCommand(text)
+    if (!command) return false
+    if (command.name === "/help") {
+      await sendTelegramMessage(config, chatId, helpText())
+      return true
+    }
+    if (command.name === "/status") {
+      const sessionId = await sessionForChat(runtime, key)
+      await sendTelegramMessage(config, chatId, `Current session: ${sessionId}`)
+      return true
+    }
+    if (command.name === "/new") {
+      const next = await createSession(config)
+      cacheSession(config, key, next)
+      await runtime.store.set(key, next)
+      await sendTelegramMessage(config, chatId, `Started a new session: ${next}`)
+      return true
+    }
+    await sendTelegramMessage(config, chatId, `Unknown command ${command.name}. Use /help.`)
+    return true
+  }
+
   try {
-    const key = String(chatId)
-    const sessionId = await sessionForChat(config, key)
+    const handled = await runCommand()
+    if (handled) return
+
+    const sessionId = await sessionForChat(runtime, key)
     const reply = await sendPrompt(config, sessionId, text).catch(async (error) => {
       if (!isMissingSession(error)) {
         throw error
       }
       sessions.delete(key)
-      const next = await sessionForChat(config, key)
+      await runtime.store.delete(key)
+      const next = await sessionForChat(runtime, key)
       return sendPrompt(config, next, text)
     })
     await sendTelegramMessage(config, chatId, reply)
@@ -332,7 +400,8 @@ async function handleTextUpdate(config: BridgeConfig, update: TelegramUpdate) {
   }
 }
 
-async function runPolling(config: BridgeConfig) {
+async function runPolling(runtime: Runtime) {
+  const config = runtime.config
   console.log("[TelegramBridge] mode=polling")
   await telegramRequest(config, "deleteWebhook", {
     drop_pending_updates: false,
@@ -357,8 +426,8 @@ async function runPolling(config: BridgeConfig) {
         offset = Math.max(offset, update.update_id + 1)
         const chatId = update.message?.chat?.id
         const run = !chatId
-          ? handleTextUpdate(config, update)
-          : queueChatUpdate(String(chatId), () => handleTextUpdate(config, update))
+          ? handleTextUpdate(runtime, update)
+          : queueChatUpdate(String(chatId), () => handleTextUpdate(runtime, update))
         runs.push(run)
       }
       if (runs.length) {
@@ -371,7 +440,8 @@ async function runPolling(config: BridgeConfig) {
   }
 }
 
-async function runWebhook(config: BridgeConfig) {
+async function runWebhook(runtime: Runtime) {
+  const config = runtime.config
   if (config.webhookUrl) {
     await telegramRequest(config, "setWebhook", {
       url: config.webhookUrl,
@@ -404,8 +474,8 @@ async function runWebhook(config: BridgeConfig) {
 
       const chatId = update.message?.chat?.id
       const run = !chatId
-        ? handleTextUpdate(config, update)
-        : queueChatUpdate(String(chatId), () => handleTextUpdate(config, update))
+        ? handleTextUpdate(runtime, update)
+        : queueChatUpdate(String(chatId), () => handleTextUpdate(runtime, update))
       void run.catch((error) => {
         console.error("[TelegramBridge] webhook handling failed", error)
       })
@@ -418,16 +488,19 @@ async function runWebhook(config: BridgeConfig) {
 
 export async function startTelegramBridge() {
   const config = parseConfig()
+  const store = createTelegramSessionStore(config.sessionStorePath)
+  const runtime = { config, store }
   console.log(`[TelegramBridge] OpenCode API: ${config.openCodeUrl}`)
+  console.log(`[TelegramBridge] Session store: ${config.sessionStorePath}`)
   if (config.directory) {
     console.log(`[TelegramBridge] OpenCode directory: ${config.directory}`)
   }
   if (config.mode === "polling") {
-    await runPolling(config)
+    await runPolling(runtime)
     return
   }
 
-  await runWebhook(config)
+  await runWebhook(runtime)
 }
 
 export function resetSessionCacheForTest() {

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -29,11 +29,59 @@ function parseStore(input: string): StoreShape {
   }
 }
 
+function errorCode(error: unknown): string {
+  return error && typeof error === "object" && "code" in error ? String(error.code) : ""
+}
+
+function isReplaceConflict(code: string): boolean {
+  return code === "EEXIST" || code === "EPERM" || code === "ENOTEMPTY" || code === "EACCES"
+}
+
+async function applyBackupStore(path: string, backupPath: string): Promise<boolean> {
+  const direct = await rename(backupPath, path).then(
+    () => true,
+    (error) => {
+      if (isReplaceConflict(errorCode(error))) return false
+      throw error
+    },
+  )
+  if (direct) return true
+
+  const displaced = `${path}.corrupt.${Date.now()}.${Math.random().toString(36).slice(2)}`
+  const moved = await rename(path, displaced).then(
+    () => true,
+    (error) => {
+      const code = errorCode(error)
+      if (code === "ENOENT") return false
+      if (isReplaceConflict(code)) return
+      throw error
+    },
+  )
+  if (moved === undefined) return false
+
+  const applied = await rename(backupPath, path).then(
+    () => true,
+    async (error) => {
+      if (moved) {
+        await rename(displaced, path).catch(() => undefined)
+      }
+      const code = errorCode(error)
+      if (isReplaceConflict(code) || code === "ENOENT") return false
+      throw error
+    },
+  )
+  if (!applied) return false
+  if (moved) {
+    await rm(displaced, { force: true }).catch(() => undefined)
+  }
+  return true
+}
+
 async function readBackupStore(path: string): Promise<StoreShape | undefined> {
   const dir = dirname(path)
   const name = basename(path)
   const entries = await readdir(dir).catch((error) => {
-    const code = error && typeof error === "object" && "code" in error ? String(error.code) : ""
+    const code = errorCode(error)
     if (code === "ENOENT" || code === "ENOTDIR") return []
     throw error
   })
@@ -56,11 +104,8 @@ async function readBackupStore(path: string): Promise<StoreShape | undefined> {
       .catch(() => undefined)
     if (!data) continue
 
-    await rename(backupPath, path).catch((error) => {
-      const code = error && typeof error === "object" && "code" in error ? String(error.code) : ""
-      if (code === "EEXIST" || code === "EPERM" || code === "ENOTEMPTY") return
-      throw error
-    })
+    const applied = await applyBackupStore(path, backupPath)
+    if (!applied) continue
     return data
   }
 

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -1,0 +1,105 @@
+import { mkdir, rename } from "node:fs/promises"
+import { dirname } from "node:path"
+
+type StoreShape = {
+  version: 1
+  sessions: Record<string, string>
+}
+
+function emptyStore(): StoreShape {
+  return {
+    version: 1,
+    sessions: {},
+  }
+}
+
+function parseStore(input: string): StoreShape {
+  if (!input.trim()) return emptyStore()
+  const data = JSON.parse(input) as Partial<StoreShape>
+  const sessions = data.sessions && typeof data.sessions === "object" ? data.sessions : {}
+  const out: Record<string, string> = {}
+  for (const key of Object.keys(sessions)) {
+    const value = sessions[key]
+    if (typeof value !== "string" || !value) continue
+    out[key] = value
+  }
+  return {
+    version: 1,
+    sessions: out,
+  }
+}
+
+async function readStore(path: string): Promise<StoreShape> {
+  const file = Bun.file(path)
+  const exists = await file.exists()
+  if (!exists) return emptyStore()
+  const text = await file.text()
+  return parseStore(text)
+}
+
+async function writeStore(path: string, data: StoreShape) {
+  await mkdir(dirname(path), { recursive: true })
+  const temp = `${path}.tmp`
+  const body = `${JSON.stringify(data, null, 2)}\n`
+  await Bun.write(temp, body)
+  await rename(temp, path)
+}
+
+export type TelegramSessionStore = {
+  get: (key: string) => Promise<string | undefined>
+  set: (key: string, sessionId: string) => Promise<void>
+  delete: (key: string) => Promise<void>
+}
+
+export function createTelegramSessionStore(path: string): TelegramSessionStore {
+  const sessions = new Map<string, string>()
+  const ready = readStore(path)
+    .then((data) => {
+      for (const [key, value] of Object.entries(data.sessions)) {
+        sessions.set(key, value)
+      }
+    })
+    .catch((error) => {
+      console.warn("[TelegramBridge] session store load failed, starting empty", { path, error })
+    })
+
+  let writes = Promise.resolve()
+
+  function flush() {
+    const payload: StoreShape = {
+      version: 1,
+      sessions: Object.fromEntries(sessions),
+    }
+    writes = writes.then(
+      () => writeStore(path, payload),
+      () => writeStore(path, payload),
+    )
+    return writes.catch((error) => {
+      console.error("[TelegramBridge] session store write failed", { path, error })
+    })
+  }
+
+  return {
+    async get(key: string) {
+      await ready
+      return sessions.get(key)
+    },
+    async set(key: string, sessionId: string) {
+      await ready
+      if (sessions.get(key) === sessionId) return
+      sessions.set(key, sessionId)
+      await flush()
+    },
+    async delete(key: string) {
+      await ready
+      const removed = sessions.delete(key)
+      if (!removed) return
+      await flush()
+    },
+  }
+}
+
+export function telegramSessionKey(chatId: number, userId?: number): string {
+  if (!userId) return `chat:${chatId}`
+  return `chat:${chatId}:user:${userId}`
+}

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -82,7 +82,7 @@ async function writeStore(path: string, data: StoreShape) {
   await Bun.write(temp, body)
   const replace = rename(temp, path).catch(async (error) => {
     const code = error && typeof error === "object" && "code" in error ? String(error.code) : ""
-    if (code !== "EEXIST" && code !== "EPERM" && code !== "ENOTEMPTY") {
+    if (code !== "EEXIST" && code !== "EPERM" && code !== "ENOTEMPTY" && code !== "EACCES") {
       await rm(temp, { force: true }).catch(() => undefined)
       throw error
     }
@@ -119,6 +119,7 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
     })
 
   let writes = Promise.resolve()
+  let ops = Promise.resolve()
 
   function flush() {
     const payload: StoreShape = {
@@ -132,6 +133,12 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
     return writes
   }
 
+  function run(task: () => Promise<void>) {
+    const step = ops.then(task, task)
+    ops = step.catch(() => undefined)
+    return step
+  }
+
   return {
     async get(key: string) {
       await ready
@@ -139,26 +146,30 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
     },
     async set(key: string, sessionId: string) {
       await ready
-      const prev = sessions.get(key)
-      if (prev === sessionId) return
-      sessions.set(key, sessionId)
-      await flush().catch((error) => {
-        if (prev !== undefined) {
-          sessions.set(key, prev)
+      await run(async () => {
+        const prev = sessions.get(key)
+        if (prev === sessionId) return
+        sessions.set(key, sessionId)
+        await flush().catch((error) => {
+          if (prev !== undefined) {
+            sessions.set(key, prev)
+            throw error
+          }
+          sessions.delete(key)
           throw error
-        }
-        sessions.delete(key)
-        throw error
+        })
       })
     },
     async delete(key: string) {
       await ready
-      const prev = sessions.get(key)
-      if (prev === undefined) return
-      sessions.delete(key)
-      await flush().catch((error) => {
-        sessions.set(key, prev)
-        throw error
+      await run(async () => {
+        const prev = sessions.get(key)
+        if (prev === undefined) return
+        sessions.delete(key)
+        await flush().catch((error) => {
+          sessions.set(key, prev)
+          throw error
+        })
       })
     },
   }

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -162,6 +162,8 @@ export type TelegramSessionStore = {
 }
 
 export function createTelegramSessionStore(path: string): TelegramSessionStore {
+  // In-memory serialization only coordinates writes within this process.
+  // Cross-process writers need an external coordinated store.
   const sessions = new Map<string, string>()
   const ready = readStore(path)
     .then((data) => {
@@ -231,6 +233,6 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
 }
 
 export function telegramSessionKey(chatId: number, userId?: number): string {
-  if (!userId) return `chat:${chatId}`
+  if (userId === undefined || userId === null) return `chat:${chatId}`
   return `chat:${chatId}:user:${userId}`
 }

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, rename } from "node:fs/promises"
+import { mkdir, rename, rm } from "node:fs/promises"
 import { dirname } from "node:path"
 
 type StoreShape = {
@@ -40,9 +40,27 @@ async function readStore(path: string): Promise<StoreShape> {
 async function writeStore(path: string, data: StoreShape) {
   await mkdir(dirname(path), { recursive: true })
   const temp = `${path}.tmp`
+  const backup = `${path}.bak.${Date.now()}.${Math.random().toString(36).slice(2)}`
   const body = `${JSON.stringify(data, null, 2)}\n`
   await Bun.write(temp, body)
-  await rename(temp, path)
+  const replace = rename(temp, path).catch(async (error) => {
+    const code = error && typeof error === "object" && "code" in error ? String(error.code) : ""
+    if (code !== "EEXIST" && code !== "EPERM" && code !== "ENOTEMPTY") {
+      await rm(temp, { force: true }).catch(() => undefined)
+      throw error
+    }
+    await rename(path, backup)
+    await rename(temp, path).catch(async (renameError) => {
+      await rename(backup, path).catch(() => undefined)
+      await rm(temp, { force: true }).catch(() => undefined)
+      throw renameError
+    })
+    await rm(backup, { force: true }).catch(() => undefined)
+  })
+  await replace.catch(async (error) => {
+    await rm(temp, { force: true }).catch(() => undefined)
+    throw error
+  })
 }
 
 export type TelegramSessionStore = {
@@ -84,15 +102,27 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
     },
     async set(key: string, sessionId: string) {
       await ready
-      if (sessions.get(key) === sessionId) return
+      const prev = sessions.get(key)
+      if (prev === sessionId) return
       sessions.set(key, sessionId)
-      await flush()
+      await flush().catch((error) => {
+        if (prev !== undefined) {
+          sessions.set(key, prev)
+          throw error
+        }
+        sessions.delete(key)
+        throw error
+      })
     },
     async delete(key: string) {
       await ready
-      const removed = sessions.delete(key)
-      if (!removed) return
-      await flush()
+      const prev = sessions.get(key)
+      if (prev === undefined) return
+      sessions.delete(key)
+      await flush().catch((error) => {
+        sessions.set(key, prev)
+        throw error
+      })
     },
   }
 }

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -136,8 +136,8 @@ async function writeStore(path: string, data: StoreShape) {
   const body = `${JSON.stringify(data, null, 2)}\n`
   await Bun.write(temp, body)
   const replace = rename(temp, path).catch(async (error) => {
-    const code = error && typeof error === "object" && "code" in error ? String(error.code) : ""
-    if (code !== "EEXIST" && code !== "EPERM" && code !== "ENOTEMPTY" && code !== "EACCES") {
+    const code = errorCode(error)
+    if (!isReplaceConflict(code)) {
       await rm(temp, { force: true }).catch(() => undefined)
       throw error
     }

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -74,9 +74,7 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
       () => writeStore(path, payload),
       () => writeStore(path, payload),
     )
-    return writes.catch((error) => {
-      console.error("[TelegramBridge] session store write failed", { path, error })
-    })
+    return writes
   }
 
   return {

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -29,14 +29,7 @@ function parseStore(input: string): StoreShape {
   }
 }
 
-async function readStore(path: string): Promise<StoreShape> {
-  const file = Bun.file(path)
-  const exists = await file.exists()
-  if (exists) {
-    const text = await file.text()
-    return parseStore(text)
-  }
-
+async function readBackupStore(path: string): Promise<StoreShape | undefined> {
   const dir = dirname(path)
   const name = basename(path)
   const entries = await readdir(dir).catch((error) => {
@@ -70,6 +63,23 @@ async function readStore(path: string): Promise<StoreShape> {
     })
     return data
   }
+
+  return
+}
+
+async function readStore(path: string): Promise<StoreShape> {
+  const file = Bun.file(path)
+  const exists = await file.exists()
+  if (exists) {
+    const text = await file.text()
+    const data = await Promise.resolve()
+      .then(() => parseStore(text))
+      .catch(() => undefined)
+    if (data) return data
+  }
+
+  const recovered = await readBackupStore(path)
+  if (recovered) return recovered
 
   return emptyStore()
 }

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -1,5 +1,5 @@
-import { mkdir, rename, rm } from "node:fs/promises"
-import { dirname } from "node:path"
+import { mkdir, readdir, rename, rm } from "node:fs/promises"
+import { basename, dirname, join } from "node:path"
 
 type StoreShape = {
   version: 1
@@ -32,9 +32,46 @@ function parseStore(input: string): StoreShape {
 async function readStore(path: string): Promise<StoreShape> {
   const file = Bun.file(path)
   const exists = await file.exists()
-  if (!exists) return emptyStore()
-  const text = await file.text()
-  return parseStore(text)
+  if (exists) {
+    const text = await file.text()
+    return parseStore(text)
+  }
+
+  const dir = dirname(path)
+  const name = basename(path)
+  const entries = await readdir(dir).catch((error) => {
+    const code = error && typeof error === "object" && "code" in error ? String(error.code) : ""
+    if (code === "ENOENT" || code === "ENOTDIR") return []
+    throw error
+  })
+  const backups = entries
+    .filter((entry) => entry.startsWith(`${name}.bak.`))
+    .sort((a, b) => {
+      const aStamp = Number(a.slice(`${name}.bak.`.length).split(".")[0] || "0")
+      const bStamp = Number(b.slice(`${name}.bak.`.length).split(".")[0] || "0")
+      return bStamp - aStamp
+    })
+
+  for (const entry of backups) {
+    const backupPath = join(dir, entry)
+    const text = await Bun.file(backupPath)
+      .text()
+      .catch(() => "")
+    if (!text) continue
+    const data = await Promise.resolve()
+      .then(() => parseStore(text))
+      .catch(() => undefined)
+    if (!data) continue
+
+    await rename(backupPath, path).catch((error) => {
+      const code = error && typeof error === "object" && "code" in error ? String(error.code) : ""
+      if (code === "EEXIST" || code === "EPERM" || code === "ENOTEMPTY") return
+      throw error
+    })
+    return data
+  }
+
+  return emptyStore()
 }
 
 async function writeStore(path: string, data: StoreShape) {


### PR DESCRIPTION
## Summary
- add a persistent Telegram chat/user to OpenCode session mapping store
- implement `/new`, `/status`, `/help`, and unknown-command help handling in the bridge
- keep per-chat update serialization and document command/session behavior in README

Closes #250