### PR TITLE
feat: add Telegram setup guide in Settings

### DIFF
--- a/app-prefixable/src/components/telegram-setup-guide.tsx
+++ b/app-prefixable/src/components/telegram-setup-guide.tsx
@@ -1,0 +1,148 @@
+import { For, createMemo, createSignal } from "solid-js"
+
+type ChecklistItem = {
+  id: string
+  label: string
+}
+
+const checklist: ChecklistItem[] = [
+  { id: "token", label: "Bot token is set with TELEGRAM_BOT_TOKEN or persisted token." },
+  { id: "mode", label: "Bridge mode is selected: polling or webhook." },
+  { id: "api", label: "openCodeUrl points to your reachable OpenCode API." },
+  { id: "path", label: "sessionStorePath points to a persistent writable location." },
+  { id: "webhook", label: "For webhook mode: TELEGRAM_WEBHOOK_URL, TELEGRAM_WEBHOOK_PATH, and HTTPS ingress are configured." },
+  { id: "notify", label: "Notifications are enabled per chat with /notify on after a test message." },
+]
+
+const commands = ["/notify on", "/notify off", "/notify status", "/new", "/status", "/help"] as const
+const sections = ["Readiness checklist", "Prerequisites", "Setup steps", "Command usage", "Security best practices", "Troubleshooting quick checks"] as const
+const title = "Telegram Setup Guide"
+
+export function TelegramSetupGuide() {
+  const [done, setDone] = createSignal(new Set<string>())
+  const ready = createMemo(() => done().size === checklist.length)
+
+  function toggle(id: string) {
+    setDone((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+        return next
+      }
+      next.add(id)
+      return next
+    })
+  }
+
+  return (
+    <div class="space-y-6">
+      <header>
+        <h1 class="text-lg font-medium" style={{ color: "var(--text-strong)" }}>
+          {title}
+        </h1>
+        <p class="text-sm mt-1" style={{ color: "var(--text-weak)" }}>
+          Configure the prokube.ai Telegram bridge with a quick readiness checklist, mode-specific setup, and troubleshooting checks.
+        </p>
+      </header>
+
+      <section class="rounded-lg p-4 space-y-3" style={{ background: "var(--background-base)", border: "1px solid var(--border-base)" }}>
+        <div class="flex items-center justify-between gap-3">
+          <h2 class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
+            Readiness checklist
+          </h2>
+          <span class="text-xs px-2 py-1 rounded" style={{ background: "var(--surface-inset)", color: "var(--text-weak)" }}>
+            {done().size}/{checklist.length}
+          </span>
+        </div>
+        <For each={checklist}>
+          {(item) => (
+            <label class="flex items-start gap-2 text-sm cursor-pointer" style={{ color: "var(--text-base)" }}>
+              <input type="checkbox" checked={done().has(item.id)} onChange={() => toggle(item.id)} class="mt-0.5 accent-[var(--interactive-base)]" />
+              <span>{item.label}</span>
+            </label>
+          )}
+        </For>
+        <p class="text-xs" style={{ color: ready() ? "var(--status-success-text)" : "var(--text-weak)" }}>
+          {ready() ? "Ready: start the bridge and verify commands in Telegram." : "Complete each item before enabling notifications in production chats."}
+        </p>
+      </section>
+
+      <section class="rounded-lg p-4 space-y-3" style={{ background: "var(--background-base)", border: "1px solid var(--border-base)" }}>
+        <h2 class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
+          Prerequisites
+        </h2>
+        <ul class="text-sm space-y-1 list-disc pl-5" style={{ color: "var(--text-base)" }}>
+          <li>Telegram bot created with BotFather and a valid bot token.</li>
+          <li>Mode choice: polling (default) or webhook.</li>
+          <li>OpenCode API reachable from the bridge via openCodeUrl (from OPENCODE_API_URL or API_URL by default).</li>
+          <li>Bridge runtime enabled with TELEGRAM_BRIDGE_ENABLED=true in supported deployments.</li>
+        </ul>
+      </section>
+
+      <section class="rounded-lg p-4 space-y-3" style={{ background: "var(--background-base)", border: "1px solid var(--border-base)" }}>
+        <h2 class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
+          Setup steps
+        </h2>
+        <div class="space-y-2 text-sm" style={{ color: "var(--text-base)" }}>
+          <p>
+            <strong>Polling mode:</strong> set <code>mode=polling</code> (or TELEGRAM_MODE=polling), configure token, and start the bridge. Polling clears webhook
+            registration automatically.
+          </p>
+          <p>
+            <strong>Webhook mode:</strong> set <code>mode=webhook</code>, configure <code>webhookUrl</code>, <code>webhookPath</code>, and optional <code>webhookSecret</code>.
+            Expose only HTTPS ingress and forward <code>x-telegram-bot-api-secret-token</code> unchanged.
+          </p>
+          <p>
+            Persisted UI fields map to runtime settings: <code>mode</code>, <code>token</code>, <code>openCodeUrl</code>, <code>directory</code>, <code>sessionCacheMax</code>,
+            <code>sessionCacheTtlMs</code>, <code>notificationDebounceMs</code>, <code>port</code>, <code>webhookPath</code>, <code>webhookSecret</code>, <code>webhookUrl</code>,
+            <code>sessionStorePath</code>, and <code>sessionLinkBase</code>. Restart after saving changes.
+          </p>
+        </div>
+      </section>
+
+      <section class="rounded-lg p-4 space-y-3" style={{ background: "var(--background-base)", border: "1px solid var(--border-base)" }}>
+        <h2 class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
+          Command usage
+        </h2>
+        <div class="flex flex-wrap gap-2">
+          <For each={commands}>
+            {(command) => (
+              <span class="text-xs px-2 py-1 rounded" style={{ background: "var(--surface-inset)", color: "var(--text-base)", border: "1px solid var(--border-base)" }}>
+                {command}
+              </span>
+            )}
+          </For>
+        </div>
+      </section>
+
+      <section class="rounded-lg p-4 space-y-3" style={{ background: "var(--background-base)", border: "1px solid var(--border-base)" }}>
+        <h2 class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
+          Security best practices
+        </h2>
+        <ul class="text-sm space-y-1 list-disc pl-5" style={{ color: "var(--text-base)" }}>
+          <li>Store TELEGRAM_BOT_TOKEN and TELEGRAM_WEBHOOK_SECRET in a secret manager, never in git.</li>
+          <li>Use HTTPS-only ingress for webhook mode and limit exposure to TELEGRAM_WEBHOOK_PATH.</li>
+          <li>Preserve the x-telegram-bot-api-secret-token header end-to-end when TELEGRAM_WEBHOOK_SECRET is set.</li>
+          <li>Keep sessionStorePath on persistent storage for restart safety in containerized deployments.</li>
+        </ul>
+      </section>
+
+      <section class="rounded-lg p-4 space-y-3" style={{ background: "var(--background-base)", border: "1px solid var(--border-base)" }}>
+        <h2 class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
+          Troubleshooting quick checks
+        </h2>
+        <ul class="text-sm space-y-1 list-disc pl-5" style={{ color: "var(--text-base)" }}>
+          <li>If replies fail, look for <code>Telegram sendMessage failed</code> and verify token validity and bot chat permissions.</li>
+          <li>If outbound alerts stop, check for <code>[TelegramBridge] outbound event stream error</code> and confirm OpenCode event streaming availability.</li>
+          <li>If webhook updates are rejected, verify your secret header and confirm TELEGRAM_WEBHOOK_URL is publicly reachable over HTTPS.</li>
+          <li>If session links are incorrect in alerts, set TELEGRAM_SESSION_LINK_BASE to the public prokube.ai UI base URL.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}
+
+export const TELEGRAM_GUIDE_COMMANDS = [...commands]
+export const TELEGRAM_READINESS_CHECKS = checklist
+export const TELEGRAM_GUIDE_SECTIONS = [...sections]
+export const TELEGRAM_GUIDE_TITLE = title

