### PR TITLE
feat: sync session bell toggle with server-side Telegram alarm state

### DIFF
--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -50,6 +50,7 @@ import {
   type ImageAttachment,
 } from "../components/image-attachments";
 import { readNotifyMap, writeNotifyMap } from "../utils/notify";
+import { getSessionAlarm, setSessionAlarm } from "../utils/extended-api";
 import { sessionQuestionRequest } from "../utils/session-tree-request";
 import { createRootSession } from "../utils/root-session";
 import {
@@ -121,7 +122,7 @@ function normalizeFollowupList(value: unknown) {
 export function Session() {
   const params = useParams<{ dir: string; id?: string }>();
   const navigate = useNavigate();
-  const { client, directory } = useSDK();
+  const { client, directory, url } = useSDK();
   const events = useEvents();
   const sync = useSync();
   const providers = useProviders();
@@ -503,7 +504,7 @@ export function Session() {
   // Double-Escape to abort: track last Escape press timestamp
   const lastEsc = { ts: 0 };
 
-  // --- Notification toggle (per-session, persisted in localStorage) ---
+  // --- Notification toggle (per-session, persisted in localStorage + server) ---
   const [notifyEnabled, setNotifyEnabled] = createSignal(
     (() => {
       const id = params.id;
@@ -512,15 +513,49 @@ export function Session() {
     })(),
   );
   const [notifyDenied, setNotifyDenied] = createSignal(false);
+  const [notifySyncing, setNotifySyncing] = createSignal(false);
   const deniedTimer = { id: null as ReturnType<typeof setTimeout> | null };
   onCleanup(() => { if (deniedTimer.id !== null) clearTimeout(deniedTimer.id) });
 
-  // Re-read notification state when session changes
+  // Re-read notification state when session changes, and seed from server alarm state
   createEffect(() => {
     const id = params.id;
-    setNotifyEnabled(id ? readNotifyMap()[id] === true : false);
     setNotifyDenied(false);
+    if (!id) {
+      setNotifyEnabled(false);
+      return;
+    }
+    // Seed from localStorage first for instant UI
+    const local = readNotifyMap()[id] === true;
+    setNotifyEnabled(local);
+    // Then fetch server-side alarm state asynchronously
+    const serverUrl = url;
+    getSessionAlarm(serverUrl, id).then((state) => {
+      // If server returned a value and we're still on the same session, adopt it
+      if (state && params.id === id) {
+        setNotifyEnabled(state.enabled);
+        // Sync localStorage to match server truth
+        const map = readNotifyMap();
+        if (state.enabled) {
+          map[id] = true;
+        } else {
+          delete map[id];
+        }
+        writeNotifyMap(map);
+      }
+    });
   });
+
+  /** Mirror bell toggle to server-side alarm state (fire-and-forget). */
+  function syncAlarmToServer(id: string, enabled: boolean) {
+    setNotifySyncing(true);
+    setSessionAlarm(url, id, enabled).then((ok) => {
+      setNotifySyncing(false);
+      if (!ok) {
+        console.warn("[Session] Failed to sync alarm state to server for session:", id);
+      }
+    });
+  }
 
   function toggleNotify() {
     const id = sessionId();
@@ -533,6 +568,7 @@ export function Session() {
       writeNotifyMap(map);
       setNotifyEnabled(false);
       setNotifyDenied(false);
+      syncAlarmToServer(id, false);
       return;
     }
 
@@ -545,6 +581,7 @@ export function Session() {
       map[id] = true;
       writeNotifyMap(map);
       setNotifyEnabled(true);
+      syncAlarmToServer(id, true);
       return;
     }
     if (perm === "denied") {
@@ -560,6 +597,7 @@ export function Session() {
         map[id] = true;
         writeNotifyMap(map);
         setNotifyEnabled(true);
+        syncAlarmToServer(id, true);
         return;
       }
       if (result === "denied") {

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -549,11 +549,7 @@ export function Session() {
 
   /** Mirror bell toggle to server-side alarm state (fire-and-forget). */
   function syncAlarmToServer(id: string, enabled: boolean) {
-    setSessionAlarm(url, id, enabled).then((ok) => {
-      if (!ok) {
-        console.warn("[Session] Failed to sync alarm state to server for session:", id);
-      }
-    });
+    setSessionAlarm(url, id, enabled);
   }
 
   function toggleNotify() {

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -513,7 +513,6 @@ export function Session() {
     })(),
   );
   const [notifyDenied, setNotifyDenied] = createSignal(false);
-  const [notifySyncing, setNotifySyncing] = createSignal(false);
   const deniedTimer = { id: null as ReturnType<typeof setTimeout> | null };
   onCleanup(() => { if (deniedTimer.id !== null) clearTimeout(deniedTimer.id) });
 
@@ -529,8 +528,7 @@ export function Session() {
     const local = readNotifyMap()[id] === true;
     setNotifyEnabled(local);
     // Then fetch server-side alarm state asynchronously
-    const serverUrl = url;
-    getSessionAlarm(serverUrl, id).then((state) => {
+    getSessionAlarm(url, id).then((state) => {
       // If server returned a value and we're still on the same session, adopt it
       if (state && params.id === id) {
         setNotifyEnabled(state.enabled);
@@ -548,9 +546,7 @@ export function Session() {
 
   /** Mirror bell toggle to server-side alarm state (fire-and-forget). */
   function syncAlarmToServer(id: string, enabled: boolean) {
-    setNotifySyncing(true);
     setSessionAlarm(url, id, enabled).then((ok) => {
-      setNotifySyncing(false);
       if (!ok) {
         console.warn("[Session] Failed to sync alarm state to server for session:", id);
       }

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -527,20 +527,21 @@ export function Session() {
     // Seed from localStorage first for instant UI
     const local = readNotifyMap()[id] === true;
     setNotifyEnabled(local);
+    // Cancellation flag for stale responses
+    let cancelled = false;
+    onCleanup(() => { cancelled = true });
     // Then fetch server-side alarm state asynchronously
     getSessionAlarm(url, id).then((state) => {
-      // If server returned a value and we're still on the same session, adopt it
-      if (state && params.id === id) {
-        setNotifyEnabled(state.enabled);
-        // Sync localStorage to match server truth
-        const map = readNotifyMap();
-        if (state.enabled) {
-          map[id] = true;
-        } else {
-          delete map[id];
-        }
-        writeNotifyMap(map);
+      if (cancelled || !state || params.id !== id) return;
+      setNotifyEnabled(state.enabled);
+      // Sync localStorage to match server truth
+      const map = readNotifyMap();
+      if (state.enabled) {
+        map[id] = true;
+      } else {
+        delete map[id];
       }
+      writeNotifyMap(map);
     });
   });
 

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -532,7 +532,9 @@ export function Session() {
     onCleanup(() => { cancelled = true });
     // Then fetch server-side alarm state asynchronously
     getSessionAlarm(url, id).then((state) => {
+      // Skip if effect was cleaned up, session changed, or user already toggled
       if (cancelled || !state || params.id !== id) return;
+      if (notifyEnabled() !== local) return; // user toggled since fetch started
       setNotifyEnabled(state.enabled);
       // Sync localStorage to match server truth
       const map = readNotifyMap();

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -189,9 +189,15 @@ export interface SessionAlarmState {
 export async function getSessionAlarm(serverUrl: string, sessionId: string): Promise<SessionAlarmState | null> {
   const params = new URLSearchParams({ sessionId })
   const res = await fetch(`${serverUrl}/api/ext/telegram/session-alarm?${params}`).catch(() => null)
-  if (!res?.ok) return null
+  if (!res?.ok) {
+    if (res) console.warn("[extended-api] getSessionAlarm failed:", res.status)
+    return null
+  }
   const data = (await res.json().catch(() => null)) as { sessionId?: string; enabled?: boolean } | null
-  if (!data || typeof data.enabled !== "boolean") return null
+  if (!data || typeof data.enabled !== "boolean") {
+    console.warn("[extended-api] getSessionAlarm: invalid response data")
+    return null
+  }
   return { sessionId: data.sessionId || sessionId, enabled: data.enabled }
 }
 

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -179,3 +179,32 @@ export async function writeSavedPrompts(
   }).catch(() => null)
   return !!res?.ok
 }
+
+export interface SessionAlarmState {
+  sessionId: string
+  enabled: boolean
+}
+
+/** Read session alarm state from the server (Telegram bridge). Returns null on failure. */
+export async function getSessionAlarm(serverUrl: string, sessionId: string): Promise<SessionAlarmState | null> {
+  const params = new URLSearchParams({ sessionId })
+  const res = await fetch(`${serverUrl}/api/ext/telegram/session-alarm?${params}`).catch(() => null)
+  if (!res?.ok) return null
+  const data = (await res.json().catch(() => null)) as { sessionId?: string; enabled?: boolean } | null
+  if (!data || typeof data.enabled !== "boolean") return null
+  return { sessionId: data.sessionId || sessionId, enabled: data.enabled }
+}
+
+/** Update session alarm state on the server (Telegram bridge). Returns true on success. */
+export async function setSessionAlarm(serverUrl: string, sessionId: string, enabled: boolean): Promise<boolean> {
+  const res = await fetch(`${serverUrl}/api/ext/telegram/session-alarm`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionId, enabled }),
+  }).catch(() => null)
+  if (!res?.ok) {
+    console.warn("[extended-api] setSessionAlarm failed:", res?.status)
+    return false
+  }
+  return true
+}

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -212,8 +212,12 @@ export async function setSessionAlarm(serverUrl: string, sessionId: string, enab
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ sessionId, enabled }),
   }).catch(() => null)
-  if (!res?.ok) {
-    console.warn("[extended-api] setSessionAlarm failed:", res?.status)
+  if (!res) {
+    console.warn("[extended-api] setSessionAlarm: network error for session", sessionId)
+    return false
+  }
+  if (!res.ok) {
+    console.warn("[extended-api] setSessionAlarm failed:", res.status)
     return false
   }
   return true

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -189,8 +189,12 @@ export interface SessionAlarmState {
 export async function getSessionAlarm(serverUrl: string, sessionId: string): Promise<SessionAlarmState | null> {
   const params = new URLSearchParams({ sessionId })
   const res = await fetch(`${serverUrl}/api/ext/telegram/session-alarm?${params}`).catch(() => null)
-  if (!res?.ok) {
-    if (res) console.warn("[extended-api] getSessionAlarm failed:", res.status)
+  if (!res) {
+    console.warn("[extended-api] getSessionAlarm: network error for session", sessionId)
+    return null
+  }
+  if (!res.ok) {
+    console.warn("[extended-api] getSessionAlarm failed:", res.status)
     return null
   }
   const data = (await res.json().catch(() => null)) as { sessionId?: string; enabled?: boolean } | null


### PR DESCRIPTION
## Summary

- When a session loads, the bell toggle now fetches the server-side alarm state (`GET /api/ext/telegram/session-alarm`) and adopts it, keeping localStorage in sync
- When the user toggles notifications on/off, the change is mirrored to the server via `PUT /api/ext/telegram/session-alarm` (fire-and-forget with console.warn on failure)
- Added `getSessionAlarm()` and `setSessionAlarm()` client helpers in `extended-api.ts`

## Files changed

- `app-prefixable/src/utils/extended-api.ts` — new `SessionAlarmState` interface + `getSessionAlarm`/`setSessionAlarm` helpers
- `app-prefixable/src/pages/session.tsx` — seed bell state from server on load, sync toggle changes to server

## Testing

- Build passes (`bun run build`)
- All 51 existing tests pass (`bun test`)

Closes #326