### PR TITLE
feat: render CompactionPart as visual divider in message stream

### DIFF
--- a/app-prefixable/src/components/message-turn.tsx
+++ b/app-prefixable/src/components/message-turn.tsx
@@ -944,7 +944,7 @@ export function MessageTurn(props: {
                     <Show when={text}>
                       <Markdown content={text} class="text-sm" />
                     </Show>
-                    {/* Agent, snapshot, retry, and patch parts */}
+                    {/* Agent, snapshot, retry, patch, and compaction parts */}
                     <Show when={meta().length > 0}>
                       <div class="space-y-2 mt-2">
                         <For each={meta()}>{(part) => renderMetaPart(part)}</For>

--- a/app-prefixable/src/components/message-turn.tsx
+++ b/app-prefixable/src/components/message-turn.tsx
@@ -104,6 +104,18 @@ const sharedChildrenEmptyBackoff = new Map<string, number>()
 const sharedChildrenRetryAt = new Map<string, number>()
 const sharedSyncedChildren = new Set<string>()
 
+function renderCenteredDivider(label: string) {
+  return (
+    <div class="flex items-center gap-2" role="separator" aria-label={label}>
+      <div class="h-px flex-1" style={{ background: "var(--border-base)" }} />
+      <span class="text-[11px] uppercase tracking-wide" style={{ color: "var(--text-weak)" }}>
+        {label}
+      </span>
+      <div class="h-px flex-1" style={{ background: "var(--border-base)" }} />
+    </div>
+  )
+}
+
 function renderMetaPart(part: Part) {
   if (isAgentPart(part)) {
     const source = part.source?.value?.trim()
@@ -128,15 +140,7 @@ function renderMetaPart(part: Part) {
     )
   }
   if (isSnapshotPart(part)) {
-    return (
-      <div class="flex items-center gap-2" aria-label={`Snapshot ${part.snapshot.slice(0, 8)}`}>
-        <div class="h-px flex-1" style={{ background: "var(--border-base)" }} />
-        <span class="text-[11px] uppercase tracking-wide" style={{ color: "var(--text-weak)" }}>
-          Snapshot {part.snapshot.slice(0, 8)}
-        </span>
-        <div class="h-px flex-1" style={{ background: "var(--border-base)" }} />
-      </div>
-    )
+    return renderCenteredDivider(`Snapshot ${part.snapshot.slice(0, 8)}`)
   }
   if (isRetryPart(part)) {
     return (
@@ -182,15 +186,7 @@ function renderMetaPart(part: Part) {
   }
   if (isCompactionPart(part)) {
     const label = part.auto ? "Context auto-compacted" : "Context compacted"
-    return (
-      <div class="flex items-center gap-2" aria-label={label}>
-        <div class="h-px flex-1" style={{ background: "var(--border-base)" }} />
-        <span class="text-[11px] uppercase tracking-wide" style={{ color: "var(--text-weak)" }}>
-          {label}
-        </span>
-        <div class="h-px flex-1" style={{ background: "var(--border-base)" }} />
-      </div>
-    )
+    return renderCenteredDivider(label)
   }
   return null
 }

--- a/app-prefixable/src/components/message-turn.tsx
+++ b/app-prefixable/src/components/message-turn.tsx
@@ -49,6 +49,10 @@ function isSubtaskPart(p: Part): p is Extract<Part, { type: "subtask" }> {
   return p.type === "subtask"
 }
 
+function isCompactionPart(p: Part): p is Extract<Part, { type: "compaction" }> {
+  return p.type === "compaction"
+}
+
 const MAX_SHARED_CHILDREN = 400
 const MAX_SHARED_CHILDREN_INFLIGHT = 200
 const MAX_SHARED_SYNCED_CHILDREN = 600
@@ -174,6 +178,18 @@ function renderMetaPart(part: Part) {
           </ul>
         </Show>
       </details>
+    )
+  }
+  if (isCompactionPart(part)) {
+    const label = part.auto ? "Context auto-compacted" : "Context compacted"
+    return (
+      <div class="flex items-center gap-2" aria-label={label}>
+        <div class="h-px flex-1" style={{ background: "var(--border-base)" }} />
+        <span class="text-[11px] uppercase tracking-wide" style={{ color: "var(--text-weak)" }}>
+          {label}
+        </span>
+        <div class="h-px flex-1" style={{ background: "var(--border-base)" }} />
+      </div>
     )
   }
   return null
@@ -898,7 +914,7 @@ export function MessageTurn(props: {
             {(message) => {
               const text = extractTextContent(message.parts).trim()
               const tools = hasTools(message)
-              const meta = () => message.parts.filter((part) => isAgentPart(part) || isSnapshotPart(part) || isRetryPart(part) || isPatchPart(part))
+              const meta = () => message.parts.filter((part) => isAgentPart(part) || isSnapshotPart(part) || isRetryPart(part) || isPatchPart(part) || isCompactionPart(part))
               const subtasks = () => message.parts.filter(isSubtaskPart)
 
               return (


### PR DESCRIPTION
## Summary
- Renders `CompactionPart` (type `"compaction"`) as a visual divider in the message stream
- Shows "Context compacted" for manual compaction or "Context auto-compacted" when `auto: true`
- Uses the same horizontal-rule-with-centered-text pattern as the existing snapshot divider
- Subtle styling with muted text (`--text-weak`) and thin border line (`--border-base`)

## Changes
- Added `isCompactionPart` type guard function
- Added compaction rendering branch in `renderMetaPart`
- Included compaction parts in the `meta()` filter so they render alongside other meta parts

Closes #234