### PR TITLE
fix: send immediate Telegram alerts for pending prompts

### DIFF
--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -1828,6 +1828,128 @@ describe("telegram bridge config and cache", () => {
     expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);
   });
 
+  test("permission.asked reuses stable request id for pending entries", async () => {
+    const pending = new Map<string, Array<{
+      id: string;
+      kind: "question" | "permission" | "task-finished";
+      sessionId: string;
+      text: string;
+      stampedAt: number;
+      resolved: boolean;
+    }>>();
+    const runtime = {
+      config: {
+        mode: "polling" as const,
+        token: "token",
+        openCodeUrl: "http://127.0.0.1:4096",
+        sessionCacheMax: 10,
+        sessionCacheTtlMs: 10_000,
+        notificationDebounceMs: 20_000,
+        port: 4097,
+        webhookPath: "/webhook",
+        sessionStorePath: "/tmp/test-store.json",
+      },
+      store: {
+        get: async () => undefined,
+        set: async () => undefined,
+        delete: async () => undefined,
+        sessionKeys: async () => ["chat:77:user:5"],
+        notificationGet: async () => false,
+        pendingGet: async (chatKey: string) => pending.get(chatKey) || [],
+        pendingSet: async (chatKey: string, items: Array<{
+          id: string;
+          kind: "question" | "permission" | "task-finished";
+          sessionId: string;
+          text: string;
+          stampedAt: number;
+          resolved: boolean;
+        }>) => {
+          pending.set(chatKey, [...items]);
+        },
+      },
+    };
+
+    await handleBridgeEvent(runtime, {
+      type: "permission.asked",
+      properties: {
+        id: "perm-request-1",
+        sessionID: "session-1",
+        permission: "shell",
+        patterns: ["docker *"],
+      },
+    });
+    await handleBridgeEvent(runtime, {
+      type: "permission.asked",
+      properties: {
+        id: "perm-request-1",
+        sessionID: "session-1",
+        permission: "shell",
+        patterns: ["kubectl *"],
+      },
+    });
+
+    const items = pending.get("chat:77") || [];
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toContain("perm-request-1");
+    expect(items[0]?.text).toContain("kubectl *");
+  });
+
+  test("question pending inbox text is truncated for oversized prompts", async () => {
+    const pending = new Map<string, Array<{
+      id: string;
+      kind: "question" | "permission" | "task-finished";
+      sessionId: string;
+      text: string;
+      stampedAt: number;
+      resolved: boolean;
+    }>>();
+    const runtime = {
+      config: {
+        mode: "polling" as const,
+        token: "token",
+        openCodeUrl: "http://127.0.0.1:4096",
+        sessionCacheMax: 10,
+        sessionCacheTtlMs: 10_000,
+        notificationDebounceMs: 20_000,
+        port: 4097,
+        webhookPath: "/webhook",
+        sessionStorePath: "/tmp/test-store.json",
+      },
+      store: {
+        get: async () => undefined,
+        set: async () => undefined,
+        delete: async () => undefined,
+        sessionKeys: async () => ["chat:77:user:5"],
+        notificationGet: async () => false,
+        pendingGet: async (chatKey: string) => pending.get(chatKey) || [],
+        pendingSet: async (chatKey: string, items: Array<{
+          id: string;
+          kind: "question" | "permission" | "task-finished";
+          sessionId: string;
+          text: string;
+          stampedAt: number;
+          resolved: boolean;
+        }>) => {
+          pending.set(chatKey, [...items]);
+        },
+      },
+    };
+
+    await handleBridgeEvent(runtime, {
+      type: "question.asked",
+      properties: {
+        id: "req-long-question",
+        sessionID: "session-1",
+        questions: [{ header: "Need confirmation ".repeat(30) }],
+      },
+    });
+
+    const text = pending.get("chat:77")?.[0]?.text || "";
+    expect(text.startsWith("Question pending:")).toBe(true);
+    expect(text.length).toBeLessThanOrEqual(240);
+    expect(text.endsWith("...")).toBe(true);
+  });
+
   test("question and permission events only queue pending when notifications are disabled", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -1828,6 +1828,182 @@ describe("telegram bridge config and cache", () => {
     expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);
   });
 
