### PR TITLE
fix: route Telegram proactive alerts by notify opt-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ This repository includes a Telegram bridge service (`docker/telegram-bridge.ts`)
 
 The bridge keeps a default OpenCode session per Telegram chat (and sender in shared chats), persisted to `TELEGRAM_SESSION_STORE_PATH` so mappings survive restarts.
 
+Proactive outbound alerts are routed independently from chat-to-session command mappings: `/status` and `/switch` control which session interactive commands target, while alert fanout is controlled by `/notify on` opt-in and per-session bell/alarm state.
+
 In container/Kubernetes deployments, the default OS temp directory is often ephemeral, so set `TELEGRAM_SESSION_STORE_PATH` to a mounted persistent volume location if you need mappings to survive pod/container recreation.
 
 The file-backed session store is single-writer/single-replica only (no cross-process locking). For horizontally scaled or multi-replica deployments, use an external coordinated session store instead of sharing one file.
@@ -234,6 +236,7 @@ Messages from the same chat are handled through a per-chat queue to avoid cross-
 
 Outbound alert behavior:
 - Safe by default: outbound alerts are disabled until a chat opts in via `/notify on`.
+- Bell-gated: only sessions with Telegram bell/alarm enabled emit proactive alerts.
 - Debounced: repeated burst events are suppressed for `TELEGRAM_NOTIFY_DEBOUNCE_MS`.
 - Context-rich: alerts include the session id and, when `TELEGRAM_SESSION_LINK_BASE` is set, a direct session URL.
 

--- a/app-prefixable/src/components/telegram-setup-guide.tsx
+++ b/app-prefixable/src/components/telegram-setup-guide.tsx
@@ -12,6 +12,7 @@ const checklist = Object.freeze([
   Object.freeze({ id: "path", label: "sessionStorePath points to a persistent writable location." }),
   Object.freeze({ id: "webhook", label: "For webhook mode: TELEGRAM_WEBHOOK_URL, TELEGRAM_WEBHOOK_PATH, and HTTPS ingress are configured." }),
   Object.freeze({ id: "notify", label: "Notifications are enabled per chat with /notify on after a test message." }),
+  Object.freeze({ id: "alarm", label: "Session bell/alarm is enabled for each OpenCode session that should emit proactive alerts." }),
 ]) as readonly Readonly<ChecklistItem>[]
 
 const commands = ["/pending", "/inbox", "/notify on", "/notify off", "/notify status", "/new", "/status", "/sessions", "/switch <session-id|index>", "/help"] as const
