### PR TITLE
feat: add inline /prompts and /notify buttons for Telegram

### DIFF
--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -702,6 +702,138 @@ describe("telegram bridge config and cache", () => {
     expect(text).toContain("Use /prompt <name|id> to run one.");
   });
 
+  test("/prompts includes inline buttons for quick prompt selection", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-1", title: "Quick summary", text: "Summarize", createdAt: 10 }],
+              project: [{ id: "p-1", title: "Deploy release", text: "Deploy", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 11,
+        message: { message_id: 11, text: "/prompts", chat: { id: 78 }, from: { id: 5 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sent = calls.find((x) => x.url.includes("/sendMessage"));
+    const markup = sent?.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined;
+    const first = markup?.inline_keyboard?.[0]?.[0]?.callback_data || "";
+    const second = markup?.inline_keyboard?.[1]?.[0]?.callback_data || "";
+    expect(first).toBe("p:p-1");
+    expect(second).toBe("p:g-1");
+  });
+
+  test("prompt callback runs the selected saved prompt", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const map = new Map<string, string>([["chat:79:user:6", "session-current"]]);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-1", title: "Quick summary", text: "Summarize now", createdAt: 10 }],
+              project: [{ id: "p-1", title: "Deploy release", text: "Deploy now", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/session-current/message")) {
+          return new Response(JSON.stringify({ parts: [{ type: "text", text: "Deploy complete." }] }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async (key: string) => map.get(key),
+          set: async (key: string, value: string) => {
+            map.set(key, value);
+          },
+          delete: async (key: string) => {
+            map.delete(key);
+          },
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 12,
+        callback_query: {
+          id: "cb-prompt-1",
+          data: "p:p-1",
+          from: { id: 6 },
+          message: { message_id: 12, chat: { id: 79 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const callbackAck = calls.find((x) => x.url.includes("/answerCallbackQuery"));
+    expect(String(callbackAck?.body.text || "")).toContain("Running prompt");
+    const promptRun = calls.find((x) => x.url.includes("/session/session-current/message"));
+    expect(promptRun?.body.parts).toEqual([{ type: "text", text: "Deploy now" }]);
+    const sentTexts = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
+    expect(sentTexts.some((text) => text.includes("Deploy complete."))).toBe(true);
+  });
+
   test("/prompts uses deterministic ordering when createdAt is invalid", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
@@ -1012,6 +1144,62 @@ describe("telegram bridge config and cache", () => {
     expect(promptCalls[2]).toBe("http://127.0.0.1:4096/api/ext/saved-prompts");
     const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
     expect(text).toContain("Global rescue [global] (g-9)");
+  });
+
+  test("/prompts reports endpoint guidance when saved-prompts returns non-JSON", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current") && !url.includes("/message")) {
+          return new Response(JSON.stringify({ id: "session-current", directory: "/workspace/project-a" }), { status: 200 });
+        }
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response("<!doctype html><html><body>Not JSON</body></html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+          directory: "/workspace/project-b",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/prompts", chat: { id: 98 }, from: { id: 6 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toContain("Saved prompts endpoint returned an unexpected response");
+    expect(text).toContain("/api/ext");
   });
 
   test("/prompt falls back to global prompts when mapped and configured directories are rejected", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -874,9 +874,9 @@ describe("telegram bridge config and cache", () => {
     const markup = sent?.body.reply_markup as { inline_keyboard?: Array<Array<{ text?: string; callback_data?: string }>> } | undefined;
     const first = markup?.inline_keyboard?.[0]?.[0];
     const second = markup?.inline_keyboard?.[1]?.[0];
-    expect(first?.text).toBe("1. First");
+    expect(first?.text).toBe("First");
     expect(first?.callback_data).toBe("p:p-1");
-    expect(second?.text).toBe("2. Third");
+    expect(second?.text).toBe("Third");
     expect(second?.callback_data).toBe("p:p-2");
   });
 

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -3553,6 +3553,131 @@ describe("telegram bridge config and cache", () => {
     }
   });
 
+  test("/notify status includes inline toggle buttons", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const notify = new Map<string, boolean>();
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          notificationGet: async (key: string) => notify.get(key) === true,
+          notificationSet: async (key: string, enabled: boolean) => {
+            if (enabled) {
+              notify.set(key, true);
+              return;
+            }
+            notify.delete(key);
+          },
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 8,
+        message: { message_id: 8, text: "/notify status", chat: { id: 81 }, from: { id: 5 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sent = calls.find((x) => x.url.includes("/sendMessage"));
+    expect(String(sent?.body.text || "")).toBe("Notifications are disabled.");
+    const markup = sent?.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined;
+    const top = markup?.inline_keyboard?.[0] || [];
+    expect(top.map((item) => item.callback_data)).toEqual(["n:on", "n:off"]);
+    expect(markup?.inline_keyboard?.[1]?.[0]?.callback_data).toBe("n:status");
+  });
+
+  test("notify callback toggles state and returns updated button state", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const notify = new Map<string, boolean>();
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          notificationGet: async (key: string) => notify.get(key) === true,
+          notificationSet: async (key: string, enabled: boolean) => {
+            if (enabled) {
+              notify.set(key, true);
+              return;
+            }
+            notify.delete(key);
+          },
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 82,
+        callback_query: {
+          id: "cb-notify-on",
+          data: "n:on",
+          from: { id: 5 },
+          message: { message_id: 7, chat: { id: 81 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/answerCallbackQuery") && String(x.body.text || "").includes("Updating notifications"))).toBe(true);
+    const sent = calls.find((x) => x.url.includes("/sendMessage"));
+    expect(String(sent?.body.text || "")).toBe("Notifications enabled for this chat.");
+    const markup = sent?.body.reply_markup as { inline_keyboard?: Array<Array<{ text?: string; callback_data?: string }>> } | undefined;
+    const top = markup?.inline_keyboard?.[0] || [];
+    expect(top.map((item) => item.callback_data)).toEqual(["n:on", "n:off"]);
+    expect((top[0]?.text || "").includes("✅")).toBe(true);
+  });
+
   test("/pending returns aggregated actionable items for the chat", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -760,6 +760,189 @@ describe("telegram bridge config and cache", () => {
     expect(second).toBe("p:g-1");
   });
 
+  test("/prompts accepts nested saved-prompts payload shapes", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: { prompts: [{ id: "g-1", title: "Quick summary", text: "Summarize", createdAt: 10 }] },
+              project: { prompts: [{ id: "p-1", title: "Deploy release", text: "Deploy", createdAt: 20 }] },
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 13,
+        message: { message_id: 13, text: "/prompts", chat: { id: 178 }, from: { id: 5 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toContain("Saved prompts:");
+    expect(text).toContain("Deploy release [project] (p-1)");
+    expect(text).toContain("Quick summary [global] (g-1)");
+  });
+
+  test("/prompts inline button numbering stays contiguous after invalid callback IDs are skipped", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [],
+              project: [
+                { id: "p-1", title: "First", text: "Run first", createdAt: 30 },
+                { id: "bad id", title: "Skipped", text: "Run skipped", createdAt: 20 },
+                { id: "p-2", title: "Third", text: "Run third", createdAt: 10 },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 14,
+        message: { message_id: 14, text: "/prompts", chat: { id: 179 }, from: { id: 5 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sent = calls.find((x) => x.url.includes("/sendMessage"));
+    const markup = sent?.body.reply_markup as { inline_keyboard?: Array<Array<{ text?: string; callback_data?: string }>> } | undefined;
+    const first = markup?.inline_keyboard?.[0]?.[0];
+    const second = markup?.inline_keyboard?.[1]?.[0];
+    expect(first?.text).toBe("1. First");
+    expect(first?.callback_data).toBe("p:p-1");
+    expect(second?.text).toBe("2. Third");
+    expect(second?.callback_data).toBe("p:p-2");
+  });
+
+  test("/prompts sends follow-up chunks when markup response exceeds Telegram limits", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const veryLong = "x".repeat(350);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [],
+              project: Array.from({ length: 25 }, (_, index) => ({
+                id: `p-${index + 1}`,
+                title: `Prompt ${index + 1} ${veryLong}`,
+                text: `Run ${index + 1}`,
+                createdAt: 1000 - index,
+              })),
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 15,
+        message: { message_id: 15, text: "/prompts", chat: { id: 180 }, from: { id: 5 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const messages = calls.filter((x) => x.url.includes("/sendMessage"));
+    expect(messages.length).toBeGreaterThan(1);
+    expect(messages[0]?.body.reply_markup).toBeDefined();
+    expect(messages.slice(1).every((item) => item.body.reply_markup === undefined)).toBe(true);
+    expect(String(messages[0]?.body.text || "").length).toBeLessThanOrEqual(3900);
+  });
+
   test("prompt callback runs the selected saved prompt", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -179,6 +179,7 @@ const sessionTitleInlineMax = 120
 const callbackIdLength = 24
 const callbackAckText = "Sending answer..."
 const promptCallbackAckText = "Running prompt..."
+const notifyCallbackAckText = "Updating notifications..."
 const inlineButtonMaxOptions = 20
 const inlineButtonTextMax = 48
 const callbackDataMax = 64
@@ -650,6 +651,10 @@ function promptCallbackData(promptId: string): string | undefined {
   return payload
 }
 
+function notifyCallbackData(mode: "on" | "off" | "status"): string {
+  return `n:${mode}`
+}
+
 function answeredQuestions(question: TelegramPendingQuestion): number {
   if (!question.answers.length) return 0
   return Math.min(question.questions.length, question.answers.length)
@@ -669,6 +674,7 @@ function activeQuestion(question: TelegramPendingQuestion): TelegramPendingQuest
 function parseCallbackData(input: string):
   | { kind: "question"; callbackId: string; questionIndex: number; optionIndex: number }
   | { kind: "prompt"; promptId: string }
+  | { kind: "notify"; mode: "on" | "off" | "status" }
   | undefined {
   const question = input.match(/^q:([a-z0-9]{6,24}):(\d+):(\d+)$/)
   if (question) {
@@ -685,10 +691,38 @@ function parseCallbackData(input: string):
   }
 
   const prompt = input.match(/^p:([A-Za-z0-9._:-]{1,62})$/)
-  if (!prompt) return
+  if (prompt) {
+    return {
+      kind: "prompt",
+      promptId: prompt[1] || "",
+    }
+  }
+
+  const notify = input.match(/^n:(on|off|status)$/)
+  if (!notify) return
   return {
-    kind: "prompt",
-    promptId: prompt[1] || "",
+    kind: "notify",
+    mode: (notify[1] as "on" | "off" | "status") || "status",
+  }
+}
+
+function notifyText(enabled: boolean, mode: "on" | "off" | "status"): string {
+  if (mode === "on") return "Notifications enabled for this chat."
+  if (mode === "off") return "Notifications disabled for this chat."
+  return enabled ? "Notifications are enabled." : "Notifications are disabled."
+}
+
+function notifyMarkup(enabled: boolean): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  const on = enabled ? "On ✅" : "On"
+  const off = enabled ? "Off" : "Off ✅"
+  return {
+    inline_keyboard: [
+      [
+        { text: on, callback_data: notifyCallbackData("on") },
+        { text: off, callback_data: notifyCallbackData("off") },
+      ],
+      [{ text: "Status", callback_data: notifyCallbackData("status") }],
+    ],
   }
 }
 
@@ -2166,6 +2200,21 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       return
     }
 
+    if (parsed.kind === "notify") {
+      const key = notificationKey(chatId)
+      await answerCallback(runtime.config, callbackId, notifyCallbackAckText)
+      state.acknowledged = true
+      if (parsed.mode === "on") {
+        await setNotificationEnabled(runtime, key, true)
+      }
+      if (parsed.mode === "off") {
+        await setNotificationEnabled(runtime, key, false)
+      }
+      const enabled = await notificationEnabled(runtime, key)
+      await sendTelegramMessageWithMarkup(runtime.config, chatId, notifyText(enabled, parsed.mode), notifyMarkup(enabled))
+      return
+    }
+
     if (parsed.kind === "prompt") {
       const key = telegramSessionKey(chatId, userId)
       await answerCallback(runtime.config, callbackId, promptCallbackAckText)
@@ -2376,17 +2425,19 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
       const notifyKey = notificationKey(chatId)
       if (mode === "on") {
         await setNotificationEnabled(runtime, notifyKey, true)
-        await sendTelegramMessage(config, chatId, "Notifications enabled for this chat.")
+        const enabled = await notificationEnabled(runtime, notifyKey)
+        await sendTelegramMessageWithMarkup(config, chatId, notifyText(enabled, "on"), notifyMarkup(enabled))
         return true
       }
       if (mode === "off") {
         await setNotificationEnabled(runtime, notifyKey, false)
-        await sendTelegramMessage(config, chatId, "Notifications disabled for this chat.")
+        const enabled = await notificationEnabled(runtime, notifyKey)
+        await sendTelegramMessageWithMarkup(config, chatId, notifyText(enabled, "off"), notifyMarkup(enabled))
         return true
       }
       if (mode === "status" || !mode) {
         const enabled = await notificationEnabled(runtime, notifyKey)
-        await sendTelegramMessage(config, chatId, enabled ? "Notifications are enabled." : "Notifications are disabled.")
+        await sendTelegramMessageWithMarkup(config, chatId, notifyText(enabled, "status"), notifyMarkup(enabled))
         return true
       }
       await sendTelegramMessage(config, chatId, "Usage: /notify on, /notify off, or /notify status")

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -690,11 +690,14 @@ function parseCallbackData(input: string):
     }
   }
 
-  const prompt = input.match(/^p:([A-Za-z0-9._:-]{1,62})$/)
-  if (prompt) {
+  if (input.startsWith("p:")) {
+    const promptId = input.slice(2)
+    if (!promptId) return
+    if (promptId.length > callbackDataMax - 2) return
+    if (!/^[A-Za-z0-9._:-]+$/.test(promptId)) return
     return {
       kind: "prompt",
-      promptId: prompt[1] || "",
+      promptId,
     }
   }
 

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1785,6 +1785,19 @@ function parseSavedPromptList(raw: unknown, scope: "global" | "project"): SavedP
     .filter((item) => item !== undefined) as SavedPrompt[]
 }
 
+function readSavedPromptArray(payload: Record<string, unknown>, field: "global" | "project"): unknown[] | undefined {
+  const direct = payload[field]
+  if (Array.isArray(direct)) return direct
+  if (direct && typeof direct === "object") {
+    const nested = (direct as { prompts?: unknown }).prompts
+    if (Array.isArray(nested)) return nested
+  }
+  const grouped = payload.prompts
+  if (!grouped || typeof grouped !== "object") return
+  const nested = (grouped as { global?: unknown; project?: unknown })[field]
+  if (Array.isArray(nested)) return nested
+}
+
 function mergeSavedPrompts(globalPrompts: SavedPrompt[], projectPrompts: SavedPrompt[]): SavedPrompt[] {
   const projectIds = new Set(projectPrompts.map((item) => item.id))
   const dedupedGlobal = globalPrompts.filter((item) => !projectIds.has(item.id))
@@ -1843,16 +1856,18 @@ async function savedPromptsForDirectory(config: BridgeConfig, directory?: string
     const body = await res.text().catch(() => "")
     throw new Error(`OpenCode saved prompts failed (${res.status}): ${body.slice(0, 300)}`)
   }
-  const data = await res.json().catch(() => undefined) as { global?: unknown; project?: unknown } | undefined
+  const data = await res.json().catch(() => undefined) as Record<string, unknown> | undefined
   if (!data || typeof data !== "object") {
     throw new Error("OpenCode saved prompts failed (invalid response): endpoint did not return JSON")
   }
-  if (!("global" in data) && !("project" in data)) {
+  const global = readSavedPromptArray(data, "global")
+  const project = readSavedPromptArray(data, "project")
+  if (!global || !project) {
     throw new Error("OpenCode saved prompts failed (invalid response): missing global/project arrays")
   }
   return {
-    global: parseSavedPromptList(data.global, "global"),
-    project: parseSavedPromptList(data.project, "project"),
+    global: parseSavedPromptList(global, "global"),
+    project: parseSavedPromptList(project, "project"),
   }
 }
 
@@ -1925,14 +1940,18 @@ function promptChoice(prompt: SavedPrompt, index: number): string {
 function promptsMarkup(prompts: SavedPrompt[]): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } | undefined {
   const rows = prompts
     .slice(0, inlineButtonMaxOptions)
-    .map((prompt, index) => {
+    .map((prompt) => {
       const callback = promptCallbackData(prompt.id)
       if (!callback) return
-      const label = `${index + 1}. ${prompt.title.trim()}`.slice(0, inlineButtonTextMax)
-      if (!label) return
-      return [{ text: label, callback_data: callback }]
+      const title = prompt.title.trim()
+      if (!title) return
+      return { title, callback_data: callback }
     })
     .filter((item) => item !== undefined)
+    .map((item, index) => [{
+      text: `${index + 1}. ${item.title}`.slice(0, inlineButtonTextMax),
+      callback_data: item.callback_data,
+    }])
   if (!rows.length) return
   return {
     inline_keyboard: rows as Array<Array<{ text: string; callback_data: string }>>,
@@ -2077,12 +2096,15 @@ async function sendTelegramMessageWithMarkup(
   text: string,
   markup: { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> },
 ) {
-  const safe = truncateTelegramText(text || "I could not produce a response.", telegramMessageSoftLimit)
-  await telegramRequest(config, "sendMessage", {
-    chat_id: chatId,
-    text: safe,
-    reply_markup: markup,
-  })
+  const safe = text || "I could not produce a response."
+  const parts = chunks(safe, telegramMessageSoftLimit)
+  for (const [i, part] of parts.entries()) {
+    await telegramRequest(config, "sendMessage", {
+      chat_id: chatId,
+      text: part,
+      ...(i === 0 ? { reply_markup: markup } : {}),
+    })
+  }
 }
 
 async function checkTelegramApi(config: BridgeConfig): Promise<BridgeHealthCheck> {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1883,7 +1883,7 @@ function savedPromptsStatus(error: unknown): number | undefined {
 function savedPromptsFailureGuidance(error: unknown, directory?: string): string {
   const status = savedPromptsStatus(error)
   if (error instanceof Error && error.message.includes("(invalid response):")) {
-    return "Saved prompts endpoint returned an unexpected response. Check Telegram bridge openCodeUrl and point it to the prokube.ai server that serves /api/ext endpoints."
+    return "Saved prompts endpoint returned an unexpected response. Check Telegram bridge openCodeUrl and point it to the OpenCode API server that exposes /api/ext endpoints."
   }
   if (status === 403 && directory) {
     return `OpenCode rejected saved prompts access for directory ${directory} (HTTP 403). Run /status in a session mapped to the right project, or update Telegram directory in bridge settings.`
@@ -1939,7 +1939,6 @@ function promptChoice(prompt: SavedPrompt, index: number): string {
 
 function promptsMarkup(prompts: SavedPrompt[]): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } | undefined {
   const rows = prompts
-    .slice(0, inlineButtonMaxOptions)
     .map((prompt) => {
       const callback = promptCallbackData(prompt.id)
       if (!callback) return
@@ -1948,8 +1947,9 @@ function promptsMarkup(prompts: SavedPrompt[]): { inline_keyboard: Array<Array<{
       return { title, callback_data: callback }
     })
     .filter((item) => item !== undefined)
-    .map((item, index) => [{
-      text: `${index + 1}. ${item.title}`.slice(0, inlineButtonTextMax),
+    .slice(0, inlineButtonMaxOptions)
+    .map((item) => [{
+      text: item.title.slice(0, inlineButtonTextMax),
       callback_data: item.callback_data,
     }])
   if (!rows.length) return

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -178,6 +178,7 @@ const recentPartTextMax = 500
 const sessionTitleInlineMax = 120
 const callbackIdLength = 24
 const callbackAckText = "Sending answer..."
+const promptCallbackAckText = "Running prompt..."
 const inlineButtonMaxOptions = 20
 const inlineButtonTextMax = 48
 const callbackDataMax = 64
@@ -640,6 +641,15 @@ function callbackData(question: TelegramPendingQuestion, questionIndex: number, 
   return `q:${question.callbackId}:${row}:${option}`
 }
 
+function promptCallbackData(promptId: string): string | undefined {
+  const clean = promptId.trim()
+  if (!clean) return
+  if (!/^[A-Za-z0-9._:-]+$/.test(clean)) return
+  const payload = `p:${clean}`
+  if (payload.length > callbackDataMax) return
+  return payload
+}
+
 function answeredQuestions(question: TelegramPendingQuestion): number {
   if (!question.answers.length) return 0
   return Math.min(question.questions.length, question.answers.length)
@@ -656,17 +666,29 @@ function activeQuestion(question: TelegramPendingQuestion): TelegramPendingQuest
   return question.questions[index]
 }
 
-function parseCallbackData(input: string): { callbackId: string; questionIndex: number; optionIndex: number } | undefined {
-  const match = input.match(/^q:([a-z0-9]{6,24}):(\d+):(\d+)$/)
-  if (!match) return
-  const questionIndex = Number.parseInt(match[2] || "", 10)
-  const optionIndex = Number.parseInt(match[3] || "", 10)
-  if (!Number.isFinite(questionIndex) || !Number.isFinite(optionIndex)) return
-  if (questionIndex < 1 || optionIndex < 1) return
+function parseCallbackData(input: string):
+  | { kind: "question"; callbackId: string; questionIndex: number; optionIndex: number }
+  | { kind: "prompt"; promptId: string }
+  | undefined {
+  const question = input.match(/^q:([a-z0-9]{6,24}):(\d+):(\d+)$/)
+  if (question) {
+    const questionIndex = Number.parseInt(question[2] || "", 10)
+    const optionIndex = Number.parseInt(question[3] || "", 10)
+    if (!Number.isFinite(questionIndex) || !Number.isFinite(optionIndex)) return
+    if (questionIndex < 1 || optionIndex < 1) return
+    return {
+      kind: "question",
+      callbackId: question[1] || "",
+      questionIndex: questionIndex - 1,
+      optionIndex: optionIndex - 1,
+    }
+  }
+
+  const prompt = input.match(/^p:([A-Za-z0-9._:-]{1,62})$/)
+  if (!prompt) return
   return {
-    callbackId: match[1] || "",
-    questionIndex: questionIndex - 1,
-    optionIndex: optionIndex - 1,
+    kind: "prompt",
+    promptId: prompt[1] || "",
   }
 }
 
@@ -1787,7 +1809,13 @@ async function savedPromptsForDirectory(config: BridgeConfig, directory?: string
     const body = await res.text().catch(() => "")
     throw new Error(`OpenCode saved prompts failed (${res.status}): ${body.slice(0, 300)}`)
   }
-  const data = await res.json().catch(() => ({})) as { global?: unknown; project?: unknown }
+  const data = await res.json().catch(() => undefined) as { global?: unknown; project?: unknown } | undefined
+  if (!data || typeof data !== "object") {
+    throw new Error("OpenCode saved prompts failed (invalid response): endpoint did not return JSON")
+  }
+  if (!("global" in data) && !("project" in data)) {
+    throw new Error("OpenCode saved prompts failed (invalid response): missing global/project arrays")
+  }
   return {
     global: parseSavedPromptList(data.global, "global"),
     project: parseSavedPromptList(data.project, "project"),
@@ -1803,7 +1831,11 @@ function savedPromptsStatus(error: unknown): number | undefined {
   return status
 }
 
-function savedPromptsFailureGuidance(status: number | undefined, directory?: string): string {
+function savedPromptsFailureGuidance(error: unknown, directory?: string): string {
+  const status = savedPromptsStatus(error)
+  if (error instanceof Error && error.message.includes("(invalid response):")) {
+    return "Saved prompts endpoint returned an unexpected response. Check Telegram bridge openCodeUrl and point it to the prokube.ai server that serves /api/ext endpoints."
+  }
   if (status === 403 && directory) {
     return `OpenCode rejected saved prompts access for directory ${directory} (HTTP 403). Run /status in a session mapped to the right project, or update Telegram directory in bridge settings.`
   }
@@ -1830,8 +1862,7 @@ async function savedPrompts(runtime: Runtime, key: string): Promise<{ prompts: S
 
   for (const directory of contexts) {
     const scoped = await savedPromptsForDirectory(config, directory).catch((error) => {
-      const status = savedPromptsStatus(error)
-      fallbackGuidance = savedPromptsFailureGuidance(status, directory)
+      fallbackGuidance = savedPromptsFailureGuidance(error, directory)
       return
     })
     if (!scoped) continue
@@ -1855,6 +1886,23 @@ function promptScope(scope: SavedPrompt["scope"]): string {
 
 function promptChoice(prompt: SavedPrompt, index: number): string {
   return `${index + 1}. ${prompt.title} [${promptScope(prompt.scope)}] (${prompt.id})`
+}
+
+function promptsMarkup(prompts: SavedPrompt[]): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } | undefined {
+  const rows = prompts
+    .slice(0, inlineButtonMaxOptions)
+    .map((prompt, index) => {
+      const callback = promptCallbackData(prompt.id)
+      if (!callback) return
+      const label = `${index + 1}. ${prompt.title.trim()}`.slice(0, inlineButtonTextMax)
+      if (!label) return
+      return [{ text: label, callback_data: callback }]
+    })
+    .filter((item) => item !== undefined)
+  if (!rows.length) return
+  return {
+    inline_keyboard: rows as Array<Array<{ text: string; callback_data: string }>>,
+  }
 }
 
 function promptsListText(prompts: SavedPrompt[], guidance?: string): string {
@@ -1901,6 +1949,22 @@ function lookupSavedPrompt(input: string, prompts: SavedPrompt[]): { prompt?: Sa
   return {
     error: `Saved prompt not found: ${value}. Use /prompts to list available options.`,
   }
+}
+
+async function runSavedPrompt(runtime: Runtime, chatId: number, key: string, prompt: SavedPrompt) {
+  const config = runtime.config
+  const sessionId = await sessionForChat(runtime, key)
+  await resolvePendingForSession(runtime, chatId, sessionId)
+  const reply = await sendPrompt(config, sessionId, prompt.text).catch(async (error) => {
+    if (!isMissingSession(error)) {
+      throw error
+    }
+    sessions.delete(key)
+    await runtime.store.delete(key)
+    const next = await sessionForChat(runtime, key)
+    return sendPrompt(config, next, prompt.text)
+  })
+  await sendTelegramMessage(config, chatId, reply)
 }
 
 function isMissingQuestion(error: unknown): boolean {
@@ -1970,10 +2034,20 @@ async function sendTelegramInlineMessage(
   text: string,
   replyMarkup: { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> },
 ) {
+  await sendTelegramMessageWithMarkup(config, chatId, text, replyMarkup)
+}
+
+async function sendTelegramMessageWithMarkup(
+  config: BridgeConfig,
+  chatId: number,
+  text: string,
+  markup: { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> },
+) {
+  const safe = truncateTelegramText(text || "I could not produce a response.", telegramMessageSoftLimit)
   await telegramRequest(config, "sendMessage", {
     chat_id: chatId,
-    text: truncateTelegramText(text, telegramMessageSoftLimit),
-    reply_markup: replyMarkup,
+    text: safe,
+    reply_markup: markup,
   })
 }
 
@@ -2089,6 +2163,24 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
     if (!parsed) {
       await answerCallback(runtime.config, callbackId, "Unsupported button payload.")
       state.acknowledged = true
+      return
+    }
+
+    if (parsed.kind === "prompt") {
+      const key = telegramSessionKey(chatId, userId)
+      await answerCallback(runtime.config, callbackId, promptCallbackAckText)
+      state.acknowledged = true
+      const list = await savedPrompts(runtime, key)
+      if (!list.prompts.length) {
+        await sendTelegramMessage(runtime.config, chatId, list.guidance || "No saved prompts found. Run /prompts to refresh the list.")
+        return
+      }
+      const selected = list.prompts.find((item) => item.id === parsed.promptId)
+      if (!selected) {
+        await sendTelegramMessage(runtime.config, chatId, "That saved prompt is no longer available. Run /prompts to refresh the list.")
+        return
+      }
+      await runSavedPrompt(runtime, chatId, key, selected)
       return
     }
 
@@ -2307,7 +2399,13 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
     }
     if (known?.name === "prompts") {
       const list = await savedPrompts(runtime, key)
-      await sendTelegramMessage(config, chatId, promptsListText(list.prompts, list.guidance))
+      const text = promptsListText(list.prompts, list.guidance)
+      const markup = promptsMarkup(list.prompts)
+      if (!markup) {
+        await sendTelegramMessage(config, chatId, text)
+        return true
+      }
+      await sendTelegramMessageWithMarkup(config, chatId, text, markup)
       return true
     }
     if (known?.name === "prompt") {
@@ -2331,18 +2429,7 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
         await sendTelegramMessage(config, chatId, "Usage: /prompt <name|id>")
         return true
       }
-      const sessionId = await sessionForChat(runtime, key)
-      await resolvePendingForSession(runtime, chatId, sessionId)
-      const reply = await sendPrompt(config, sessionId, selected.text).catch(async (error) => {
-        if (!isMissingSession(error)) {
-          throw error
-        }
-        sessions.delete(key)
-        await runtime.store.delete(key)
-        const next = await sessionForChat(runtime, key)
-        return sendPrompt(config, next, selected.text)
-      })
-      await sendTelegramMessage(config, chatId, reply)
+      await runSavedPrompt(runtime, chatId, key, selected)
       return true
     }
     const suggestions = commandSuggestions(command.name)


### PR DESCRIPTION
## Summary
- add inline keyboard buttons to `/prompts` so saved prompts can be run with one tap
- add inline toggle buttons to `/notify` for one-tap notification control in Telegram
- extend callback handling with prompt-specific and notify payloads, and harden saved-prompt response parsing/guidance for `/api/ext` response variants

Closes #331