### PR TITLE
refactor: rename Sounds settings tab to Notifications

### DIFF
--- a/app-prefixable/src/components/telegram-settings.tsx
+++ b/app-prefixable/src/components/telegram-settings.tsx
@@ -218,7 +218,7 @@ export function TelegramSettings(props: Props) {
           Configure Telegram bridge runtime settings. Saving changes writes persisted values and may require restarting the bridge service.
         </p>
         <p class="text-xs mt-2" style={{ color: "var(--text-weak)" }}>
-          Proactive Telegram delivery is controlled from Settings / Sounds / Telegram alarm channel. If you miss a ping, use <code class="px-1 py-0.5 rounded" style={{ background: "var(--surface-inset)" }}>/pending</code> in Telegram to review outstanding prompts.
+          Proactive Telegram delivery is controlled from Settings / Notifications / Telegram alarm channel. If you miss a ping, use <code class="px-1 py-0.5 rounded" style={{ background: "var(--surface-inset)" }}>/pending</code> in Telegram to review outstanding prompts.
         </p>
       </header>
 

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1692,8 +1692,8 @@ export function Layout(props: ParentProps) {
     if (typeof document !== "undefined" && document.hidden) flashTitle();
 
     // Play sound if enabled in settings
-    const sound = notificationCache();
-    if (sound.enabled) playSound(sound.sound);
+    const settings = notificationCache();
+    if (settings.enabled) playSound(settings.sound);
 
     if (typeof window === "undefined" || !("Notification" in window)) return;
     if (Notification.permission !== "granted") return;

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -81,7 +81,7 @@ import {
   readAlarmChannels,
   ALARM_CHANNELS_STORAGE_KEY,
 } from "../utils/notify";
-import { readSoundSettings, playSound, primeAudioContext, SOUND_STORAGE_KEY } from "../utils/sound";
+import { readNotificationSettings, playSound, primeAudioContext, NOTIFICATION_STORAGE_KEY } from "../utils/notifications";
 import { dispatchStorageEvent } from "../utils/storage";
 import { sessionHasQuestion, buildChildMap, rootAncestorId } from "../utils/session-tree-request";
 import { createRootSession } from "../utils/root-session";
@@ -1627,12 +1627,12 @@ export function Layout(props: ParentProps) {
   // Cached notify map — avoids repeated localStorage reads + JSON.parse on every SSE event.
   // Updated via storage events (including synthetic same-tab events dispatched by writeNotifyMap).
   const [notifyCache, setNotifyCache] = createSignal(readNotifyMap());
-  const [soundCache, setSoundCache] = createSignal(readSoundSettings());
+  const [notificationCache, setNotificationCache] = createSignal(readNotificationSettings());
   const [alarmChannels, setAlarmChannels] = createSignal(readAlarmChannels());
   onMount(() => {
     function handleStorage(e: StorageEvent) {
       if (e.key === NOTIFY_STORAGE_KEY) setNotifyCache(readNotifyMap());
-      if (e.key === SOUND_STORAGE_KEY) setSoundCache(readSoundSettings());
+      if (e.key === NOTIFICATION_STORAGE_KEY) setNotificationCache(readNotificationSettings());
       if (e.key === ALARM_CHANNELS_STORAGE_KEY) setAlarmChannels(readAlarmChannels());
     }
     window.addEventListener("storage", handleStorage);
@@ -1642,7 +1642,7 @@ export function Layout(props: ParentProps) {
     // so notification sounds work reliably after page reload. Listeners stay
     // attached until priming succeeds so that enabling sound later still works.
     function primeOnGesture() {
-      if (!soundCache().enabled) return;
+      if (!notificationCache().enabled) return;
       primeAudioContext();
       window.removeEventListener("pointerdown", primeOnGesture);
       window.removeEventListener("keydown", primeOnGesture);
@@ -1692,7 +1692,7 @@ export function Layout(props: ParentProps) {
     if (typeof document !== "undefined" && document.hidden) flashTitle();
 
     // Play sound if enabled in settings
-    const sound = soundCache();
+    const sound = notificationCache();
     if (sound.enabled) playSound(sound.sound);
 
     if (typeof window === "undefined" || !("Notification" in window)) return;

--- a/app-prefixable/src/pages/settings-tabs.ts
+++ b/app-prefixable/src/pages/settings-tabs.ts
@@ -1,1 +1,1 @@
-export const SETTINGS_BASE_TABS = ["providers", "servers", "git", "mcp", "prompts", "instructions", "appearance", "sounds", "telegram"] as const
+export const SETTINGS_BASE_TABS = ["providers", "servers", "git", "mcp", "prompts", "instructions", "appearance", "notifications", "telegram"] as const

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -9,8 +9,8 @@ import { useConfig } from "../context/config"
 import { MCPAddDialog } from "../components/mcp-add-dialog"
 import { ConfirmDialog } from "../components/confirm-dialog"
 import { Button } from "../components/ui/button"
-import { Check, Copy, Plug, GitBranch, Server, Globe, ExternalLink, Key, Search, X, Trash2, BookmarkPlus, Pencil, Palette, Sun, Moon, Monitor, BookOpen, Plus, Save, Volume2, Play, Settings2, Code, Shield, Cpu, Wrench, ChevronDown, ChevronRight, Info } from "lucide-solid"
-import { SOUND_OPTIONS, readSoundSettings, writeSoundSettings, playSound, primeAudioContext, SOUND_STORAGE_KEY, type SoundSettings } from "../utils/sound"
+import { Check, Copy, Plug, GitBranch, Server, Globe, ExternalLink, Key, Search, X, Trash2, BookmarkPlus, Pencil, Palette, Sun, Moon, Monitor, BookOpen, Plus, Save, Bell, Play, Settings2, Code, Shield, Cpu, Wrench, ChevronDown, ChevronRight, Info } from "lucide-solid"
+import { SOUND_OPTIONS, readNotificationSettings, writeNotificationSettings, playSound, primeAudioContext, NOTIFICATION_STORAGE_KEY, type NotificationSettings } from "../utils/notifications"
 import { useSavedPrompts, type PromptScope } from "../context/saved-prompts"
 import { useTheme } from "../context/theme"
 import { useServer } from "../context/server"
@@ -62,8 +62,8 @@ export function Settings() {
   const [promptToDelete, setPromptToDelete] = createSignal<string | null>(null)
   const [promptSaveError, setPromptSaveError] = createSignal<string | null>(null)
 
-  // Sound settings
-  const [soundSettings, setSoundSettings] = createSignal<SoundSettings>(readSoundSettings())
+  // Notification settings
+  const [notificationSettings, setNotificationSettings] = createSignal<NotificationSettings>(readNotificationSettings())
   const [alarmChannels, setAlarmChannels] = createSignal<AlarmChannels>(readAlarmChannels())
   const [telegramAlarmReady, setTelegramAlarmReady] = createSignal(false)
   const [telegramAlarmSaving, setTelegramAlarmSaving] = createSignal(false)
@@ -75,20 +75,20 @@ export function Settings() {
     return `${hint} Restart Telegram bridge before this change takes effect.`
   })
 
-  // Keep soundSettings in sync with localStorage changes from other tabs
+  // Keep notificationSettings in sync with localStorage changes from other tabs
   onMount(() => {
     function handleStorage(e: StorageEvent) {
-      if (e.key === SOUND_STORAGE_KEY) setSoundSettings(readSoundSettings())
+      if (e.key === NOTIFICATION_STORAGE_KEY) setNotificationSettings(readNotificationSettings())
       if (e.key === ALARM_CHANNELS_STORAGE_KEY) setAlarmChannels(readAlarmChannels())
     }
     window.addEventListener("storage", handleStorage)
     onCleanup(() => window.removeEventListener("storage", handleStorage))
   })
 
-  function updateSoundSettings(patch: Partial<SoundSettings>) {
-    const next = { ...soundSettings(), ...patch }
-    setSoundSettings(next)
-    writeSoundSettings(next)
+  function updateNotificationSettings(patch: Partial<NotificationSettings>) {
+    const next = { ...notificationSettings(), ...patch }
+    setNotificationSettings(next)
+    writeNotificationSettings(next)
   }
 
   function updateAlarmChannels(patch: Partial<AlarmChannels>) {
@@ -252,7 +252,7 @@ export function Settings() {
       setInstructionLoaded(true)
       loadInstructions()
     }
-    if (tabId === "sounds") {
+    if (tabId === "notifications") {
       void loadTelegramAlarmState()
     }
   }
@@ -267,7 +267,7 @@ export function Settings() {
       setInstructionLoaded(true)
       loadInstructions()
     }
-    if (activeTab() === "sounds") {
+    if (activeTab() === "notifications") {
       void loadTelegramAlarmState()
     }
   })
@@ -807,7 +807,7 @@ Add your project-specific instructions here.
       base.push({ id: "config", label: "Project Config", icon: () => <Settings2 class="w-4 h-4" />, scope: "Project" })
     }
     base.push({ id: "appearance", label: "Appearance", icon: () => <Palette class="w-4 h-4" />, scope: null })
-    base.push({ id: "sounds", label: "Sounds", icon: () => <Volume2 class="w-4 h-4" />, scope: null })
+    base.push({ id: "notifications", label: "Notifications", icon: () => <Bell class="w-4 h-4" />, scope: null })
     return base
   })
 
@@ -2385,12 +2385,12 @@ Add your project-specific instructions here.
             </div>
           </Show>
 
-          {/* Sounds Tab */}
-          <Show when={activeTab() === "sounds"}>
+          {/* Notifications Tab */}
+          <Show when={activeTab() === "notifications"}>
             <div class="space-y-6">
               <header>
                 <h1 class="text-lg font-medium" style={{ color: "var(--text-strong)" }}>
-                  Sound Notifications
+                  Notifications
                 </h1>
                 <p class="text-sm mt-1" style={{ color: "var(--text-weak)" }}>
                   Configure browser and Telegram alarm channels for notification-worthy events (task complete, permission request, agent question)
@@ -2491,23 +2491,23 @@ Add your project-specific instructions here.
                   </h2>
                   <button
                     onClick={() => {
-                      const enabling = !soundSettings().enabled
-                      updateSoundSettings({ enabled: enabling })
+                      const enabling = !notificationSettings().enabled
+                      updateNotificationSettings({ enabled: enabling })
                       if (enabling) primeAudioContext()
                     }}
                     class="relative w-10 h-5 rounded-full transition-colors"
                     style={{
-                      background: soundSettings().enabled ? "var(--interactive-base)" : "var(--surface-inset)",
+                      background: notificationSettings().enabled ? "var(--interactive-base)" : "var(--surface-inset)",
                     }}
                     role="switch"
-                    aria-checked={soundSettings().enabled}
+                    aria-checked={notificationSettings().enabled}
                     aria-label="Enable sound notifications"
                   >
                     <div
                       class="absolute top-0.5 w-4 h-4 rounded-full transition-all"
                       style={{
                         background: "var(--background-base)",
-                        left: soundSettings().enabled ? "calc(100% - 18px)" : "2px",
+                        left: notificationSettings().enabled ? "calc(100% - 18px)" : "2px",
                       }}
                     />
                   </button>
@@ -2529,14 +2529,14 @@ Add your project-specific instructions here.
                             for={`sound-option-${option.id}`}
                             class="flex items-center justify-between px-3 py-2 rounded-md transition-colors cursor-pointer"
                             style={{
-                              background: soundSettings().sound === option.id ? "var(--surface-inset)" : "transparent",
-                              border: soundSettings().sound === option.id ? "1px solid var(--interactive-base)" : "1px solid transparent",
+                              background: notificationSettings().sound === option.id ? "var(--surface-inset)" : "transparent",
+                              border: notificationSettings().sound === option.id ? "1px solid var(--interactive-base)" : "1px solid transparent",
                             }}
                             onMouseEnter={(e) => {
-                              if (soundSettings().sound !== option.id) e.currentTarget.style.background = "var(--surface-inset)"
+                              if (notificationSettings().sound !== option.id) e.currentTarget.style.background = "var(--surface-inset)"
                             }}
                             onMouseLeave={(e) => {
-                              if (soundSettings().sound !== option.id) e.currentTarget.style.background = "transparent"
+                              if (notificationSettings().sound !== option.id) e.currentTarget.style.background = "transparent"
                             }}
                           >
                             <div class="flex items-center gap-3">
@@ -2545,11 +2545,11 @@ Add your project-specific instructions here.
                                 type="radio"
                                 name="sound"
                                 value={option.id}
-                                checked={soundSettings().sound === option.id}
+                                checked={notificationSettings().sound === option.id}
                                 class="accent-[var(--interactive-base)]"
                                 onChange={(e) => {
                                   e.stopPropagation()
-                                  updateSoundSettings({ sound: option.id })
+                                  updateNotificationSettings({ sound: option.id })
                                   playSound(option.id)
                                 }}
                                 onClick={(e) => e.stopPropagation()}

--- a/app-prefixable/src/utils/notifications.ts
+++ b/app-prefixable/src/utils/notifications.ts
@@ -1,5 +1,5 @@
 /**
- * Sound notification utilities.
+ * Notification utilities.
  *
  * Sounds are generated programmatically via the Web Audio API so no external
  * audio files are needed. Each sound option exposes a `play` function that
@@ -12,43 +12,43 @@ import { dispatchStorageEvent } from "./storage"
 // localStorage persistence
 // ---------------------------------------------------------------------------
 
-export const SOUND_STORAGE_KEY = "opencode.soundSettings"
+export const NOTIFICATION_STORAGE_KEY = "opencode.soundSettings"
 
-export interface SoundSettings {
+export interface NotificationSettings {
   enabled: boolean
   /** ID of the selected sound from SOUND_OPTIONS */
   sound: string
 }
 
-const DEFAULTS: SoundSettings = { enabled: false, sound: "chime" }
+const DEFAULTS: NotificationSettings = { enabled: false, sound: "chime" }
 
-export function readSoundSettings(): SoundSettings {
+export function readNotificationSettings(): NotificationSettings {
   if (typeof window === "undefined") return { ...DEFAULTS }
   try {
-    const raw = window.localStorage.getItem(SOUND_STORAGE_KEY)
+    const raw = window.localStorage.getItem(NOTIFICATION_STORAGE_KEY)
     if (!raw) return { ...DEFAULTS }
     const parsed = JSON.parse(raw) as unknown
     if (!parsed || typeof parsed !== "object") return { ...DEFAULTS }
-    const settings = parsed as Partial<SoundSettings>
+    const settings = parsed as Partial<NotificationSettings>
     return {
       enabled: typeof settings.enabled === "boolean" ? settings.enabled : DEFAULTS.enabled,
       sound: typeof settings.sound === "string" && SOUND_OPTIONS.some((o) => o.id === settings.sound) ? settings.sound : DEFAULTS.sound,
     }
   } catch {
-    try { window.localStorage.removeItem(SOUND_STORAGE_KEY) } catch { /* ignore */ }
+    try { window.localStorage.removeItem(NOTIFICATION_STORAGE_KEY) } catch { /* ignore */ }
     return { ...DEFAULTS }
   }
 }
 
-export function writeSoundSettings(settings: SoundSettings) {
+export function writeNotificationSettings(settings: NotificationSettings) {
   if (typeof window === "undefined") return
   const value = JSON.stringify(settings)
   try {
-    window.localStorage.setItem(SOUND_STORAGE_KEY, value)
+    window.localStorage.setItem(NOTIFICATION_STORAGE_KEY, value)
   } catch {
     return
   }
-  dispatchStorageEvent(SOUND_STORAGE_KEY, value)
+  dispatchStorageEvent(NOTIFICATION_STORAGE_KEY, value)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Renames the "Sounds" settings tab to "Notifications" with a bell icon (`Bell` from lucide-solid)
- Updates all internal identifiers: `SoundSettings` → `NotificationSettings`, `readSoundSettings` → `readNotificationSettings`, `writeSoundSettings` → `writeNotificationSettings`, `soundSettings` signal → `notificationSettings`, `soundCache` → `notificationCache`
- Renames `sound.ts` → `notifications.ts` and updates all imports
- Preserves backward compatibility: the localStorage key value `"opencode.soundSettings"` is unchanged, and sound-specific APIs (`playSound`, `SOUND_OPTIONS`, `SoundOption`, `primeAudioContext`) are kept as-is

Closes #334