--- a/app-prefixable/src/components/telegram-setup-guide.tsx
+++ b/app-prefixable/src/components/telegram-setup-guide.tsx
@@ -5,14 +5,14 @@ type ChecklistItem = {
   label: string
 }
 
-const checklist: ChecklistItem[] = [
-  { id: "token", label: "Bot token is set with TELEGRAM_BOT_TOKEN or persisted token." },
-  { id: "mode", label: "Bridge mode is selected: polling or webhook." },
-  { id: "api", label: "openCodeUrl points to your reachable OpenCode API." },
-  { id: "path", label: "sessionStorePath points to a persistent writable location." },
-  { id: "webhook", label: "For webhook mode: TELEGRAM_WEBHOOK_URL, TELEGRAM_WEBHOOK_PATH, and HTTPS ingress are configured." },
-  { id: "notify", label: "Notifications are enabled per chat with /notify on after a test message." },
-]
+const checklist = Object.freeze([
+  Object.freeze({ id: "token", label: "Bot token is set with TELEGRAM_BOT_TOKEN or persisted token." }),
+  Object.freeze({ id: "mode", label: "Bridge mode is selected: polling or webhook." }),
+  Object.freeze({ id: "api", label: "openCodeUrl points to your reachable OpenCode API." }),
+  Object.freeze({ id: "path", label: "sessionStorePath points to a persistent writable location." }),
+  Object.freeze({ id: "webhook", label: "For webhook mode: TELEGRAM_WEBHOOK_URL, TELEGRAM_WEBHOOK_PATH, and HTTPS ingress are configured." }),
+  Object.freeze({ id: "notify", label: "Notifications are enabled per chat with /notify on after a test message." }),
+]) as readonly Readonly<ChecklistItem>[]
 
 const commands = ["/notify on", "/notify off", "/notify status", "/new", "/status", "/help"] as const
 const sections = ["Readiness checklist", "Prerequisites", "Setup steps", "Command usage", "Security best practices", "Troubleshooting quick checks"] as const

