### PR TITLE
fix: align Telegram saved prompts with active session context

### DIFF
--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -817,6 +817,194 @@ describe("telegram bridge config and cache", () => {
     expect(calls.some((x) => x.url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a"))).toBe(true);
   });
 
+  test("/prompts falls back to configured directory when mapped directory is rejected", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a")) {
+          return new Response("forbidden", { status: 403 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-1", title: "Global backup", text: "Global", createdAt: 10 }],
+              project: [{ id: "p-2", title: "Project fallback", text: "Project", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompts", chat: { id: 93 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const promptCalls = calls.filter((x) => x.url.includes("/api/ext/saved-prompts")).map((x) => x.url);
+    expect(promptCalls[0]).toContain("directory=%2Fworkspace%2Fproject-a");
+    expect(promptCalls[1]).toContain("directory=%2Fworkspace%2Fproject-b");
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toContain("Project fallback [project] (p-2)");
+  });
+
+  test("/prompt falls back to global prompts when mapped and configured directories are rejected", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a")) {
+          return new Response("forbidden", { status: 403 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b")) {
+          return new Response("forbidden", { status: 403 });
+        }
+        if (url.endsWith("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-1", title: "Global fallback", text: "Run global plan", createdAt: 10 }],
+              project: [],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/session/session-current/message")) {
+          return new Response(JSON.stringify({ parts: [{ type: "text", text: "Global prompt complete." }] }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompt Global fallback", chat: { id: 94 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const promptCalls = calls.filter((x) => x.url.includes("/api/ext/saved-prompts")).map((x) => x.url);
+    expect(promptCalls[0]).toContain("directory=%2Fworkspace%2Fproject-a");
+    expect(promptCalls[1]).toContain("directory=%2Fworkspace%2Fproject-b");
+    expect(promptCalls[2]).toBe("http://127.0.0.1:4096/api/ext/saved-prompts");
+    const runCall = calls.find((x) => x.url.includes("/session/session-current/message"));
+    expect(runCall?.body.parts).toEqual([{ type: "text", text: "Run global plan" }]);
+  });
+
+  test("/prompts returns actionable guidance when saved prompts access is rejected", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response("forbidden", { status: 403 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompts", chat: { id: 95 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toContain("OpenCode rejected saved prompts access");
+    expect(text).not.toContain("internal error");
+  });
+
   test("/prompts empty-state message reflects merged prompt list", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -755,6 +755,68 @@ describe("telegram bridge config and cache", () => {
     expect(text.indexOf("Project dated [project] (p-1)")).toBeLessThan(text.indexOf("Global fallback [global] (g-1)"));
   });
 
+  test("/prompts resolves project prompts from the mapped session directory", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts")) {
+          const value = new URL(url).searchParams.get("directory");
+          if (value !== "/workspace/project-a") {
+            return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+          }
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-1", title: "Global prompt", text: "Global", createdAt: 10 }],
+              project: [{ id: "p-1", title: "Project deploy", text: "Deploy", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompts", chat: { id: 91 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toContain("Project deploy [project] (p-1)");
+    expect(calls.some((x) => x.url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a"))).toBe(true);
+  });
+
   test("/prompts empty-state message reflects merged prompt list", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
@@ -800,7 +862,9 @@ describe("telegram bridge config and cache", () => {
     }
 
     const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
-    expect(text).toBe("No saved prompts found. Create one in the web UI, then run /prompts again.");
+    expect(text).toBe(
+      "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings.",
+    );
   });
 
   test("/prompt runs a saved prompt and returns assistant response", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -926,6 +926,79 @@ describe("telegram bridge config and cache", () => {
     expect(sent).toBe("Deployment complete.");
   });
 
+  test("/prompt resolves prompt list from mapped session directory", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts")) {
+          const value = new URL(url).searchParams.get("directory");
+          if (value !== "/workspace/project-a") {
+            return new Response(
+              JSON.stringify({
+                global: [{ id: "g-1", title: "Global fallback", text: "Global", createdAt: 10 }],
+                project: [],
+              }),
+              { status: 200 },
+            );
+          }
+          return new Response(
+            JSON.stringify({
+              global: [],
+              project: [{ id: "p-1", title: "Project deploy", text: "Deploy from mapped context", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/session/session-current/message")) {
+          return new Response(JSON.stringify({ parts: [{ type: "text", text: "Project deployment complete." }] }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompt Project deploy", chat: { id: 92 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a"))).toBe(true);
+    expect(calls.some((x) => x.url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b"))).toBe(false);
+    const runCall = calls.find((x) => x.url.includes("/session/session-current/message"));
+    expect(runCall?.body.parts).toEqual([{ type: "text", text: "Deploy from mapped context" }]);
+  });
+
   test("/prompt returns actionable guidance for unknown names", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1478,10 +1478,44 @@ function mergeSavedPrompts(globalPrompts: SavedPrompt[], projectPrompts: SavedPr
     })
 }
 
-async function savedPrompts(config: BridgeConfig): Promise<SavedPrompt[]> {
+function sessionDirectoryFromPayload(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== "object") return
+  const row = raw as { directory?: unknown; info?: unknown }
+  const direct = typeof row.directory === "string" ? row.directory.trim() : ""
+  if (direct) return direct
+  if (!row.info || typeof row.info !== "object") return
+  const info = row.info as { directory?: unknown }
+  const nested = typeof info.directory === "string" ? info.directory.trim() : ""
+  if (nested) return nested
+}
+
+async function sessionDirectory(config: BridgeConfig, sessionId: string): Promise<string | undefined> {
+  const id = sessionId.trim()
+  if (!id) return
+  const lookup = async (withConfiguredDirectory: boolean) => {
+    const url = opencodeUrl(config, `/session/${encodeURIComponent(id)}`)
+    if (withConfiguredDirectory && config.directory) {
+      url.searchParams.set("directory", config.directory)
+    }
+    const res = await fetch(url, {
+      method: "GET",
+      signal: AbortSignal.timeout(12_000),
+    }).catch(() => undefined)
+    if (!res?.ok) return
+    const data = await res.json().catch(() => ({}))
+    return sessionDirectoryFromPayload(data)
+  }
+
+  const first = await lookup(true)
+  if (first) return first
+  if (!config.directory) return
+  return lookup(false)
+}
+
+async function savedPromptsForDirectory(config: BridgeConfig, directory?: string) {
   const url = opencodeUrl(config, "/api/ext/saved-prompts")
-  if (config.directory) {
-    url.searchParams.set("directory", config.directory)
+  if (directory) {
+    url.searchParams.set("directory", directory)
   }
   const res = await fetch(url, {
     method: "GET",
@@ -1492,9 +1526,32 @@ async function savedPrompts(config: BridgeConfig): Promise<SavedPrompt[]> {
     throw new Error(`OpenCode saved prompts failed (${res.status}): ${body.slice(0, 300)}`)
   }
   const data = await res.json().catch(() => ({})) as { global?: unknown; project?: unknown }
-  const global = parseSavedPromptList(data.global, "global")
-  const project = parseSavedPromptList(data.project, "project")
-  return mergeSavedPrompts(global, project)
+  return {
+    global: parseSavedPromptList(data.global, "global"),
+    project: parseSavedPromptList(data.project, "project"),
+  }
+}
+
+async function savedPrompts(runtime: Runtime, key: string): Promise<{ prompts: SavedPrompt[]; guidance?: string }> {
+  const config = runtime.config
+  const current = await runtime.store.get(key) || sessionFromCache(config, key)
+  const bySession = current ? await sessionDirectory(config, current) : undefined
+  const resolved = bySession || config.directory
+  const scoped = await savedPromptsForDirectory(config, resolved)
+  const merged = mergeSavedPrompts(scoped.global, scoped.project)
+  if (merged.length) {
+    return { prompts: merged }
+  }
+  if (resolved) {
+    return {
+      prompts: [],
+      guidance: "No saved prompts found for this context. If prompts exist in another project, run /status in that project first or configure Telegram directory in bridge settings.",
+    }
+  }
+  return {
+    prompts: [],
+    guidance: "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings.",
+  }
 }
 
 function promptScope(scope: SavedPrompt["scope"]): string {
@@ -1506,9 +1563,9 @@ function promptChoice(prompt: SavedPrompt, index: number): string {
   return `${index + 1}. ${prompt.title} [${promptScope(prompt.scope)}] (${prompt.id})`
 }
 
-function promptsListText(prompts: SavedPrompt[]): string {
+function promptsListText(prompts: SavedPrompt[], guidance?: string): string {
   if (!prompts.length) {
-    return "No saved prompts found. Create one in the web UI, then run /prompts again."
+    return guidance || "No saved prompts found. Create one in the web UI, then run /prompts again."
   }
   const shown = prompts.slice(0, 25)
   const lines = shown.map(promptChoice)
@@ -1928,8 +1985,8 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
       return true
     }
     if (known?.name === "prompts") {
-      const prompts = await savedPrompts(config)
-      await sendTelegramMessage(config, chatId, promptsListText(prompts))
+      const list = await savedPrompts(runtime, key)
+      await sendTelegramMessage(config, chatId, promptsListText(list.prompts, list.guidance))
       return true
     }
     if (known?.name === "prompt") {
@@ -1938,8 +1995,12 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
         await sendTelegramMessage(config, chatId, "Usage: /prompt <name|id>")
         return true
       }
-      const prompts = await savedPrompts(config)
-      const resolved = lookupSavedPrompt(target, prompts)
+      const list = await savedPrompts(runtime, key)
+      if (!list.prompts.length && list.guidance) {
+        await sendTelegramMessage(config, chatId, list.guidance)
+        return true
+      }
+      const resolved = lookupSavedPrompt(target, list.prompts)
       if (resolved.error) {
         await sendTelegramMessage(config, chatId, resolved.error)
         return true

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1532,25 +1532,64 @@ async function savedPromptsForDirectory(config: BridgeConfig, directory?: string
   }
 }
 
+function savedPromptsStatus(error: unknown): number | undefined {
+  if (!(error instanceof Error)) return
+  const match = error.message.match(/^OpenCode saved prompts failed \((\d+)\):/)
+  if (!match) return
+  const status = Number.parseInt(match[1] || "", 10)
+  if (!Number.isFinite(status)) return
+  return status
+}
+
+function savedPromptsFailureGuidance(status: number | undefined, directory?: string): string {
+  if (status === 403 && directory) {
+    return `OpenCode rejected saved prompts access for directory ${directory} (HTTP 403). Run /status in a session mapped to the right project, or update Telegram directory in bridge settings.`
+  }
+  if (status === 403) {
+    return "OpenCode rejected saved prompts access (HTTP 403). Check bridge permissions, then run /prompts again."
+  }
+  if (directory) {
+    return `Saved prompts for directory ${directory} are temporarily unavailable. Try /prompts again, or run /status to verify your active session mapping.`
+  }
+  return "Saved prompts are temporarily unavailable. Try /prompts again in a moment."
+}
+
 async function savedPrompts(runtime: Runtime, key: string): Promise<{ prompts: SavedPrompt[]; guidance?: string }> {
   const config = runtime.config
   const current = await runtime.store.get(key) || sessionFromCache(config, key)
   const bySession = current ? await sessionDirectory(config, current) : undefined
-  const resolved = bySession || config.directory
-  const scoped = await savedPromptsForDirectory(config, resolved)
-  const merged = mergeSavedPrompts(scoped.global, scoped.project)
-  if (merged.length) {
-    return { prompts: merged }
-  }
-  if (resolved) {
+  const candidates = [bySession, config.directory]
+    .filter((value): value is string => Boolean(value))
+    .filter((value, index, list) => list.indexOf(value) === index)
+  const contexts = [...candidates, undefined]
+  let fallbackGuidance: string | undefined
+
+  for (const directory of contexts) {
+    const scoped = await savedPromptsForDirectory(config, directory).catch((error) => {
+      const status = savedPromptsStatus(error)
+      fallbackGuidance = savedPromptsFailureGuidance(status, directory)
+      return
+    })
+    if (!scoped) continue
+    const merged = mergeSavedPrompts(scoped.global, scoped.project)
+    if (merged.length) {
+      return { prompts: merged }
+    }
+    if (directory) {
+      return {
+        prompts: [],
+        guidance: "No saved prompts found for this context. If prompts exist in another project, run /status in that project first or configure Telegram directory in bridge settings.",
+      }
+    }
     return {
       prompts: [],
-      guidance: "No saved prompts found for this context. If prompts exist in another project, run /status in that project first or configure Telegram directory in bridge settings.",
+      guidance: fallbackGuidance || "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings.",
     }
   }
+
   return {
     prompts: [],
-    guidance: "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings.",
+    guidance: fallbackGuidance || "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings.",
   }
 }
 


### PR DESCRIPTION
## Summary
- resolve Telegram saved prompt lookups using the mapped session directory when available, with fallback to configured bridge directory
- update /prompts and /prompt to return actionable guidance when context is missing or points to the wrong project scope
- add regression coverage for session-scoped prompt resolution and updated empty-state guidance

Closes #316