@@ -102,6 +103,9 @@ export function TelegramSetupGuide() {
           </p>
           <p>
             <strong>Mode:</strong> set <code>mode=polling</code> for local/simple setups, or <code>mode=webhook</code> for production ingress. Polling clears webhook registration automatically.
+          </p>
+          <p>
+            <strong>Alert routing model:</strong> proactive Telegram alerts fan out to chats that enabled <code>/notify on</code> and only for sessions with bell/alarm enabled. Chat-to-session mappings from <code>/status</code> and <code>/switch</code> are used for interactive commands and do not limit proactive routing.
           </p>
           <p>
             Persisted UI fields map to runtime settings: <code>mode</code>, <code>token</code>, <code>openCodeUrl</code>, <code>directory</code>, <code>sessionCacheMax</code>,

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4019,7 +4019,7 @@ describe("telegram bridge config and cache", () => {
           set: async () => undefined,
           delete: async () => undefined,
           sessionKeys: async () => ["chat:77:user:5"],
-          notificationGet: async () => false,
+          notificationGet: async () => true,
           pendingGet: async (chatKey: string) => pending.get(chatKey) || [],
           pendingSet: async (chatKey: string, items: Array<{
             id: string;
@@ -4244,6 +4244,7 @@ describe("telegram bridge config and cache", () => {
         sessionCacheMax: 10,
         sessionCacheTtlMs: 10_000,
         notificationDebounceMs: 20_000,
+        telegramAlarmChannelEnabled: false,
         port: 4097,
         webhookPath: "/webhook",
         sessionStorePath: "/tmp/test-store.json",
@@ -4364,6 +4365,7 @@ describe("telegram bridge config and cache", () => {
         sessionCacheMax: 10,
         sessionCacheTtlMs: 10_000,
         notificationDebounceMs: 20_000,
+        telegramAlarmChannelEnabled: false,
         port: 4097,
         webhookPath: "/webhook",
         sessionStorePath: "/tmp/test-store.json",
@@ -4373,7 +4375,7 @@ describe("telegram bridge config and cache", () => {
         set: async () => undefined,
         delete: async () => undefined,
         sessionKeys: async () => ["chat:77:user:5"],
-        notificationGet: async () => false,
+        notificationGet: async () => true,
         pendingGet: async (chatKey: string) => {
           await new Promise((resolve) => setTimeout(resolve, 5));
           return pending.get(chatKey) || [];
@@ -4425,6 +4427,7 @@ describe("telegram bridge config and cache", () => {
         sessionCacheMax: 10,
         sessionCacheTtlMs: 10_000,
         notificationDebounceMs: 20_000,
+        telegramAlarmChannelEnabled: false,
         port: 4097,
         webhookPath: "/webhook",
         sessionStorePath: "/tmp/test-store.json",
@@ -4434,7 +4437,7 @@ describe("telegram bridge config and cache", () => {
         set: async () => undefined,
         delete: async () => undefined,
         sessionKeys: async () => ["chat:77:user:5"],
-        notificationGet: async () => false,
+        notificationGet: async () => true,
         pendingGet: async (chatKey: string) => pending.get(chatKey) || [],
         pendingSet: async (chatKey: string, items: Array<{
           id: string;
@@ -4565,6 +4568,7 @@ describe("telegram bridge config and cache", () => {
         sessionCacheMax: 10,
         sessionCacheTtlMs: 10_000,
         notificationDebounceMs: 20_000,
+        telegramAlarmChannelEnabled: false,
         port: 4097,
         webhookPath: "/webhook",
         sessionStorePath: "/tmp/test-store.json",
@@ -4574,7 +4578,7 @@ describe("telegram bridge config and cache", () => {
         set: async () => undefined,
         delete: async () => undefined,
         sessionKeys: async () => ["chat:77:user:5"],
-        notificationGet: async () => false,
+        notificationGet: async () => true,
         pendingGet: async (chatKey: string) => pending.get(chatKey) || [],
         pendingSet: async (chatKey: string, items: Array<{
           id: string;
@@ -4604,7 +4608,7 @@ describe("telegram bridge config and cache", () => {
     expect(text.endsWith("...")).toBe(true);
   });
 
-  test("question and permission events only queue pending when notifications are disabled", async () => {
+  test("question and permission events are skipped when notifications are disabled", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
     const inbox = new Map<string, Array<{
@@ -4686,10 +4690,9 @@ describe("telegram bridge config and cache", () => {
 
     expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(false);
     const items = inbox.get("chat:77") || [];
-    expect(items).toHaveLength(2);
-    expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);
+    expect(items).toHaveLength(0);
     const stored = (pending.get("chat:77:user:5") || []) as Array<{ requestId?: string }>;
-    expect(stored[0]?.requestId).toBe("req-disabled");
+    expect(stored).toEqual([]);
   });
 
   test("question and permission events notify immediately when enabled", async () => {
@@ -4778,6 +4781,209 @@ describe("telegram bridge config and cache", () => {
     const items = inbox.get("chat:88") || [];
     expect(items).toHaveLength(2);
     expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);
+  });
+
+  test("question alerts route to notify-on chats even without session mapping", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const inbox = new Map<string, Array<{
+      id: string;
+      kind: "question" | "permission" | "task-finished";
+      sessionId: string;
+      text: string;
+      stampedAt: number;
+      resolved: boolean;
+    }>>();
+    const pending = new Map<string, unknown[]>();
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => [],
+          notificationKeys: async () => ["chat:188"],
+          sessionAlarmGet: async () => true,
+          pendingGet: async (chatKey: string) => inbox.get(chatKey) || [],
+          pendingSet: async (chatKey: string, items: Array<{
+            id: string;
+            kind: "question" | "permission" | "task-finished";
+            sessionId: string;
+            text: string;
+            stampedAt: number;
+            resolved: boolean;
+          }>) => {
+            inbox.set(chatKey, [...items]);
+          },
+          questionList: async (name: string) => (pending.get(name) || []) as unknown[],
+          questionUpsert: async (name: string, row: unknown) => {
+            pending.set(name, [row]);
+          },
+          questionDelete: async () => undefined,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-notify-fanout",
+          sessionID: "session-bell",
+          questions: [{ header: "Need approval", options: [{ label: "Yes" }, { label: "No" }] }],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sent = calls.filter((x) => x.url.includes("/sendMessage"));
+    expect(sent.some((x) => x.body.chat_id === 188)).toBe(true);
+    expect((inbox.get("chat:188") || []).map((item) => item.kind)).toEqual(["question"]);
+    const stored = (pending.get("chat:188") || []) as Array<{ requestId?: string }>;
+    expect(stored[0]?.requestId).toBe("req-notify-fanout");
+  });
+
+  test("notify-off chats do not receive proactive alerts", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => [],
+          notificationKeys: async () => [],
+          sessionAlarmGet: async () => true,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "permission.asked",
+        properties: {
+          id: "perm-notify-off",
+          sessionID: "session-bell",
+          permission: "shell",
+          patterns: ["docker *"],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(false);
+  });
+
+  test("session alarms gate proactive Telegram alerts", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const inbox = new Map<string, Array<{
+      id: string;
+      kind: "question" | "permission" | "task-finished";
+      sessionId: string;
+      text: string;
+      stampedAt: number;
+      resolved: boolean;
+    }>>();
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => [],
+          notificationKeys: async () => ["chat:188"],
+          sessionAlarmGet: async () => false,
+          pendingGet: async (chatKey: string) => inbox.get(chatKey) || [],
+          pendingSet: async (chatKey: string, items: Array<{
+            id: string;
+            kind: "question" | "permission" | "task-finished";
+            sessionId: string;
+            text: string;
+            stampedAt: number;
+            resolved: boolean;
+          }>) => {
+            inbox.set(chatKey, [...items]);
+          },
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-alarm-off",
+          sessionID: "session-muted",
+          questions: [{ header: "Need approval" }],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(false);
+    expect((inbox.get("chat:188") || []).length).toBe(0);
   });
 
   test("question, permission, and task-finished skip proactive send when telegram channel is disabled", async () => {
@@ -4970,7 +5176,7 @@ describe("telegram bridge config and cache", () => {
         set: async () => undefined,
         delete: async () => undefined,
         sessionKeys: async () => ["chat:77:user:5"],
-        notificationGet: async () => false,
+        notificationGet: async () => true,
         pendingGet: async (chatKey: string) => pending.get(chatKey) || [],
         pendingSet: async (chatKey: string, items: Array<{
           id: string;

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -5249,20 +5249,15 @@ describe("telegram bridge config and cache", () => {
     expect(pendingSetCalled).toBe(false);
   });
 
-  test("handleBridgeEvent does not debounce failed key and still notifies another key in same chat", async () => {
+  test("handleBridgeEvent dedupes proactive session-key notifications per chat when debounce is disabled", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
-    let failed = false;
     try {
       globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
         const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
         calls.push({ url, body });
         if (url.includes("/sendMessage")) {
-          if (!failed) {
-            failed = true;
-            throw new Error("temporary telegram error");
-          }
           return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
         }
         throw new Error(`Unexpected fetch ${url}`);
@@ -5275,7 +5270,7 @@ describe("telegram bridge config and cache", () => {
           openCodeUrl: "http://127.0.0.1:4096",
           sessionCacheMax: 10,
           sessionCacheTtlMs: 10_000,
-          notificationDebounceMs: 20_000,
+          notificationDebounceMs: 0,
           port: 4097,
           webhookPath: "/webhook",
           sessionStorePath: "/tmp/test-store.json",
@@ -5301,7 +5296,7 @@ describe("telegram bridge config and cache", () => {
     }
 
     const messages = calls.filter((x) => x.url.includes("/sendMessage") && x.body.chat_id === 77);
-    expect(messages.length).toBe(2);
+    expect(messages.length).toBe(1);
   });
 
   test("handleBridgeEvent continues notifying other chats after one failure", async () => {
@@ -7000,6 +6995,67 @@ describe("telegram bridge config and cache", () => {
       .map((x) => String(x.body.text || ""));
     expect(sentTexts.filter((text) => text.includes("Question pending:")).length).toBe(2);
     expect((pending.get("chat:77:user:5") || []).map((row) => row.requestId)).toEqual(["req-a", "req-b"]);
+  });
+
+  test("question notifications dedupe proactive sends per chat when debounce is disabled", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const pending = new Map<string, Array<{ requestId: string }>>();
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          questionList: async (name: string) => pending.get(name) || [],
+          questionUpsert: async (name: string, row: unknown) => {
+            const next = [...(pending.get(name) || []), row as { requestId: string }];
+            pending.set(name, next);
+          },
+          questionDelete: async () => undefined,
+          sessionKeys: async () => ["chat:77:user:5", "chat:77:user:6"],
+          notificationGet: async () => true,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-dedupe",
+          sessionID: "session-dedupe",
+          questions: [{ header: "Need one answer" }],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sentTexts = calls
+      .filter((x) => x.url.includes("/sendMessage") && x.body.chat_id === 77)
+      .map((x) => String(x.body.text || ""));
+    expect(sentTexts.filter((text) => text.includes("Question pending:")).length).toBe(1);
+    expect(sentTexts.filter((text) => text.includes("Open session session-dedupe")).length).toBe(1);
   });
 
   test("question fallback notifications debounce per request id and refresh pending entries", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4608,7 +4608,7 @@ describe("telegram bridge config and cache", () => {
     expect(text.endsWith("...")).toBe(true);
   });
 
-  test("question and permission events are skipped when notifications are disabled", async () => {
+  test("question and permission events still queue pending when notifications are disabled", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
     const inbox = new Map<string, Array<{
@@ -4690,9 +4690,10 @@ describe("telegram bridge config and cache", () => {
 
     expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(false);
     const items = inbox.get("chat:77") || [];
-    expect(items).toHaveLength(0);
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);
     const stored = (pending.get("chat:77:user:5") || []) as Array<{ requestId?: string }>;
-    expect(stored).toEqual([]);
+    expect(stored[0]?.requestId).toBe("req-disabled");
   });
 
   test("question and permission events notify immediately when enabled", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4864,6 +4864,118 @@ describe("telegram bridge config and cache", () => {
     expect(stored[0]?.requestId).toBe("req-notify-fanout");
   });
 
+  test("question pending storage prefers chat-scoped key when notify and mapped keys both exist", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const upsertKeys: string[] = [];
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => ["chat:188:user:9"],
+          notificationKeys: async () => ["chat:188"],
+          notificationGet: async () => true,
+          sessionAlarmGet: async () => true,
+          questionList: async () => [],
+          questionUpsert: async (name: string) => {
+            upsertKeys.push(name);
+          },
+          questionDelete: async () => undefined,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-prefer-chat-key",
+          sessionID: "session-bell",
+          questions: [{ header: "Need approval", options: [{ label: "Yes" }, { label: "No" }] }],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(upsertKeys).toEqual(["chat:188"]);
+    expect(calls.some((x) => x.url.includes("/sendMessage") && x.body.chat_id === 188)).toBe(true);
+  });
+
+  test("legacy user-scoped notification keys do not bypass /notify chat status", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => [],
+          notificationKeys: async () => ["chat:188:user:9"],
+          notificationGet: async (key: string) => key === "chat:188" ? false : true,
+          sessionAlarmGet: async () => true,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "permission.asked",
+        properties: {
+          id: "perm-legacy-notify-key",
+          sessionID: "session-bell",
+          permission: "shell",
+          patterns: ["docker *"],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(false);
+  });
+
   test("notify-off chats do not receive proactive alerts", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
@@ -5870,6 +5982,80 @@ describe("telegram bridge config and cache", () => {
     expect(sentTexts.some((text) => text.includes("1) Alpha"))).toBe(true);
     expect(sentTexts.some((text) => text.includes("Open session session-1"))).toBe(true);
     expect(sentTexts.some((text) => text.includes("Thanks, your answer was sent."))).toBe(true);
+  });
+
+  test("text replies resolve pending question from chat-scoped notify key", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const pending = new Map<string, unknown[]>();
+    pending.set("chat:77", [{
+      requestId: "req-chat-key",
+      callbackId: "cbchatkey",
+      sessionId: "session-1",
+      createdAt: Date.now() - 1000,
+      expiresAt: Date.now() + 60_000,
+      questions: [{
+        header: "Pick one",
+        question: "Pick one",
+        options: ["Alpha", "Beta"],
+        multiple: false,
+        custom: true,
+      }],
+      answers: [],
+    }]);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        if (url.includes("/question/req-chat-key/reply")) {
+          return new Response(JSON.stringify(true), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          questionList: async (name: string) => (pending.get(name) || []) as unknown[],
+          questionUpsert: async (name: string, row: unknown) => {
+            pending.set(name, [row]);
+          },
+          questionDelete: async (name: string, requestId: string) => {
+            const rows = (pending.get(name) || []) as Array<{ requestId?: string }>;
+            pending.set(name, rows.filter((row) => row.requestId !== requestId));
+          },
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 2,
+        message: { message_id: 2, text: "1", chat: { id: 77 }, from: { id: 5 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const replyCall = calls.find((x) => x.url.includes("/question/req-chat-key/reply"));
+    expect(replyCall?.body.answers).toEqual([["Alpha"]]);
+    expect(pending.get("chat:77")).toEqual([]);
+    expect(pending.get("chat:77:user:5")).toBeUndefined();
   });
 
   test("question notifications include inline buttons with compact callback payloads", async () => {

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -189,6 +189,21 @@ describe("telegram session store", () => {
     expect(await second.notificationGet?.(key)).toBe(false)
   })
 
+  test("notificationKeys lists only enabled chat notification entries", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
+    const path = join(dir, "sessions.json")
+    files.push(path)
+    files.push(dir)
+
+    const store = createTelegramSessionStore(path)
+    await store.notificationSet?.(telegramSessionKey(901), true)
+    await store.notificationSet?.(telegramSessionKey(902), true)
+    await store.notificationSet?.(telegramSessionKey(903), false)
+
+    const keys = await store.notificationKeys?.()
+    expect(keys?.sort()).toEqual([telegramSessionKey(901), telegramSessionKey(902)])
+  })
+
   test("persists session alarm flags", async () => {
     const dir = await mkdtemp(join(tmpdir(), "telegram-session-store-"))
     const path = join(dir, "sessions.json")

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -517,7 +517,9 @@ async function notificationTargets(runtime: Runtime): Promise<string[]> {
   for (const key of keys) {
     const parsed = parseTelegramKey(key)
     if (!parsed) continue
-    targets.add(key)
+    const chatKey = notificationKey(parsed.chatId)
+    if (runtime.store.notificationGet && !(await notificationEnabled(runtime, chatKey))) continue
+    targets.add(chatKey)
   }
   return [...targets]
 }
@@ -644,9 +646,17 @@ async function readPendingQuestionsByKey(runtime: Runtime, key: string): Promise
   return []
 }
 
-async function readPendingQuestions(runtime: Runtime, chatId: number, userId?: number): Promise<TelegramPendingQuestion[]> {
-  const key = pendingKey(chatId, userId)
-  return readPendingQuestionsByKey(runtime, key)
+async function readPendingQuestionMatch(
+  runtime: Runtime,
+  chatId: number,
+  userId?: number,
+): Promise<{ itemKey: string; pending: TelegramPendingQuestion } | undefined> {
+  for (const itemKey of pendingLookupKeys(chatId, userId)) {
+    const queue = await readPendingQuestionsByKey(runtime, itemKey)
+    const pending = queue[0]
+    if (!pending) continue
+    return { itemKey, pending }
+  }
 }
 
 async function upsertPendingQuestion(runtime: Runtime, key: string, question: TelegramPendingQuestion) {
@@ -662,11 +672,6 @@ async function upsertPendingQuestion(runtime: Runtime, key: string, question: Te
     return
   }
   pendingQuestions.delete(key)
-}
-
-async function deletePendingQuestion(runtime: Runtime, chatId: number, requestId: string, userId?: number) {
-  const key = pendingKey(chatId, userId)
-  await deletePendingQuestionByKey(runtime, key, requestId)
 }
 
 async function deletePendingQuestionByKey(runtime: Runtime, key: string, requestId: string) {
@@ -2583,8 +2588,8 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
     const handled = await runCommand()
     if (handled) return
 
-    const queuedQuestions = await readPendingQuestions(runtime, chatId, userId)
-    const pending = queuedQuestions[0]
+    const match = await readPendingQuestionMatch(runtime, chatId, userId)
+    const pending = match?.pending
     if (pending) {
       const index = pendingQuestionIndex(pending)
       const row = pending.questions[index]
@@ -2596,9 +2601,8 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
         return
       }
       if (answers.length < pending.questions.length) {
-        const keyForPending = pendingKey(chatId, userId)
-        await upsertPendingQuestion(runtime, keyForPending, withAnswers(pending, answers))
-        const queue = await readPendingQuestions(runtime, chatId, userId)
+        await upsertPendingQuestion(runtime, match.itemKey, withAnswers(pending, answers))
+        const queue = await readPendingQuestionsByKey(runtime, match.itemKey)
         const next = queue.find((item) => item.requestId === pending.requestId)
         if (!next) {
           await sendTelegramMessage(config, chatId, "That question is no longer pending. Wait for the next prompt or use /status.")
@@ -2610,8 +2614,8 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
       }
       await sendQuestionReply(config, pending.requestId, answers)
         .then(async () => {
-          await deletePendingQuestion(runtime, chatId, pending.requestId, userId)
-          const remaining = await readPendingQuestions(runtime, chatId, userId)
+          await deletePendingQuestionByKey(runtime, match.itemKey, pending.requestId)
+          const remaining = await readPendingQuestionsByKey(runtime, match.itemKey)
           if (remaining.length) {
             const next = remaining[0]
             if (next) {
@@ -2624,7 +2628,7 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
         })
         .catch(async (error) => {
           if (!isMissingQuestion(error)) throw error
-          await deletePendingQuestion(runtime, chatId, pending.requestId, userId)
+          await deletePendingQuestionByKey(runtime, match.itemKey, pending.requestId)
           await sendTelegramMessage(config, chatId, "That question is no longer pending. Wait for the next prompt or use /status.")
         })
       return
@@ -2719,6 +2723,19 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, question: Tel
     notifyChats.add(parsed.chatId)
   }
   const kind = `question:${question.requestId}`
+  const pendingByChat = new Map<number, { key: string; userId?: number }>()
+  for (const key of pending) {
+    const parsed = parseTelegramKey(key)
+    if (!parsed) continue
+    const current = pendingByChat.get(parsed.chatId)
+    if (!current) {
+      pendingByChat.set(parsed.chatId, { key, userId: parsed.userId })
+      continue
+    }
+    if (current.userId !== undefined && parsed.userId === undefined) {
+      pendingByChat.set(parsed.chatId, { key, userId: parsed.userId })
+    }
+  }
   const chats = new Set<number>()
   const proactiveChats = new Set<number>()
   for (const key of pending) {
@@ -2726,9 +2743,10 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, question: Tel
       const parsed = parseTelegramKey(key)
       if (!parsed) continue
       const chatId = parsed.chatId
-      await upsertPendingQuestion(runtime, key, question)
       if (!chats.has(chatId)) {
         chats.add(chatId)
+        const pendingKey = pendingByChat.get(chatId)?.key || key
+        await upsertPendingQuestion(runtime, pendingKey, question)
         await appendPending(runtime, chatId, {
           id: pendingEntryId(sessionId, "question", chatId, question.requestId),
           kind: "question",

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -510,6 +510,39 @@ function notificationKey(chatId: number): string {
   return telegramSessionKey(chatId)
 }
 
+async function notificationTargets(runtime: Runtime): Promise<string[]> {
+  if (!runtime.store.notificationKeys) return []
+  const keys = await runtime.store.notificationKeys()
+  const targets = new Set<string>()
+  for (const key of keys) {
+    const parsed = parseTelegramKey(key)
+    if (!parsed) continue
+    targets.add(key)
+  }
+  return [...targets]
+}
+
+async function eventTargets(runtime: Runtime, sessionId: string): Promise<string[]> {
+  const alarmEnabled = runtime.store.sessionAlarmGet
+    ? await runtime.store.sessionAlarmGet(sessionId)
+    : true
+  if (!alarmEnabled) return []
+
+  const optedIn = await notificationTargets(runtime)
+  if (optedIn.length) return optedIn
+  if (!runtime.store.sessionKeys) return []
+
+  const targets = new Set<string>()
+  const keys = await runtime.store.sessionKeys(sessionId)
+  for (const key of keys) {
+    const parsed = parseTelegramKey(key)
+    if (!parsed) continue
+    if (!(await notificationEnabled(runtime, notificationKey(parsed.chatId)))) continue
+    targets.add(key)
+  }
+  return [...targets]
+}
+
 function proactiveTelegramEnabled(config: BridgeConfig): boolean {
   return config.telegramAlarmChannelEnabled !== false
 }
@@ -2597,57 +2630,58 @@ async function notifySessionKeys(
   requestId?: string,
   notifyKind?: string,
 ) {
-  if (!runtime.store.sessionKeys) return
+  const targets = await eventTargets(runtime, sessionId)
+  if (!targets.length) return
   const dedupeKey = notifyKind || kind
-  const keys = await runtime.store.sessionKeys(sessionId)
   const chats = new Set<number>()
-  for (const mapKey of keys) {
+  for (const key of targets) {
     try {
-      const parsed = parseTelegramKey(mapKey)
+      const parsed = parseTelegramKey(key)
       if (!parsed) continue
-      if (!chats.has(parsed.chatId)) {
-        chats.add(parsed.chatId)
-        const entry: TelegramPendingItem = {
-          id: pendingEntryId(sessionId, kind, parsed.chatId, requestId),
-          kind,
-          sessionId,
-          text,
-          stampedAt: Date.now(),
-          resolved: kind === "task-finished",
-        }
-        await appendPending(runtime, parsed.chatId, entry)
+      const chatId = parsed.chatId
+      const entry: TelegramPendingItem = {
+        id: pendingEntryId(sessionId, kind, chatId, requestId),
+        kind,
+        sessionId,
+        text,
+        stampedAt: Date.now(),
+        resolved: kind === "task-finished",
+      }
+      if (!chats.has(chatId)) {
+        chats.add(chatId)
+        await appendPending(runtime, chatId, entry)
         if (kind === "task-finished") {
-          await resolvePendingForSession(runtime, parsed.chatId, sessionId)
+          await resolvePendingForSession(runtime, chatId, sessionId)
         }
       }
-      if (!(await notificationEnabled(runtime, notificationKey(parsed.chatId)))) continue
       if (!proactiveTelegramEnabled(runtime.config)) continue
-      if (!shouldNotify(runtime.config, parsed.chatId, dedupeKey, sessionId)) continue
+      if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId)}`
-      await queueChatUpdate(String(parsed.chatId), async () => {
-        await sendTelegramMessage(runtime.config, parsed.chatId, message)
+      await queueChatUpdate(String(chatId), async () => {
+        await sendTelegramMessage(runtime.config, chatId, message)
       })
-      stampNotification(parsed.chatId, dedupeKey, sessionId)
+      stampNotification(chatId, dedupeKey, sessionId)
     } catch (error) {
-      console.error("[TelegramBridge] outbound notify failed", { sessionId, key: mapKey, kind, error })
+      console.error("[TelegramBridge] outbound notify failed", { sessionId, key, kind, error })
     }
   }
 }
 
 async function notifyQuestion(runtime: Runtime, sessionId: string, question: TelegramPendingQuestion) {
-  if (!runtime.store.sessionKeys) return
-  const keys = await runtime.store.sessionKeys(sessionId)
+  const targets = await eventTargets(runtime, sessionId)
+  if (!targets.length) return
   const kind = `question:${question.requestId}`
   const chats = new Set<number>()
-  for (const key of keys) {
+  for (const key of targets) {
     try {
       const parsed = parseTelegramKey(key)
       if (!parsed) continue
+      const chatId = parsed.chatId
       await upsertPendingQuestion(runtime, key, question)
-      if (!chats.has(parsed.chatId)) {
-        chats.add(parsed.chatId)
-        await appendPending(runtime, parsed.chatId, {
-          id: pendingEntryId(sessionId, "question", parsed.chatId, question.requestId),
+      if (!chats.has(chatId)) {
+        chats.add(chatId)
+        await appendPending(runtime, chatId, {
+          id: pendingEntryId(sessionId, "question", chatId, question.requestId),
           kind: "question",
           sessionId,
           text: pendingQuestionText(question),
@@ -2655,14 +2689,13 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, question: Tel
           resolved: false,
         })
       }
-      if (!(await notificationEnabled(runtime, notificationKey(parsed.chatId)))) continue
       if (!proactiveTelegramEnabled(runtime.config)) continue
-      if (!shouldNotify(runtime.config, parsed.chatId, kind, sessionId)) continue
-      await queueChatUpdate(String(parsed.chatId), async () => {
-        await sendTelegramQuestionPrompt(runtime.config, parsed.chatId, question)
-        await sendTelegramMessage(runtime.config, parsed.chatId, `Open ${sessionLabel(runtime.config, sessionId)}`)
+      if (!shouldNotify(runtime.config, chatId, kind, sessionId)) continue
+      await queueChatUpdate(String(chatId), async () => {
+        await sendTelegramQuestionPrompt(runtime.config, chatId, question)
+        await sendTelegramMessage(runtime.config, chatId, `Open ${sessionLabel(runtime.config, sessionId)}`)
       })
-      stampNotification(parsed.chatId, kind, sessionId)
+      stampNotification(chatId, kind, sessionId)
     } catch (error) {
       console.error("[TelegramBridge] outbound question notify failed", { sessionId, key, error })
     }
@@ -2714,16 +2747,17 @@ export async function handleBridgeEvent(runtime: Runtime, event: { type: string;
     const deletedSessionId = typeof info?.id === "string" ? info.id : sessionId
     if (!deletedSessionId) return
     statusBySession.delete(deletedSessionId)
-    if (runtime.store.sessionKeys) {
-      const keys = await runtime.store.sessionKeys(deletedSessionId)
-      const chats = new Set<number>()
-      for (const key of keys) {
-        const parsed = parseTelegramKey(key)
-        if (!parsed) continue
-        if (chats.has(parsed.chatId)) continue
-        chats.add(parsed.chatId)
-        await resolvePendingForSession(runtime, parsed.chatId, deletedSessionId)
-      }
+    const targets = await notificationTargets(runtime)
+    const keys = targets.length || !runtime.store.sessionKeys
+      ? targets
+      : await runtime.store.sessionKeys(deletedSessionId)
+    const chats = new Set<number>()
+    for (const key of keys) {
+      const parsed = parseTelegramKey(key)
+      if (!parsed) continue
+      if (chats.has(parsed.chatId)) continue
+      chats.add(parsed.chatId)
+      await resolvePendingForSession(runtime, parsed.chatId, deletedSessionId)
     }
     return
   }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -522,6 +522,36 @@ async function notificationTargets(runtime: Runtime): Promise<string[]> {
   return [...targets]
 }
 
+async function sessionTargets(runtime: Runtime, sessionId: string): Promise<string[]> {
+  if (!runtime.store.sessionKeys) return []
+  const keys = await runtime.store.sessionKeys(sessionId)
+  const targets = new Set<string>()
+  for (const key of keys) {
+    const parsed = parseTelegramKey(key)
+    if (!parsed) continue
+    targets.add(key)
+  }
+  return [...targets]
+}
+
+async function pendingTargets(runtime: Runtime, sessionId: string): Promise<string[]> {
+  const alarmEnabled = runtime.store.sessionAlarmGet
+    ? await runtime.store.sessionAlarmGet(sessionId)
+    : true
+  if (!alarmEnabled) return []
+
+  const targets = new Set<string>()
+  const mapped = await sessionTargets(runtime, sessionId)
+  for (const key of mapped) {
+    targets.add(key)
+  }
+  const optedIn = await notificationTargets(runtime)
+  for (const key of optedIn) {
+    targets.add(key)
+  }
+  return [...targets]
+}
+
 async function eventTargets(runtime: Runtime, sessionId: string): Promise<string[]> {
   const alarmEnabled = runtime.store.sessionAlarmGet
     ? await runtime.store.sessionAlarmGet(sessionId)
@@ -530,10 +560,10 @@ async function eventTargets(runtime: Runtime, sessionId: string): Promise<string
 
   const optedIn = await notificationTargets(runtime)
   if (optedIn.length) return optedIn
-  if (!runtime.store.sessionKeys) return []
+  const keys = await sessionTargets(runtime, sessionId)
+  if (!keys.length) return []
 
   const targets = new Set<string>()
-  const keys = await runtime.store.sessionKeys(sessionId)
   for (const key of keys) {
     const parsed = parseTelegramKey(key)
     if (!parsed) continue
@@ -2630,11 +2660,18 @@ async function notifySessionKeys(
   requestId?: string,
   notifyKind?: string,
 ) {
-  const targets = await eventTargets(runtime, sessionId)
-  if (!targets.length) return
+  const pending = await pendingTargets(runtime, sessionId)
+  if (!pending.length) return
+  const notify = await eventTargets(runtime, sessionId)
+  const notifyChats = new Set<number>()
+  for (const key of notify) {
+    const parsed = parseTelegramKey(key)
+    if (!parsed) continue
+    notifyChats.add(parsed.chatId)
+  }
   const dedupeKey = notifyKind || kind
   const chats = new Set<number>()
-  for (const key of targets) {
+  for (const key of pending) {
     try {
       const parsed = parseTelegramKey(key)
       if (!parsed) continue
@@ -2654,6 +2691,7 @@ async function notifySessionKeys(
           await resolvePendingForSession(runtime, chatId, sessionId)
         }
       }
+      if (!notifyChats.has(chatId)) continue
       if (!proactiveTelegramEnabled(runtime.config)) continue
       if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId)}`
@@ -2668,11 +2706,18 @@ async function notifySessionKeys(
 }
 
 async function notifyQuestion(runtime: Runtime, sessionId: string, question: TelegramPendingQuestion) {
-  const targets = await eventTargets(runtime, sessionId)
-  if (!targets.length) return
+  const pending = await pendingTargets(runtime, sessionId)
+  if (!pending.length) return
+  const notify = await eventTargets(runtime, sessionId)
+  const notifyChats = new Set<number>()
+  for (const key of notify) {
+    const parsed = parseTelegramKey(key)
+    if (!parsed) continue
+    notifyChats.add(parsed.chatId)
+  }
   const kind = `question:${question.requestId}`
   const chats = new Set<number>()
-  for (const key of targets) {
+  for (const key of pending) {
     try {
       const parsed = parseTelegramKey(key)
       if (!parsed) continue
@@ -2689,6 +2734,7 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, question: Tel
           resolved: false,
         })
       }
+      if (!notifyChats.has(chatId)) continue
       if (!proactiveTelegramEnabled(runtime.config)) continue
       if (!shouldNotify(runtime.config, chatId, kind, sessionId)) continue
       await queueChatUpdate(String(chatId), async () => {
@@ -2747,12 +2793,17 @@ export async function handleBridgeEvent(runtime: Runtime, event: { type: string;
     const deletedSessionId = typeof info?.id === "string" ? info.id : sessionId
     if (!deletedSessionId) return
     statusBySession.delete(deletedSessionId)
-    const targets = await notificationTargets(runtime)
-    const keys = targets.length || !runtime.store.sessionKeys
-      ? targets
-      : await runtime.store.sessionKeys(deletedSessionId)
+    const targets = new Set<string>()
+    const mapped = await sessionTargets(runtime, deletedSessionId)
+    for (const key of mapped) {
+      targets.add(key)
+    }
+    const optedIn = await notificationTargets(runtime)
+    for (const key of optedIn) {
+      targets.add(key)
+    }
     const chats = new Set<number>()
-    for (const key of keys) {
+    for (const key of targets) {
       const parsed = parseTelegramKey(key)
       if (!parsed) continue
       if (chats.has(parsed.chatId)) continue

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -2671,6 +2671,7 @@ async function notifySessionKeys(
   }
   const dedupeKey = notifyKind || kind
   const chats = new Set<number>()
+  const proactiveChats = new Set<number>()
   for (const key of pending) {
     try {
       const parsed = parseTelegramKey(key)
@@ -2692,6 +2693,8 @@ async function notifySessionKeys(
         }
       }
       if (!notifyChats.has(chatId)) continue
+      if (proactiveChats.has(chatId)) continue
+      proactiveChats.add(chatId)
       if (!proactiveTelegramEnabled(runtime.config)) continue
       if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId)}`
@@ -2717,6 +2720,7 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, question: Tel
   }
   const kind = `question:${question.requestId}`
   const chats = new Set<number>()
+  const proactiveChats = new Set<number>()
   for (const key of pending) {
     try {
       const parsed = parseTelegramKey(key)
@@ -2735,6 +2739,8 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, question: Tel
         })
       }
       if (!notifyChats.has(chatId)) continue
+      if (proactiveChats.has(chatId)) continue
+      proactiveChats.add(chatId)
       if (!proactiveTelegramEnabled(runtime.config)) continue
       if (!shouldNotify(runtime.config, chatId, kind, sessionId)) continue
       await queueChatUpdate(String(chatId), async () => {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -2589,8 +2589,8 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
     if (handled) return
 
     const match = await readPendingQuestionMatch(runtime, chatId, userId)
-    const pending = match?.pending
-    if (pending) {
+    if (match) {
+      const pending = match.pending
       const index = pendingQuestionIndex(pending)
       const row = pending.questions[index]
       const current = row ? answerFromInput(row, text) : undefined

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -347,6 +347,7 @@ export type TelegramSessionStore = {
   historySet?: (key: string, ids: string[]) => Promise<void>
   notificationGet?: (key: string) => Promise<boolean>
   notificationSet?: (key: string, enabled: boolean) => Promise<void>
+  notificationKeys?: () => Promise<string[]>
   sessionAlarmGet?: (sessionId: string) => Promise<boolean>
   sessionAlarmSet?: (sessionId: string, enabled: boolean) => Promise<void>
   inboxGet?: (key: string) => Promise<TelegramPendingItem[]>
@@ -564,6 +565,10 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
           throw error
         })
       })
+    },
+    async notificationKeys() {
+      await ready
+      return Array.from(notifications.keys())
     },
     async sessionAlarmGet(sessionId: string) {
       await ready


### PR DESCRIPTION
## Summary
- route proactive Telegram event fanout from chats with /notify on opt-in instead of relying on per-session chat mappings
- gate proactive alerts and pending inbox entries on per-session bell/alarm state from sessionAlarms
- add notification key listing in the session store, update bridge tests, and document the new routing model

Closes #327