--- a/app-prefixable/src/pages/settings-tabs.ts
+++ b/app-prefixable/src/pages/settings-tabs.ts
@@ -1,0 +1,1 @@
+export const SETTINGS_BASE_TABS = ["providers", "servers", "git", "mcp", "prompts", "instructions", "appearance", "sounds", "telegram"] as const

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -9,12 +9,14 @@ import { useConfig } from "../context/config"
 import { MCPAddDialog } from "../components/mcp-add-dialog"
 import { ConfirmDialog } from "../components/confirm-dialog"
 import { Button } from "../components/ui/button"
-import { Check, Copy, Plug, GitBranch, Server, Globe, ExternalLink, Key, Search, X, Trash2, BookmarkPlus, Pencil, Palette, Sun, Moon, Monitor, BookOpen, Plus, Save, Volume2, Play, Settings2, Code, Shield, Cpu, Wrench, ChevronDown, ChevronRight, Info } from "lucide-solid"
+import { Check, Copy, Plug, GitBranch, Server, Globe, ExternalLink, Key, Search, X, Trash2, BookmarkPlus, Pencil, Palette, Sun, Moon, Monitor, BookOpen, Plus, Save, Volume2, Play, Settings2, Code, Shield, Cpu, Wrench, ChevronDown, ChevronRight, Info, MessageCircle } from "lucide-solid"
 import { SOUND_OPTIONS, readSoundSettings, writeSoundSettings, playSound, primeAudioContext, SOUND_STORAGE_KEY, type SoundSettings } from "../utils/sound"
 import { useSavedPrompts, type PromptScope } from "../context/saved-prompts"
 import { useTheme } from "../context/theme"
 import { useServer } from "../context/server"
 import { ServerDialog } from "../components/server-dialog"
+import { TelegramSetupGuide } from "../components/telegram-setup-guide"
+import { SETTINGS_BASE_TABS } from "./settings-tabs"
 import { writeFile } from "../utils/extended-api"
 import type { Config, PermissionActionConfig } from "../sdk/client"
 