+  test("question and permission events only queue pending when notifications are disabled", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const inbox = new Map<string, Array<{
+      id: string;
+      kind: "question" | "permission" | "task-finished";
+      sessionId: string;
+      text: string;
+      stampedAt: number;
+      resolved: boolean;
+    }>>();
+    const pending = new Map<string, unknown[]>();
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => ["chat:77:user:5"],
+          notificationGet: async () => false,
+          pendingGet: async (chatKey: string) => inbox.get(chatKey) || [],
+          pendingSet: async (chatKey: string, items: Array<{
+            id: string;
+            kind: "question" | "permission" | "task-finished";
+            sessionId: string;
+            text: string;
+            stampedAt: number;
+            resolved: boolean;
+          }>) => {
+            inbox.set(chatKey, [...items]);
+          },
+          questionList: async (name: string) => (pending.get(name) || []) as unknown[],
+          questionUpsert: async (name: string, row: unknown) => {
+            pending.set(name, [row]);
+          },
+          questionDelete: async () => undefined,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-disabled",
+          sessionID: "session-1",
+          questions: [{ header: "Need approval", options: [{ label: "Yes" }, { label: "No" }] }],
+        },
+      });
+      await handleBridgeEvent(runtime, {
+        type: "permission.asked",
+        properties: {
+          sessionID: "session-1",
+          permission: "shell",
+          patterns: ["docker *"],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(false);
+    const items = inbox.get("chat:77") || [];
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);
+    const stored = (pending.get("chat:77:user:5") || []) as Array<{ requestId?: string }>;
+    expect(stored[0]?.requestId).toBe("req-disabled");
+  });
+
+  test("question and permission events notify immediately when enabled", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const inbox = new Map<string, Array<{
+      id: string;
+      kind: "question" | "permission" | "task-finished";
+      sessionId: string;
+      text: string;
+      stampedAt: number;
+      resolved: boolean;
+    }>>();
+    const pending = new Map<string, unknown[]>();
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => ["chat:88:user:9"],
+          notificationGet: async () => true,
+          pendingGet: async (chatKey: string) => inbox.get(chatKey) || [],
+          pendingSet: async (chatKey: string, items: Array<{
+            id: string;
+            kind: "question" | "permission" | "task-finished";
+            sessionId: string;
+            text: string;
+            stampedAt: number;
+            resolved: boolean;
+          }>) => {
+            inbox.set(chatKey, [...items]);
+          },
+          questionList: async (name: string) => (pending.get(name) || []) as unknown[],
+          questionUpsert: async (name: string, row: unknown) => {
+            pending.set(name, [row]);
+          },
+          questionDelete: async () => undefined,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-enabled",
+          sessionID: "session-1",
+          questions: [{ header: "Need approval", options: [{ label: "Yes" }, { label: "No" }] }],
+        },
+      });
+      await handleBridgeEvent(runtime, {
+        type: "permission.asked",
+        properties: {
+          sessionID: "session-1",
+          permission: "shell",
+          patterns: ["docker *"],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sent = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
+    expect(sent.some((text) => text.includes("Question pending:"))).toBe(true);
+    expect(sent.some((text) => text.includes("Permission request: shell"))).toBe(true);
+    const items = inbox.get("chat:88") || [];
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);
+  });
+
   test("/pending response is chunked under Telegram message limits", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
@@ -2046,6 +2222,15 @@ describe("telegram bridge config and cache", () => {
   test("handleBridgeEvent continues notifying other chats after one failure", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
+    const pending = new Map<string, Array<{
+      id: string;
+      kind: "question" | "permission" | "task-finished";
+      sessionId: string;
+      text: string;
+      stampedAt: number;
+      resolved: boolean;
+    }>>();
+    const queued = new Map<string, unknown[]>();
     try {
       globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
@@ -2078,6 +2263,22 @@ describe("telegram bridge config and cache", () => {
           delete: async () => undefined,
           sessionKeys: async () => ["chat:77:user:5", "chat:88:user:6"],
           notificationGet: async () => true,
+          pendingGet: async (chatKey: string) => pending.get(chatKey) || [],
+          pendingSet: async (chatKey: string, items: Array<{
+            id: string;
+            kind: "question" | "permission" | "task-finished";
+            sessionId: string;
+            text: string;
+            stampedAt: number;
+            resolved: boolean;
+          }>) => {
+            pending.set(chatKey, [...items]);
+          },
+          questionList: async (name: string) => (queued.get(name) || []) as unknown[],
+          questionUpsert: async (name: string, row: unknown) => {
+            queued.set(name, [row]);
+          },
+          questionDelete: async () => undefined,
         },
       };
 
@@ -2094,6 +2295,8 @@ describe("telegram bridge config and cache", () => {
 
     const messages = calls.filter((x) => x.url.includes("/sendMessage"));
     expect(messages.some((x) => x.body.chat_id === 88)).toBe(true);
+    expect((pending.get("chat:77") || []).length).toBe(1);
+    expect((pending.get("chat:88") || []).length).toBe(1);
   });
 
   test("handleBridgeEvent sends task-finished only on non-idle to idle transition", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -1894,6 +1894,80 @@ describe("telegram bridge config and cache", () => {
     expect(items[0]?.text).toContain("kubectl *");
   });
 
+  test("permission notifications debounce retries per request id only", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 60_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => ["chat:77:user:5"],
+          notificationGet: async () => true,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "permission.asked",
+        properties: {
+          id: "perm-a",
+          sessionID: "session-same",
+          permission: "shell",
+          patterns: ["docker *"],
+        },
+      });
+      await handleBridgeEvent(runtime, {
+        type: "permission.asked",
+        properties: {
+          id: "perm-a",
+          sessionID: "session-same",
+          permission: "shell",
+          patterns: ["docker *"],
+        },
+      });
+      await handleBridgeEvent(runtime, {
+        type: "permission.asked",
+        properties: {
+          id: "perm-b",
+          sessionID: "session-same",
+          permission: "shell",
+          patterns: ["kubectl *"],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sentTexts = calls
+      .filter((x) => x.url.includes("/sendMessage"))
+      .map((x) => String(x.body.text || ""));
+    expect(sentTexts).toHaveLength(2);
+    expect(sentTexts[0]).toContain("docker *");
+    expect(sentTexts[1]).toContain("kubectl *");
+  });
+
   test("question pending inbox text is truncated for oversized prompts", async () => {
     const pending = new Map<string, Array<{
       id: string;
@@ -4037,6 +4111,99 @@ describe("telegram bridge config and cache", () => {
       .map((x) => String(x.body.text || ""));
     expect(sentTexts.filter((text) => text.includes("Question pending:")).length).toBe(2);
     expect((pending.get("chat:77:user:5") || []).map((row) => row.requestId)).toEqual(["req-a", "req-b"]);
+  });
+
+  test("question fallback notifications debounce per request id and refresh pending entries", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const pending = new Map<string, Array<{
+      id: string;
+      kind: "question" | "permission" | "task-finished";
+      sessionId: string;
+      text: string;
+      stampedAt: number;
+      resolved: boolean;
+    }>>();
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 60_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => ["chat:77:user:5"],
+          notificationGet: async () => true,
+          pendingGet: async (chatKey: string) => pending.get(chatKey) || [],
+          pendingSet: async (chatKey: string, items: Array<{
+            id: string;
+            kind: "question" | "permission" | "task-finished";
+            sessionId: string;
+            text: string;
+            stampedAt: number;
+            resolved: boolean;
+          }>) => {
+            pending.set(chatKey, [...items]);
+          },
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-fallback-a",
+          sessionID: "session-fallback",
+          questions: [],
+        },
+      });
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-fallback-a",
+          sessionID: "session-fallback",
+          questions: [],
+        },
+      });
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-fallback-b",
+          sessionID: "session-fallback",
+          questions: [],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sentTexts = calls
+      .filter((x) => x.url.includes("/sendMessage"))
+      .map((x) => String(x.body.text || ""));
+    expect(sentTexts).toHaveLength(2);
+
+    const items = pending.get("chat:77") || [];
+    expect(items).toHaveLength(2);
+    expect(items.filter((item) => item.id.includes("req-fallback-a"))).toHaveLength(1);
+    expect(items.filter((item) => item.id.includes("req-fallback-b"))).toHaveLength(1);
   });
 
   test("pending question queues are scoped per chat and user", async () => {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1749,19 +1749,27 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
   }
 }
 
-async function notifySessionKeys(runtime: Runtime, sessionId: string, kind: string, text: string, requestId?: string) {
+async function notifySessionKeys(
+  runtime: Runtime,
+  sessionId: string,
+  kind: "question" | "permission" | "task-finished",
+  text: string,
+  requestId?: string,
+  notifyKind?: string,
+) {
   if (!runtime.store.sessionKeys) return
+  const dedupeKey = notifyKind || kind
   const keys = await runtime.store.sessionKeys(sessionId)
   const chats = new Set<number>()
-  for (const key of keys) {
+  for (const mapKey of keys) {
     try {
-      const parsed = parseTelegramKey(key)
+      const parsed = parseTelegramKey(mapKey)
       if (!parsed) continue
       if (!chats.has(parsed.chatId)) {
         chats.add(parsed.chatId)
         const entry: TelegramPendingItem = {
           id: pendingEntryId(sessionId, kind, parsed.chatId, requestId),
-          kind: kind === "task-finished" ? "task-finished" : kind === "permission" ? "permission" : "question",
+          kind,
           sessionId,
           text,
           stampedAt: Date.now(),
@@ -1773,14 +1781,14 @@ async function notifySessionKeys(runtime: Runtime, sessionId: string, kind: stri
         }
       }
       if (!(await notificationEnabled(runtime, notificationKey(parsed.chatId)))) continue
-      if (!shouldNotify(runtime.config, parsed.chatId, kind, sessionId)) continue
+      if (!shouldNotify(runtime.config, parsed.chatId, dedupeKey, sessionId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId)}`
       await queueChatUpdate(String(parsed.chatId), async () => {
         await sendTelegramMessage(runtime.config, parsed.chatId, message)
       })
-      stampNotification(parsed.chatId, kind, sessionId)
+      stampNotification(parsed.chatId, dedupeKey, sessionId)
     } catch (error) {
-      console.error("[TelegramBridge] outbound notify failed", { sessionId, key, kind, error })
+      console.error("[TelegramBridge] outbound notify failed", { sessionId, key: mapKey, kind, error })
     }
   }
 }
@@ -1881,7 +1889,16 @@ export async function handleBridgeEvent(runtime: Runtime, event: { type: string;
   if (event.type === "question.asked") {
     const pending = parsePendingQuestion(event.properties)
     if (!pending) {
-      await notifySessionKeys(runtime, sessionId, "question", `Question pending: ${questionText(event.properties)}`)
+      const requestId = typeof event.properties.id === "string" ? event.properties.id.trim() : ""
+      const notifyKind = requestId ? `question:${requestId}` : undefined
+      await notifySessionKeys(
+        runtime,
+        sessionId,
+        "question",
+        `Question pending: ${questionText(event.properties)}`,
+        requestId || undefined,
+        notifyKind,
+      )
       return
     }
     await notifyQuestion(runtime, sessionId, pending)
@@ -1889,7 +1906,8 @@ export async function handleBridgeEvent(runtime: Runtime, event: { type: string;
   }
   if (event.type === "permission.asked") {
     const requestId = typeof event.properties.id === "string" ? event.properties.id.trim() : ""
-    await notifySessionKeys(runtime, sessionId, "permission", permissionText(event.properties), requestId || undefined)
+    const notifyKind = requestId ? `permission:${requestId}` : undefined
+    await notifySessionKeys(runtime, sessionId, "permission", permissionText(event.properties), requestId || undefined, notifyKind)
     return
   }
   if (event.type !== "session.status") return

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -152,6 +152,7 @@ const startedAt = Date.now()
 const pendingRetentionMs = 3 * 24 * 60 * 60 * 1000
 const pendingMaxItems = 60
 const pendingDigestMax = 8
+const pendingTextMax = 240
 const sessionHistoryMax = 12
 const callbackIdLength = 24
 const callbackAckText = "Sending answer..."
@@ -441,7 +442,10 @@ function pendingEntryId(sessionId: string, kind: string, chatId: number, request
 function pendingQuestionText(question: TelegramPendingQuestion): string {
   const row = question.questions[0]
   const title = row?.header || row?.question || "The assistant is waiting for your answer."
-  return `Question pending: ${title}`
+  const text = `Question pending: ${title}`
+  if (text.length <= pendingTextMax) return text
+  if (pendingTextMax <= 3) return text.slice(0, pendingTextMax)
+  return `${text.slice(0, pendingTextMax - 3)}...`
 }
 
 async function resolvePendingForSession(runtime: Runtime, chatId: number, sessionId: string) {
@@ -1745,7 +1749,7 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
   }
 }
 
-async function notifySessionKeys(runtime: Runtime, sessionId: string, kind: string, text: string) {
+async function notifySessionKeys(runtime: Runtime, sessionId: string, kind: string, text: string, requestId?: string) {
   if (!runtime.store.sessionKeys) return
   const keys = await runtime.store.sessionKeys(sessionId)
   const chats = new Set<number>()
@@ -1756,7 +1760,7 @@ async function notifySessionKeys(runtime: Runtime, sessionId: string, kind: stri
       if (!chats.has(parsed.chatId)) {
         chats.add(parsed.chatId)
         const entry: TelegramPendingItem = {
-          id: pendingEntryId(sessionId, kind, parsed.chatId),
+          id: pendingEntryId(sessionId, kind, parsed.chatId, requestId),
           kind: kind === "task-finished" ? "task-finished" : kind === "permission" ? "permission" : "question",
           sessionId,
           text,
@@ -1884,7 +1888,8 @@ export async function handleBridgeEvent(runtime: Runtime, event: { type: string;
     return
   }
   if (event.type === "permission.asked") {
-    await notifySessionKeys(runtime, sessionId, "permission", permissionText(event.properties))
+    const requestId = typeof event.properties.id === "string" ? event.properties.id.trim() : ""
+    await notifySessionKeys(runtime, sessionId, "permission", permissionText(event.properties), requestId || undefined)
     return
   }
   if (event.type !== "session.status") return

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -430,6 +430,20 @@ async function appendPending(runtime: Runtime, chatId: number, entry: TelegramPe
   })
 }
 
+function pendingEntryId(sessionId: string, kind: string, chatId: number, requestId?: string): string {
+  const base = requestId?.trim()
+  if (base) return `${sessionId}:${kind}:${base}:${chatId}`
+  const seq = String(pendingEntrySeq).padStart(8, "0")
+  pendingEntrySeq += 1
+  return `${sessionId}:${kind}:${Date.now()}:${seq}:${chatId}`
+}
+
+function pendingQuestionText(question: TelegramPendingQuestion): string {
+  const row = question.questions[0]
+  const title = row?.header || row?.question || "The assistant is waiting for your answer."
+  return `Question pending: ${title}`
+}
+
 async function resolvePendingForSession(runtime: Runtime, chatId: number, sessionId: string) {
   await queueChatUpdate(`pending:${chatId}`, async () => {
     const key = pendingChatKey(chatId)
@@ -1741,16 +1755,14 @@ async function notifySessionKeys(runtime: Runtime, sessionId: string, kind: stri
       if (!parsed) continue
       if (!chats.has(parsed.chatId)) {
         chats.add(parsed.chatId)
-        const seq = String(pendingEntrySeq).padStart(8, "0")
         const entry: TelegramPendingItem = {
-          id: `${sessionId}:${kind}:${Date.now()}:${seq}:${parsed.chatId}`,
+          id: pendingEntryId(sessionId, kind, parsed.chatId),
           kind: kind === "task-finished" ? "task-finished" : kind === "permission" ? "permission" : "question",
           sessionId,
           text,
           stampedAt: Date.now(),
           resolved: kind === "task-finished",
         }
-        pendingEntrySeq += 1
         await appendPending(runtime, parsed.chatId, entry)
         if (kind === "task-finished") {
           await resolvePendingForSession(runtime, parsed.chatId, sessionId)
@@ -1773,13 +1785,25 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, question: Tel
   if (!runtime.store.sessionKeys) return
   const keys = await runtime.store.sessionKeys(sessionId)
   const kind = `question:${question.requestId}`
+  const chats = new Set<number>()
   for (const key of keys) {
     try {
       const parsed = parseTelegramKey(key)
       if (!parsed) continue
+      await upsertPendingQuestion(runtime, key, question)
+      if (!chats.has(parsed.chatId)) {
+        chats.add(parsed.chatId)
+        await appendPending(runtime, parsed.chatId, {
+          id: pendingEntryId(sessionId, "question", parsed.chatId, question.requestId),
+          kind: "question",
+          sessionId,
+          text: pendingQuestionText(question),
+          stampedAt: Date.now(),
+          resolved: false,
+        })
+      }
       if (!(await notificationEnabled(runtime, notificationKey(parsed.chatId)))) continue
       if (!shouldNotify(runtime.config, parsed.chatId, kind, sessionId)) continue
-      await upsertPendingQuestion(runtime, key, question)
       await queueChatUpdate(String(parsed.chatId), async () => {
         await sendTelegramQuestionPrompt(runtime.config, parsed.chatId, question)
         await sendTelegramMessage(runtime.config, parsed.chatId, `Open ${sessionLabel(runtime.config, sessionId)}`)


### PR DESCRIPTION
Closes #301

## Summary
- always persist question and permission pending entries for mapped chats, even when Telegram notifications are disabled
- send immediate Telegram alerts for question and permission events when notifications are enabled, while keeping debounce/dedupe behavior
- add tests for enabled/disabled notification behavior and pending fallback retention when send attempts fail