### PR TITLE
fix: continue telegram prompt fallback after empty mapped context

### DIFF
--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -1084,6 +1084,70 @@ describe("telegram bridge config and cache", () => {
     expect(runCall?.body.parts).toEqual([{ type: "text", text: "Run global plan" }]);
   });
 
+  test("/prompts returns no-prompts guidance when any context lookup succeeded", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a")) {
+          return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b")) {
+          return new Response("unavailable", { status: 503 });
+        }
+        if (url.endsWith("/api/ext/saved-prompts")) {
+          return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompts", chat: { id: 95 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const promptCalls = calls.filter((x) => x.url.includes("/api/ext/saved-prompts")).map((x) => x.url);
+    expect(promptCalls[0]).toContain("directory=%2Fworkspace%2Fproject-a");
+    expect(promptCalls[1]).toContain("directory=%2Fworkspace%2Fproject-b");
+    expect(promptCalls[2]).toBe("http://127.0.0.1:4096/api/ext/saved-prompts");
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toBe(
+      "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings.",
+    );
+  });
+
   test("/prompts returns actionable guidance when saved prompts access is rejected", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -817,6 +817,70 @@ describe("telegram bridge config and cache", () => {
     expect(calls.some((x) => x.url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a"))).toBe(true);
   });
 
+  test("/prompts falls back when mapped directory has no saved prompts", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a")) {
+          return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-1", title: "Global backup", text: "Global", createdAt: 10 }],
+              project: [{ id: "p-2", title: "Project fallback", text: "Project", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompts", chat: { id: 96 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const promptCalls = calls.filter((x) => x.url.includes("/api/ext/saved-prompts")).map((x) => x.url);
+    expect(promptCalls[0]).toContain("directory=%2Fworkspace%2Fproject-a");
+    expect(promptCalls[1]).toContain("directory=%2Fworkspace%2Fproject-b");
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toContain("Project fallback [project] (p-2)");
+  });
+
   test("/prompts falls back to configured directory when mapped directory is rejected", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
@@ -1185,6 +1249,73 @@ describe("telegram bridge config and cache", () => {
     expect(calls.some((x) => x.url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b"))).toBe(false);
     const runCall = calls.find((x) => x.url.includes("/session/session-current/message"));
     expect(runCall?.body.parts).toEqual([{ type: "text", text: "Deploy from mapped context" }]);
+  });
+
+  test("/prompt falls back when mapped directory has no saved prompts", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a")) {
+          return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b")) {
+          return new Response(
+            JSON.stringify({
+              global: [],
+              project: [{ id: "p-2", title: "Project fallback", text: "Run fallback prompt", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/session/session-current/message")) {
+          return new Response(JSON.stringify({ parts: [{ type: "text", text: "Fallback prompt complete." }] }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompt Project fallback", chat: { id: 97 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const promptCalls = calls.filter((x) => x.url.includes("/api/ext/saved-prompts")).map((x) => x.url);
+    expect(promptCalls[0]).toContain("directory=%2Fworkspace%2Fproject-a");
+    expect(promptCalls[1]).toContain("directory=%2Fworkspace%2Fproject-b");
+    const runCall = calls.find((x) => x.url.includes("/session/session-current/message"));
+    expect(runCall?.body.parts).toEqual([{ type: "text", text: "Run fallback prompt" }]);
   });
 
   test("/prompt returns actionable guidance for unknown names", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -945,6 +945,74 @@ describe("telegram bridge config and cache", () => {
     expect(text).toContain("Project fallback [project] (p-2)");
   });
 
+  test("/prompts falls back to global prompts when mapped and configured directories are empty", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a")) {
+          return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b")) {
+          return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+        }
+        if (url.endsWith("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-9", title: "Global rescue", text: "Run global rescue", createdAt: 10 }],
+              project: [],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompts", chat: { id: 98 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const promptCalls = calls.filter((x) => x.url.includes("/api/ext/saved-prompts")).map((x) => x.url);
+    expect(promptCalls[0]).toContain("directory=%2Fworkspace%2Fproject-a");
+    expect(promptCalls[1]).toContain("directory=%2Fworkspace%2Fproject-b");
+    expect(promptCalls[2]).toBe("http://127.0.0.1:4096/api/ext/saved-prompts");
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toContain("Global rescue [global] (g-9)");
+  });
+
   test("/prompt falls back to global prompts when mapped and configured directories are rejected", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
@@ -1316,6 +1384,77 @@ describe("telegram bridge config and cache", () => {
     expect(promptCalls[1]).toContain("directory=%2Fworkspace%2Fproject-b");
     const runCall = calls.find((x) => x.url.includes("/session/session-current/message"));
     expect(runCall?.body.parts).toEqual([{ type: "text", text: "Run fallback prompt" }]);
+  });
+
+  test("/prompt falls back to global prompts when mapped and configured directories are empty", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-a")) {
+          return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts?directory=%2Fworkspace%2Fproject-b")) {
+          return new Response(JSON.stringify({ global: [], project: [] }), { status: 200 });
+        }
+        if (url.endsWith("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-9", title: "Global rescue", text: "Run global rescue", createdAt: 10 }],
+              project: [],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/session/session-current/message")) {
+          return new Response(JSON.stringify({ parts: [{ type: "text", text: "Global rescue done." }] }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompt Global rescue", chat: { id: 99 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const promptCalls = calls.filter((x) => x.url.includes("/api/ext/saved-prompts")).map((x) => x.url);
+    expect(promptCalls[0]).toContain("directory=%2Fworkspace%2Fproject-a");
+    expect(promptCalls[1]).toContain("directory=%2Fworkspace%2Fproject-b");
+    expect(promptCalls[2]).toBe("http://127.0.0.1:4096/api/ext/saved-prompts");
+    const runCall = calls.find((x) => x.url.includes("/session/session-current/message"));
+    expect(runCall?.body.parts).toEqual([{ type: "text", text: "Run global rescue" }]);
   });
 
   test("/prompt returns actionable guidance for unknown names", async () => {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1575,16 +1575,6 @@ async function savedPrompts(runtime: Runtime, key: string): Promise<{ prompts: S
     if (merged.length) {
       return { prompts: merged }
     }
-    if (directory) {
-      return {
-        prompts: [],
-        guidance: "No saved prompts found for this context. If prompts exist in another project, run /status in that project first or configure Telegram directory in bridge settings.",
-      }
-    }
-    return {
-      prompts: [],
-      guidance: fallbackGuidance || "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings.",
-    }
   }
 
   return {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1556,6 +1556,7 @@ function savedPromptsFailureGuidance(status: number | undefined, directory?: str
 
 async function savedPrompts(runtime: Runtime, key: string): Promise<{ prompts: SavedPrompt[]; guidance?: string }> {
   const config = runtime.config
+  const noPromptsGuidance = "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings."
   const current = await runtime.store.get(key) || sessionFromCache(config, key)
   const bySession = current ? await sessionDirectory(config, current) : undefined
   const candidates = [bySession, config.directory]
@@ -1563,6 +1564,7 @@ async function savedPrompts(runtime: Runtime, key: string): Promise<{ prompts: S
     .filter((value, index, list) => list.indexOf(value) === index)
   const contexts = [...candidates, undefined]
   let fallbackGuidance: string | undefined
+  let hasSuccess = false
 
   for (const directory of contexts) {
     const scoped = await savedPromptsForDirectory(config, directory).catch((error) => {
@@ -1571,6 +1573,7 @@ async function savedPrompts(runtime: Runtime, key: string): Promise<{ prompts: S
       return
     })
     if (!scoped) continue
+    hasSuccess = true
     const merged = mergeSavedPrompts(scoped.global, scoped.project)
     if (merged.length) {
       return { prompts: merged }
@@ -1579,7 +1582,7 @@ async function savedPrompts(runtime: Runtime, key: string): Promise<{ prompts: S
 
   return {
     prompts: [],
-    guidance: fallbackGuidance || "No saved prompts found. If your prompts are project-scoped, run /status in the target project first or configure Telegram directory in bridge settings.",
+    guidance: hasSuccess ? noPromptsGuidance : fallbackGuidance || noPromptsGuidance,
   }
 }
 


### PR DESCRIPTION
## Summary
- continue saved prompt lookup through configured/global fallback contexts when a mapped session directory returns an empty prompt list
- preserve existing rejection/error guidance behavior while only returning no-prompts guidance after all contexts are exhausted
- add regression coverage for both `/prompts` listing and `/prompt` execution when the first context is empty and later fallback contexts contain prompts

Closes #322