@@ -31,7 +33,7 @@ export function Settings() {
   // Initialize tab from URL hash, default to "providers"
   const getInitialTab = () => {
     const hash = window.location.hash.slice(1)
-    const baseTabs = ["providers", "servers", "git", "mcp", "prompts", "instructions", "appearance", "sounds"]
+    const baseTabs: string[] = [...SETTINGS_BASE_TABS]
     const validTabs = directory ? [...baseTabs, "config"] : baseTabs
     return validTabs.includes(hash) ? hash : "providers"
   }
@@ -669,6 +671,7 @@ Add your project-specific instructions here.
     }
     base.push({ id: "appearance", label: "Appearance", icon: () => <Palette class="w-4 h-4" />, scope: null })
     base.push({ id: "sounds", label: "Sounds", icon: () => <Volume2 class="w-4 h-4" />, scope: null })
+    base.push({ id: "telegram", label: "Telegram", icon: () => <MessageCircle class="w-4 h-4" />, scope: "Global" })
     return base
   })
 
@@ -2288,6 +2291,11 @@ Add your project-specific instructions here.
                 </div>
               </section>
             </div>
+          </Show>
+
+          {/* Telegram Tab */}
+          <Show when={activeTab() === "telegram"}>
+            <TelegramSetupGuide />
           </Show>
         </div>
       </div>

--- a/app-prefixable/tests/telegram-guide.test.tsx
+++ b/app-prefixable/tests/telegram-guide.test.tsx
@@ -18,5 +18,11 @@ describe("Telegram setup guide UI", () => {
   test("guide constants include expected quick checks", () => {
     expect(TELEGRAM_GUIDE_COMMANDS).toEqual(expect.arrayContaining(["/new", "/status", "/help", "/notify status"]))
     expect(TELEGRAM_READINESS_CHECKS.length).toBeGreaterThanOrEqual(5)
+    expect(TELEGRAM_READINESS_CHECKS.some((item) => item.id === "webhook")).toBe(true)
+  })
+
+  test("readiness checklist export is immutable", () => {
+    expect(Object.isFrozen(TELEGRAM_READINESS_CHECKS)).toBe(true)
+    expect(TELEGRAM_READINESS_CHECKS.every((item) => Object.isFrozen(item))).toBe(true)
   })
 })

--- a/app-prefixable/tests/telegram-guide.test.tsx
+++ b/app-prefixable/tests/telegram-guide.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { TELEGRAM_GUIDE_COMMANDS, TELEGRAM_GUIDE_SECTIONS, TELEGRAM_GUIDE_TITLE, TELEGRAM_READINESS_CHECKS } from "../src/components/telegram-setup-guide"
+import { SETTINGS_BASE_TABS } from "../src/pages/settings-tabs"
+
+describe("Telegram setup guide UI", () => {
+  test("settings navigation includes telegram tab", () => {
+    expect(SETTINGS_BASE_TABS).toContain("telegram")
+  })
+
+  test("guide exposes key sections and commands", () => {
+    expect(TELEGRAM_GUIDE_TITLE).toBe("Telegram Setup Guide")
+    expect(TELEGRAM_GUIDE_SECTIONS).toEqual(
+      expect.arrayContaining(["Readiness checklist", "Setup steps", "Troubleshooting quick checks"]),
+    )
+    expect(TELEGRAM_GUIDE_COMMANDS).toContain("/notify on")
+  })
+
+  test("guide constants include expected quick checks", () => {
+    expect(TELEGRAM_GUIDE_COMMANDS).toEqual(expect.arrayContaining(["/new", "/status", "/help", "/notify status"]))
+    expect(TELEGRAM_READINESS_CHECKS.length).toBeGreaterThanOrEqual(5)
+  })
+})


### PR DESCRIPTION
## Summary
- add a new **Settings -> Telegram** tab with an in-app setup guide and concise readiness checklist
- document polling and webhook setup flows, command usage, security practices, and troubleshooting signatures/checks
- add basic UI coverage to verify Telegram tab discoverability and guide content constants

## Validation
- `bun test tests/telegram-guide.test.tsx`
- `bun run test`
- `bun run build`

Closes #262