### PR TITLE
feat: add followup queue dock below composer

### DIFF
--- a/app-prefixable/src/components/followup-dock.tsx
+++ b/app-prefixable/src/components/followup-dock.tsx
@@ -5,6 +5,7 @@ import { Button } from "./ui/button";
 export function FollowupDock(props: {
   items: { id: string; text: string }[];
   sending?: string;
+  processing?: boolean;
   onSend: (id: string) => void;
   onEdit: (id: string) => void;
 }) {
@@ -69,7 +70,7 @@ export function FollowupDock(props: {
                   type="button"
                   size="sm"
                   variant="secondary"
-                  disabled={!!props.sending}
+                  disabled={!!props.sending || !!props.processing}
                   onClick={() => props.onSend(item.id)}
                 >
                   Send now
@@ -78,7 +79,7 @@ export function FollowupDock(props: {
                   type="button"
                   size="sm"
                   variant="ghost"
-                  disabled={!!props.sending}
+                  disabled={!!props.sending || !!props.processing}
                   onClick={() => props.onEdit(item.id)}
                 >
                   Edit

--- a/app-prefixable/src/components/followup-dock.tsx
+++ b/app-prefixable/src/components/followup-dock.tsx
@@ -47,7 +47,7 @@ export function FollowupDock(props: {
           class="w-4 h-4 shrink-0 transition-transform"
           style={{
             color: "var(--text-weak)",
-            transform: collapsed() ? "rotate(180deg)" : "rotate(0deg)",
+            transform: collapsed() ? "rotate(0deg)" : "rotate(180deg)",
           }}
         />
       </button>

--- a/app-prefixable/src/components/followup-dock.tsx
+++ b/app-prefixable/src/components/followup-dock.tsx
@@ -1,0 +1,85 @@
+import { For, Show, createMemo, createSignal } from "solid-js";
+import { ChevronDown } from "lucide-solid";
+import { Button } from "./ui/button";
+
+export function FollowupDock(props: {
+  items: { id: string; text: string }[];
+  sending?: string;
+  onSend: (id: string) => void;
+  onEdit: (id: string) => void;
+}) {
+  const [collapsed, setCollapsed] = createSignal(true);
+  const count = createMemo(() => props.items.length);
+  const preview = createMemo(() => props.items[0]?.text ?? "");
+  const label = createMemo(() =>
+    count() === 1 ? "1 followup queued" : `${count()} followups queued`,
+  );
+
+  function toggle() {
+    setCollapsed((v) => !v);
+  }
+
+  return (
+    <div
+      class="rounded-lg border mb-2"
+      style={{
+        background: "var(--background-base)",
+        border: "1px solid var(--border-base)",
+      }}
+    >
+      <button
+        type="button"
+        class="w-full flex items-center gap-2 px-3 py-2 text-left"
+        onClick={toggle}
+      >
+        <span class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
+          {label()}
+        </span>
+        <Show when={collapsed() && preview()}>
+          <span class="text-xs truncate min-w-0 flex-1" style={{ color: "var(--text-weak)" }}>
+            {preview()}
+          </span>
+        </Show>
+        <ChevronDown
+          class="w-4 h-4 shrink-0 transition-transform"
+          style={{
+            color: "var(--text-weak)",
+            transform: collapsed() ? "rotate(180deg)" : "rotate(0deg)",
+          }}
+        />
+      </button>
+
+      <Show when={!collapsed()}>
+        <div class="px-3 pb-3 pt-1 flex flex-col gap-2 max-h-44 overflow-y-auto">
+          <For each={props.items}>
+            {(item) => (
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="text-sm truncate flex-1" style={{ color: "var(--text-base)" }}>
+                  {item.text}
+                </span>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  disabled={!!props.sending}
+                  onClick={() => props.onSend(item.id)}
+                >
+                  Send now
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  disabled={!!props.sending}
+                  onClick={() => props.onEdit(item.id)}
+                >
+                  Edit
+                </Button>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/app-prefixable/src/components/followup-dock.tsx
+++ b/app-prefixable/src/components/followup-dock.tsx
@@ -6,6 +6,7 @@ export function FollowupDock(props: {
   items: { id: string; text: string }[];
   sending?: string;
   processing?: boolean;
+  loading?: boolean;
   onSend: (id: string) => void;
   onEdit: (id: string) => void;
 }) {
@@ -70,7 +71,7 @@ export function FollowupDock(props: {
                   type="button"
                   size="sm"
                   variant="secondary"
-                  disabled={!!props.sending || !!props.processing}
+                  disabled={!!props.sending || !!props.processing || !!props.loading}
                   onClick={() => props.onSend(item.id)}
                 >
                   Send now
@@ -79,7 +80,7 @@ export function FollowupDock(props: {
                   type="button"
                   size="sm"
                   variant="ghost"
-                  disabled={!!props.sending || !!props.processing}
+                  disabled={!!props.sending || !!props.processing || !!props.loading}
                   onClick={() => props.onEdit(item.id)}
                 >
                   Edit

--- a/app-prefixable/src/components/followup-dock.tsx
+++ b/app-prefixable/src/components/followup-dock.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo, createSignal } from "solid-js";
+import { For, Show, createMemo, createSignal, createUniqueId } from "solid-js";
 import { ChevronDown } from "lucide-solid";
 import { Button } from "./ui/button";
 
@@ -9,6 +9,7 @@ export function FollowupDock(props: {
   onEdit: (id: string) => void;
 }) {
   const [collapsed, setCollapsed] = createSignal(true);
+  const contentId = `followup-dock-${createUniqueId()}`;
   const count = createMemo(() => props.items.length);
   const preview = createMemo(() => props.items[0]?.text ?? "");
   const label = createMemo(() =>
@@ -31,6 +32,8 @@ export function FollowupDock(props: {
         type="button"
         class="w-full flex items-center gap-2 px-3 py-2 text-left"
         onClick={toggle}
+        aria-expanded={!collapsed()}
+        aria-controls={contentId}
       >
         <span class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
           {label()}
@@ -50,7 +53,12 @@ export function FollowupDock(props: {
       </button>
 
       <Show when={!collapsed()}>
-        <div class="px-3 pb-3 pt-1 flex flex-col gap-2 max-h-44 overflow-y-auto">
+        <div
+          id={contentId}
+          class="px-3 pb-3 pt-1 flex flex-col gap-2 max-h-44 overflow-y-auto"
+          role="region"
+          aria-label="Queued followup messages"
+        >
           <For each={props.items}>
             {(item) => (
               <div class="flex items-center gap-2 min-w-0">

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -94,6 +94,19 @@ function followupStorageKey(dir: string) {
   return `opencode.followup.${dir}`;
 }
 
+function normalizeFollowupList(value: unknown) {
+  if (!Array.isArray(value)) return;
+  const next: FollowupItem[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const id = (item as { id?: unknown }).id;
+    const text = (item as { text?: unknown }).text;
+    if (typeof id !== "string" || typeof text !== "string") continue;
+    next.push({ id, text });
+  }
+  return next;
+}
+
 export function Session() {
   const params = useParams<{ dir: string; id?: string }>();
   const navigate = useNavigate();
@@ -296,7 +309,13 @@ export function Session() {
         clearFollowupStorageKey();
         return {} as Record<string, FollowupItem[] | undefined>;
       }
-      return parsed as Record<string, FollowupItem[] | undefined>;
+      const map = {} as Record<string, FollowupItem[] | undefined>;
+      for (const [id, value] of Object.entries(parsed)) {
+        const list = normalizeFollowupList(value);
+        if (!list) continue;
+        map[id] = list;
+      }
+      return map;
     } catch {
       clearFollowupStorageKey();
       return {} as Record<string, FollowupItem[] | undefined>;

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -276,6 +276,15 @@ export function Session() {
   const pendingPermissions = createMemo(() => permission.pendingForSession(sessionId() ?? ""));
   const inputBlocked = createMemo(() => !!pendingQuestion() || pendingPermissions().length > 0);
 
+  function clearFollowupStorageKey() {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(followupStorageKey(params.dir));
+    } catch {
+      return;
+    }
+  }
+
   function readFollowupMap() {
     if (typeof window === "undefined") return {} as Record<string, FollowupItem[] | undefined>;
     const key = followupStorageKey(params.dir);
@@ -284,12 +293,12 @@ export function Session() {
       if (!raw) return {} as Record<string, FollowupItem[] | undefined>;
       const parsed = JSON.parse(raw);
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        window.localStorage.removeItem(key);
+        clearFollowupStorageKey();
         return {} as Record<string, FollowupItem[] | undefined>;
       }
       return parsed as Record<string, FollowupItem[] | undefined>;
     } catch {
-      window.localStorage.removeItem(key);
+      clearFollowupStorageKey();
       return {} as Record<string, FollowupItem[] | undefined>;
     }
   }
@@ -1438,7 +1447,7 @@ export function Session() {
 
     const files = fileContext();
     const images = imageAttachments();
-    if ((!text && files.length === 0 && images.length === 0) || loading() || inputBlocked())
+    if ((!text && files.length === 0 && images.length === 0) || loading() || inputBlocked() || !!followupSending())
       return;
 
     if (processing() && text && files.length === 0 && images.length === 0) {

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -289,24 +289,24 @@ export function Session() {
   const pendingPermissions = createMemo(() => permission.pendingForSession(sessionId() ?? ""));
   const inputBlocked = createMemo(() => !!pendingQuestion() || pendingPermissions().length > 0);
 
-  function clearFollowupStorageKey() {
+  function clearFollowupStorageKey(dir: string) {
     if (typeof window === "undefined") return;
     try {
-      window.localStorage.removeItem(followupStorageKey(params.dir));
+      window.localStorage.removeItem(followupStorageKey(dir));
     } catch {
       return;
     }
   }
 
-  function readFollowupMap() {
+  function readFollowupMap(dir = params.dir) {
     if (typeof window === "undefined") return {} as Record<string, FollowupItem[] | undefined>;
-    const key = followupStorageKey(params.dir);
+    const key = followupStorageKey(dir);
     try {
       const raw = window.localStorage.getItem(key);
       if (!raw) return {} as Record<string, FollowupItem[] | undefined>;
       const parsed = JSON.parse(raw);
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        clearFollowupStorageKey();
+        clearFollowupStorageKey(dir);
         return {} as Record<string, FollowupItem[] | undefined>;
       }
       const map = {} as Record<string, FollowupItem[] | undefined>;
@@ -317,15 +317,15 @@ export function Session() {
       }
       return map;
     } catch {
-      clearFollowupStorageKey();
+      clearFollowupStorageKey(dir);
       return {} as Record<string, FollowupItem[] | undefined>;
     }
   }
 
-  function writeFollowupMap(map: Record<string, FollowupItem[] | undefined>) {
+  function writeFollowupMap(map: Record<string, FollowupItem[] | undefined>, dir = params.dir) {
     if (typeof window === "undefined") return;
     try {
-      window.localStorage.setItem(followupStorageKey(params.dir), JSON.stringify(map));
+      window.localStorage.setItem(followupStorageKey(dir), JSON.stringify(map));
     } catch {
       return;
     }
@@ -1401,6 +1401,7 @@ export function Session() {
   }
 
   async function sendFollowupNow(id: string) {
+    const dir = params.dir;
     const sid = sessionId();
     if (!sid || followupSending() || processing()) return;
     const model = sessionModel();
@@ -1430,10 +1431,10 @@ export function Session() {
       const next = queued.filter((entry) => entry.id !== id);
       if (sessionId() === sid) setFollowups(next);
 
-      const map = readFollowupMap();
+      const map = readFollowupMap(dir);
       if (next.length === 0) delete map[sid];
       if (next.length > 0) map[sid] = next;
-      writeFollowupMap(map);
+      writeFollowupMap(map, dir);
       startProcessing();
     } catch (err) {
       setPendingUserMessageText(null);

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -278,11 +278,18 @@ export function Session() {
 
   function readFollowupMap() {
     if (typeof window === "undefined") return {} as Record<string, FollowupItem[] | undefined>;
+    const key = followupStorageKey(params.dir);
     try {
-      const raw = window.localStorage.getItem(followupStorageKey(params.dir));
+      const raw = window.localStorage.getItem(key);
       if (!raw) return {} as Record<string, FollowupItem[] | undefined>;
-      return JSON.parse(raw) as Record<string, FollowupItem[] | undefined>;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        window.localStorage.removeItem(key);
+        return {} as Record<string, FollowupItem[] | undefined>;
+      }
+      return parsed as Record<string, FollowupItem[] | undefined>;
     } catch {
+      window.localStorage.removeItem(key);
       return {} as Record<string, FollowupItem[] | undefined>;
     }
   }
@@ -1391,7 +1398,12 @@ export function Session() {
         agent: providers.selectedAgent || "build",
         model,
       });
-      removeFollowup(id);
+      const map = readFollowupMap();
+      const next = (map[sid] ?? []).filter((entry) => entry.id !== id);
+      if (next.length === 0) delete map[sid];
+      if (next.length > 0) map[sid] = next;
+      writeFollowupMap(map);
+      if (sessionId() === sid) setFollowups(next);
       startProcessing();
     } catch (err) {
       setPendingUserMessageText(null);
@@ -1431,6 +1443,7 @@ export function Session() {
 
     if (processing() && text && files.length === 0 && images.length === 0) {
       if (!queueFollowup(text)) return;
+      setError(null);
       setInput("");
       setDragHeight(0);
       if (inputRef) inputRef.style.height = "";

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -1402,7 +1402,7 @@ export function Session() {
 
   async function sendFollowupNow(id: string) {
     const sid = sessionId();
-    if (!sid || followupSending()) return;
+    if (!sid || followupSending() || processing()) return;
     const model = sessionModel();
     if (!model) {
       setError("Please select a model before sending messages. Click the model button in the header.");
@@ -2360,6 +2360,7 @@ export function Session() {
               <FollowupDock
                 items={followups()}
                 sending={followupSending()}
+                processing={processing()}
                 onSend={sendFollowupNow}
                 onEdit={editFollowup}
               />

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -35,6 +35,7 @@ import { SessionSidebar } from "../components/session-sidebar";
 import { ReviewPanel } from "../components/review-panel";
 import { SessionHeader } from "../components/session-header";
 import { ResizeHandle } from "../components/resize-handle";
+import { FollowupDock } from "../components/followup-dock";
 import { base64Encode, base64Decode } from "../utils/path";
 import type { Part, QuestionRequest, TextPart } from "../sdk/client";
 import type { DisplayMessage } from "../types/message";
@@ -82,6 +83,15 @@ const drafts = new Map<string, SessionDraft>();
 // pair. Uses "__new__" as sentinel when there is no session id yet.
 function draftKey(dir: string, id?: string) {
   return `${dir}:${id ?? "__new__"}`;
+}
+
+interface FollowupItem {
+  id: string;
+  text: string;
+}
+
+function followupStorageKey(dir: string) {
+  return `opencode.followup.${dir}`;
 }
 
 export function Session() {
@@ -251,6 +261,8 @@ export function Session() {
   const [imageAttachments, setImageAttachments] = createSignal<
     ImageAttachment[]
   >([]);
+  const [followups, setFollowups] = createSignal<FollowupItem[]>([]);
+  const [followupSending, setFollowupSending] = createSignal<string | undefined>();
   const [error, setError] = createSignal<string | null>(null);
   // Use session tree walk to find pending questions from this session or any descendant.
   // This surfaces child/grandchild session questions in the parent session view.
@@ -263,6 +275,47 @@ export function Session() {
 
   const pendingPermissions = createMemo(() => permission.pendingForSession(sessionId() ?? ""));
   const inputBlocked = createMemo(() => !!pendingQuestion() || pendingPermissions().length > 0);
+
+  function readFollowupMap() {
+    if (typeof window === "undefined") return {} as Record<string, FollowupItem[] | undefined>;
+    const raw = window.localStorage.getItem(followupStorageKey(params.dir));
+    if (!raw) return {} as Record<string, FollowupItem[] | undefined>;
+    try {
+      return JSON.parse(raw) as Record<string, FollowupItem[] | undefined>;
+    } catch {
+      return {} as Record<string, FollowupItem[] | undefined>;
+    }
+  }
+
+  function writeFollowupMap(map: Record<string, FollowupItem[] | undefined>) {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(followupStorageKey(params.dir), JSON.stringify(map));
+  }
+
+  function setSessionFollowups(id: string, list: FollowupItem[]) {
+    const map = readFollowupMap();
+    if (list.length === 0) delete map[id];
+    if (list.length > 0) map[id] = list;
+    writeFollowupMap(map);
+    setFollowups(list);
+  }
+
+  function queueFollowup(text: string) {
+    const id = sessionId();
+    if (!id) return false;
+    const next = [...followups(), { id: crypto.randomUUID(), text }];
+    setSessionFollowups(id, next);
+    return true;
+  }
+
+  function removeFollowup(id: string) {
+    const sid = sessionId();
+    if (!sid) return;
+    setSessionFollowups(
+      sid,
+      followups().filter((item) => item.id !== id),
+    );
+  }
 
   // Double-Escape to abort: track last Escape press timestamp
   const lastEsc = { ts: 0 };
@@ -364,6 +417,8 @@ export function Session() {
 
     setSessionId(id);
     setPendingUserMessageText(null); // Clear pending text on session change
+    setFollowupSending(undefined);
+    setFollowups(id ? readFollowupMap()[id] ?? [] : []);
 
     // Restore draft for the new session (or clear if none saved)
     const saved = drafts.get(key);
@@ -1290,6 +1345,64 @@ export function Session() {
     }
   }
 
+  function optimisticUserMessage(text: string, sid: string) {
+    return {
+      id: crypto.randomUUID(),
+      role: "user",
+      parts: [
+        {
+          id: crypto.randomUUID(),
+          sessionID: sid,
+          messageID: "",
+          type: "text",
+          text,
+        },
+      ] as Part[],
+    } satisfies DisplayMessage;
+  }
+
+  async function sendFollowupNow(id: string) {
+    const sid = sessionId();
+    if (!sid || followupSending()) return;
+    const model = sessionModel();
+    if (!model) {
+      setError("Please select a model before sending messages. Click the model button in the header.");
+      return;
+    }
+    if (!providers.connected.includes(model.providerID)) {
+      setError(`Provider "${model.providerID}" is not connected. Please configure it in Settings.`);
+      return;
+    }
+    const item = followups().find((entry) => entry.id === id);
+    if (!item) return;
+    setFollowupSending(id);
+    setError(null);
+    setPendingUserMessageText(item.text);
+    setOptimisticMessage(optimisticUserMessage(item.text, sid));
+
+    try {
+      await client.session.promptAsync({
+        sessionID: sid,
+        parts: [{ type: "text", text: item.text }],
+        agent: providers.selectedAgent || "build",
+        model,
+      });
+      removeFollowup(id);
+      startProcessing();
+    } catch (err) {
+      setError(`Failed to send queued followup: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setFollowupSending(undefined);
+    }
+  }
+
+  function editFollowup(id: string) {
+    const item = followups().find((entry) => entry.id === id);
+    if (!item || !inputRef) return;
+    applyInputAndAutogrow(inputRef, item.text);
+    removeFollowup(id);
+  }
+
   async function sendMessage(e: SubmitEvent) {
     e.preventDefault();
     const text = input().trim();
@@ -1309,6 +1422,15 @@ export function Session() {
     const images = imageAttachments();
     if ((!text && files.length === 0 && images.length === 0) || loading() || inputBlocked())
       return;
+
+    if (processing() && text && files.length === 0 && images.length === 0) {
+      if (!queueFollowup(text)) return;
+      setInput("");
+      setDragHeight(0);
+      if (inputRef) inputRef.style.height = "";
+      drafts.delete(draftKey(params.dir, sessionId()));
+      return;
+    }
 
     // Require explicit model selection to avoid OpenCode auto-selecting a broken provider
     const model = sessionModel();
@@ -1342,19 +1464,7 @@ export function Session() {
     setPendingUserMessageText(text);
 
     // Optimistic update - show user message immediately while waiting for server
-    const userMessage: DisplayMessage = {
-      id: crypto.randomUUID(),
-      role: "user",
-      parts: [
-        {
-          id: crypto.randomUUID(),
-          sessionID: sessionId() || "",
-          messageID: "",
-          type: "text",
-          text: text || "(files attached)",
-        },
-      ] as Part[],
-    };
+    const userMessage = optimisticUserMessage(text || "(files attached)", sessionId() || "");
     setOptimisticMessage(userMessage);
 
     try {
@@ -2198,6 +2308,15 @@ export function Session() {
                 </div>
               </div>
             </form>
+
+            <Show when={followups().length > 0}>
+              <FollowupDock
+                items={followups()}
+                sending={followupSending()}
+                onSend={sendFollowupNow}
+                onEdit={editFollowup}
+              />
+            </Show>
           </div>
         </div>
 

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -278,9 +278,9 @@ export function Session() {
 
   function readFollowupMap() {
     if (typeof window === "undefined") return {} as Record<string, FollowupItem[] | undefined>;
-    const raw = window.localStorage.getItem(followupStorageKey(params.dir));
-    if (!raw) return {} as Record<string, FollowupItem[] | undefined>;
     try {
+      const raw = window.localStorage.getItem(followupStorageKey(params.dir));
+      if (!raw) return {} as Record<string, FollowupItem[] | undefined>;
       return JSON.parse(raw) as Record<string, FollowupItem[] | undefined>;
     } catch {
       return {} as Record<string, FollowupItem[] | undefined>;
@@ -289,7 +289,11 @@ export function Session() {
 
   function writeFollowupMap(map: Record<string, FollowupItem[] | undefined>) {
     if (typeof window === "undefined") return;
-    window.localStorage.setItem(followupStorageKey(params.dir), JSON.stringify(map));
+    try {
+      window.localStorage.setItem(followupStorageKey(params.dir), JSON.stringify(map));
+    } catch {
+      return;
+    }
   }
 
   function setSessionFollowups(id: string, list: FollowupItem[]) {
@@ -1390,6 +1394,8 @@ export function Session() {
       removeFollowup(id);
       startProcessing();
     } catch (err) {
+      setPendingUserMessageText(null);
+      setOptimisticMessage(null);
       setError(`Failed to send queued followup: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setFollowupSending(undefined);

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -1412,7 +1412,8 @@ export function Session() {
       setError(`Provider "${model.providerID}" is not connected. Please configure it in Settings.`);
       return;
     }
-    const item = followups().find((entry) => entry.id === id);
+    const queued = followups();
+    const item = queued.find((entry) => entry.id === id);
     if (!item) return;
     setFollowupSending(id);
     setError(null);
@@ -1426,12 +1427,13 @@ export function Session() {
         agent: providers.selectedAgent || "build",
         model,
       });
+      const next = queued.filter((entry) => entry.id !== id);
+      if (sessionId() === sid) setFollowups(next);
+
       const map = readFollowupMap();
-      const next = (map[sid] ?? []).filter((entry) => entry.id !== id);
       if (next.length === 0) delete map[sid];
       if (next.length > 0) map[sid] = next;
       writeFollowupMap(map);
-      if (sessionId() === sid) setFollowups(next);
       startProcessing();
     } catch (err) {
       setPendingUserMessageText(null);

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -1403,7 +1403,7 @@ export function Session() {
   async function sendFollowupNow(id: string) {
     const dir = params.dir;
     const sid = sessionId();
-    if (!sid || followupSending() || processing()) return;
+    if (!sid || followupSending() || processing() || loading()) return;
     const model = sessionModel();
     if (!model) {
       setError("Please select a model before sending messages. Click the model button in the header.");
@@ -2364,6 +2364,7 @@ export function Session() {
                 items={followups()}
                 sending={followupSending()}
                 processing={processing()}
+                loading={loading()}
                 onSend={sendFollowupNow}
                 onEdit={editFollowup}
               />


### PR DESCRIPTION
## Summary
- add a new FollowupDock component with collapsed and expanded queue views
- queue plain-text followups when users submit while a session is processing, persisted in localStorage per directory/session
- integrate send-now and edit actions in the session page to submit queued followups or restore them to the composer

## Investigation
- this repo's SDK/events do not expose backend-generated followup suggestions
- implemented followups as a client-side deferred message queue for user-typed text

Closes #232