### PR TITLE
fix: treat outbound event stream timeouts as expected reconnects

### DIFF
--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -10,6 +10,7 @@ import {
   extractReply,
   handleBridgeEvent,
   handleTextUpdate,
+  isTimeoutError,
   joinOpenCodeUrl,
   parseConfig,
   parseMode,
@@ -2313,6 +2314,20 @@ describe("telegram bridge config and cache", () => {
   test("outbound SSE parser handles CRLF split across chunk boundaries", () => {
     const blocks = parseOutboundBlocks(["data: one\r", "\n\r", "\ndata: two\n\n"]);
     expect(blocks).toEqual(["data: one", "data: two"]);
+  });
+
+  test("isTimeoutError classifies timeout names, codes, and messages", () => {
+    const named = new Error("stream died");
+    named.name = "TimeoutError";
+    expect(isTimeoutError(named)).toBe(true);
+
+    const coded = Object.assign(new Error("network failed"), { code: "ETIMEDOUT" });
+    expect(isTimeoutError(coded)).toBe(true);
+
+    expect(isTimeoutError(new Error("request timed out after 30s"))).toBe(true);
+    expect(isTimeoutError(new Error("socket timeout waiting for headers"))).toBe(true);
+    expect(isTimeoutError(new Error("connection reset by peer"))).toBe(false);
+    expect(isTimeoutError("timeout")).toBe(false);
   });
 
   test("outbound SSE parser normalizes lone CR and detects boundaries", () => {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -781,6 +781,13 @@ function isMissingSession(error: unknown): boolean {
   return false
 }
 
+function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  if (error.name === "TimeoutError") return true
+  if (error.message.toLowerCase().includes("timed out")) return true
+  return false
+}
+
 async function retry<T>(
   name: string,
   fn: () => Promise<T>,
@@ -1558,6 +1565,11 @@ async function runOutboundNotifications(runtime: Runtime) {
 
       await consumeOutboundEventStream(runtime, response.body)
     } catch (error) {
+      if (isTimeoutError(error)) {
+        console.info("[TelegramBridge] outbound event stream timed out, reconnecting")
+        await sleep(1500)
+        continue
+      }
       console.error("[TelegramBridge] outbound event stream error", error)
       await sleep(1500)
     }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -781,10 +781,13 @@ function isMissingSession(error: unknown): boolean {
   return false
 }
 
-function isTimeoutError(error: unknown): boolean {
+export function isTimeoutError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
   if (error.name === "TimeoutError") return true
-  if (error.message.toLowerCase().includes("timed out")) return true
+  if ("code" in error && error.code === "ETIMEDOUT") return true
+  const message = error.message.toLowerCase()
+  if (message.includes("timed out")) return true
+  if (message.includes("timeout")) return true
   return false
 }
 
@@ -1566,7 +1569,7 @@ async function runOutboundNotifications(runtime: Runtime) {
       await consumeOutboundEventStream(runtime, response.body)
     } catch (error) {
       if (isTimeoutError(error)) {
-        console.info("[TelegramBridge] outbound event stream timed out, reconnecting")
+        console.log("[TelegramBridge] outbound event stream timed out, reconnecting")
         await sleep(1500)
         continue
       }


### PR DESCRIPTION
## Summary
- classify outbound event stream `TimeoutError` as an expected reconnect path in the Telegram bridge
- log expected timeout reconnects at info level instead of error level to reduce noise
- keep non-timeout outbound stream failures logged as errors

## Validation
- bun test app-prefixable/tests/telegram-bridge.test.ts