### PR TITLE
fix: sync /notify on with mapped session alarms

### DIFF
--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -2108,6 +2108,9 @@ describe("telegram bridge config and cache", () => {
         const url = String(input);
         const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
         calls.push({ url, body });
+        if (url.includes("/session/session-1")) {
+          return new Response(JSON.stringify({ title: "Sprint Planning" }), { status: 200 });
+        }
         if (url.includes("/sendMessage")) {
           return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
         }
@@ -3882,6 +3885,255 @@ describe("telegram bridge config and cache", () => {
     expect(alarms.get("session-81")).toBe(true);
   });
 
+  test("session action switch callback remaps to target session", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/session-target")) {
+          return new Response(JSON.stringify({ title: "Launch Readiness" }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const map = new Map<string, string>();
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async (key: string) => map.get(key),
+          set: async (key: string, value: string) => {
+            map.set(key, value);
+          },
+          delete: async () => undefined,
+          historyGet: async () => [],
+          historySet: async () => undefined,
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 83,
+        callback_query: {
+          id: "cb-session-switch",
+          data: "a:s:session-target",
+          from: { id: 5 },
+          message: { message_id: 7, chat: { id: 81 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/answerCallbackQuery") && String(x.body.text || "").includes("Switched"))).toBe(true);
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes("Switched to session: Launch Readiness"))).toBe(true);
+  });
+
+  test("session action latest-message callback sends recent output", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/session-target/message")) {
+          return new Response(JSON.stringify([
+            {
+              info: { id: "m1", role: "user" },
+              parts: [{ type: "text", text: "show me latest" }],
+            },
+            {
+              info: { id: "m2", role: "assistant", parentID: "m1" },
+              parts: [{ type: "text", text: "Here is the latest update." }],
+            },
+          ]), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 84,
+        callback_query: {
+          id: "cb-session-recent",
+          data: "a:r:session-target",
+          from: { id: 5 },
+          message: { message_id: 7, chat: { id: 81 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/answerCallbackQuery") && String(x.body.text || "").includes("Fetching latest message"))).toBe(true);
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes("Latest message in session-target"))).toBe(true);
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes("Assistant: Here is the latest update."))).toBe(true);
+  });
+
+  test("session action latest-message callback does not truncate long assistant output", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const longText = `${"A".repeat(520)} END`;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/session-target/message")) {
+          return new Response(JSON.stringify([
+            {
+              info: { id: "m1", role: "assistant" },
+              parts: [{ type: "text", text: longText }],
+            },
+          ]), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 86,
+        callback_query: {
+          id: "cb-session-recent-long",
+          data: "a:r:session-target",
+          from: { id: 5 },
+          message: { message_id: 7, chat: { id: 81 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes(longText))).toBe(true);
+  });
+
+  test("session action latest-message callback falls back to assistant-only history", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/session-target/message")) {
+          return new Response(JSON.stringify([
+            {
+              info: { id: "m1", role: "assistant" },
+              parts: [{ type: "text", text: "Pipeline completed successfully." }],
+            },
+          ]), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 85,
+        callback_query: {
+          id: "cb-session-recent-assistant-only",
+          data: "a:r:session-target",
+          from: { id: 5 },
+          message: { message_id: 7, chat: { id: 81 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes("Latest message in session-target"))).toBe(true);
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes("Assistant: Pipeline completed successfully."))).toBe(true);
+  });
+
   test("/pending returns aggregated actionable items for the chat", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
@@ -5570,7 +5822,10 @@ describe("telegram bridge config and cache", () => {
     const sentTexts = calls
       .filter((x) => x.url.includes("/sendMessage"))
       .map((x) => String(x.body.text || ""));
-    expect(sentTexts).toEqual(["Task finished: the session is now idle.\n\nOpen session session-1"]);
+    expect(sentTexts).toEqual(["Task finished: the session is now idle.\n\nSession: session-1"]);
+    const sent = calls.find((x) => x.url.includes("/sendMessage"));
+    const markup = sent?.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined;
+    expect(markup?.inline_keyboard?.[0]?.map((item) => item.callback_data)).toEqual(["a:s:session-1", "a:r:session-1"]);
   });
 
   test("handleBridgeEvent clears tracked status on session.deleted without sessionID", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -301,6 +301,7 @@ describe("telegram bridge config and cache", () => {
       { command: "sessions", description: "List known sessions for this chat/user mapping" },
       { command: "recent", description: "Show latest user/assistant exchanges" },
       { command: "switch", description: "Switch this chat/user mapping to an existing session" },
+      { command: "project", description: "Show or set OpenCode project directory" },
       { command: "notify", description: "Control proactive notifications" },
       { command: "pending", description: "Show pending inbox items" },
       { command: "inbox", description: "Alias for /pending" },
@@ -643,6 +644,55 @@ describe("telegram bridge config and cache", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test("handleTextUpdate reports long-running prompt timeout without generic error", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current/message")) {
+          throw new DOMException("The operation timed out.", "TimeoutError");
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 4,
+        message: { message_id: 4, text: "please continue", chat: { id: 7 }, from: { id: 9 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sentTexts = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
+    expect(sentTexts.some((text) => text.includes("Prompt started in session session-current"))).toBe(true);
+    expect(sentTexts.some((text) => text.includes("internal error"))).toBe(false);
   });
 
   test("/prompts lists available saved prompts with scope hints", async () => {
@@ -2483,6 +2533,224 @@ describe("telegram bridge config and cache", () => {
       .map((x) => String(x.body.text || ""));
     expect(sent[0]).toBe("Current session: session-current");
     expect(historyWrites).toBe(0);
+  });
+
+  test("/project status reports whether override is configured", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 90,
+        message: { message_id: 90, text: "/project", chat: { id: 95 }, from: { id: 8 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const text = String(calls.find((x) => x.url.includes("/sendMessage"))?.body.text || "");
+    expect(text).toContain("Project directory override is not set");
+  });
+
+  test("/project status includes project picker buttons from recent sessions", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/s-a")) {
+          return new Response(JSON.stringify({ id: "s-a", title: "Alpha", directory: "/work/a" }), { status: 200 });
+        }
+        if (url.includes("/session/s-b")) {
+          return new Response(JSON.stringify({ id: "s-b", title: "Beta", directory: "/work/b" }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => "s-a",
+          set: async () => undefined,
+          delete: async () => undefined,
+          historyGet: async () => ["s-b"],
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 93,
+        message: { message_id: 93, text: "/project", chat: { id: 95 }, from: { id: 8 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sent = calls.find((x) => x.url.includes("/sendMessage"));
+    const keyboard = sent?.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined;
+    expect(keyboard?.inline_keyboard?.[0]?.[0]?.callback_data).toBe("d:s:s-a");
+    expect(keyboard?.inline_keyboard?.[1]?.[0]?.callback_data).toBe("d:s:s-b");
+  });
+
+  test("/project set and clear update runtime and persist settings", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const settingsPath = process.env.TELEGRAM_SETTINGS_PATH || "";
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 91,
+        message: { message_id: 91, text: "/project /tmp/work-a", chat: { id: 95 }, from: { id: 8 } },
+      });
+      expect(runtime.config.directory).toBe("/tmp/work-a");
+
+      let stored = JSON.parse(await Bun.file(settingsPath).text()) as { settings?: { directory?: string } };
+      expect(stored.settings?.directory).toBe("/tmp/work-a");
+
+      await handleTextUpdate(runtime, {
+        update_id: 92,
+        message: { message_id: 92, text: "/project clear", chat: { id: 95 }, from: { id: 8 } },
+      });
+      expect(runtime.config.directory).toBeUndefined();
+
+      stored = JSON.parse(await Bun.file(settingsPath).text()) as { settings?: { directory?: string } };
+      expect(stored.settings?.directory).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sentTexts = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
+    expect(sentTexts.some((text) => text.includes("Project directory override set to: /tmp/work-a"))).toBe(true);
+    expect(sentTexts.some((text) => text.includes("Cleared project directory override"))).toBe(true);
+  });
+
+  test("project picker callback switches directory from selected session", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/s-a")) {
+          return new Response(JSON.stringify({ id: "s-a", title: "Alpha", directory: "/work/a" }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => "s-a",
+          set: async () => undefined,
+          delete: async () => undefined,
+          historyGet: async () => ["s-a"],
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 94,
+        callback_query: {
+          id: "cb-project-switch",
+          data: "d:s:s-a",
+          from: { id: 8 },
+          message: { message_id: 94, chat: { id: 95 } },
+        },
+      });
+
+      expect(runtime.config.directory).toBe("/work/a");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sentTexts = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
+    expect(sentTexts.some((text) => text.includes("Project directory override set to: /work/a"))).toBe(true);
   });
 
   test("/sessions and /status reuse cached session metadata within ttl", async () => {
@@ -5528,6 +5796,128 @@ describe("telegram bridge config and cache", () => {
     expect((inbox.get("chat:188") || []).length).toBe(0);
   });
 
+  test("session alarms read latest state from disk for cross-process updates", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const dir = await mkdtemp(join(tmpdir(), "telegram-store-"));
+    testTempDirs.push(dir);
+    const storePath = join(dir, "telegram-sessions.json");
+    await writeFile(
+      storePath,
+      `${JSON.stringify({
+        version: 4,
+        sessions: {},
+        history: {},
+        notifications: { "chat:188": true },
+        sessionAlarms: { "session-disk": true },
+        inbox: {},
+        pending: {},
+      }, null, 2)}\n`,
+    );
+
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: storePath,
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => [],
+          notificationKeys: async () => ["chat:188"],
+          sessionAlarmGet: async () => false,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-disk-alarm",
+          sessionID: "session-disk",
+          questions: [{ header: "Need confirmation" }],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes("Question pending:"))).toBe(true);
+  });
+
+  test("session alarms inherit from root session for child events", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const alarms = new Map<string, boolean>([["session-root", true]]);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-child")) {
+          return new Response(JSON.stringify({ id: "session-child", parentID: "session-root" }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          sessionKeys: async () => [],
+          notificationKeys: async () => ["chat:188"],
+          sessionAlarmGet: async (sessionId: string) => alarms.get(sessionId) === true,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "question.asked",
+        properties: {
+          id: "req-inherited",
+          sessionID: "session-child",
+          questions: [{ header: "Confirm" }],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes("Question pending:"))).toBe(true);
+  });
+
   test("question, permission, and task-finished skip proactive send when telegram channel is disabled", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
@@ -6179,6 +6569,63 @@ describe("telegram bridge config and cache", () => {
     }
   });
 
+  test("/new auto-enables session alarm when chat notifications are enabled", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const alarms = new Map<string, boolean>();
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url === "http://127.0.0.1:4096/session") {
+          return new Response(JSON.stringify({ id: "session-new" }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          notificationGet: async (key: string) => key === "chat:7",
+          sessionAlarmSet: async (sessionId: string, enabled: boolean) => {
+            if (enabled) {
+              alarms.set(sessionId, true);
+              return;
+            }
+            alarms.delete(sessionId);
+          },
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 3,
+        message: { message_id: 3, text: "/new", chat: { id: 7 }, from: { id: 9 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(alarms.get("session-new")).toBe(true);
+    expect(calls.some((x) => x.url.includes("/sendMessage") && String(x.body.text || "").includes("Started a new session: session-new"))).toBe(true);
+  });
+
   test("outbound SSE parser handles CRLF split across chunk boundaries", () => {
     const blocks = parseOutboundBlocks(["data: one\r", "\n\r", "\ndata: two\n\n"]);
     expect(blocks).toEqual(["data: one", "data: two"]);
@@ -6394,7 +6841,13 @@ describe("telegram bridge config and cache", () => {
         properties: {
           id: "req-1",
           sessionID: "session-1",
-          questions: [{ header: "Pick one", options: [{ label: "Alpha" }, { label: "Beta" }] }],
+          questions: [{
+            header: "Pick one",
+            options: [
+              { label: "Alpha", description: "Issue #101 - stabilize rollout" },
+              { label: "Beta", description: "Issue #102 - add project picker" },
+            ],
+          }],
         },
       });
 
@@ -6411,7 +6864,7 @@ describe("telegram bridge config and cache", () => {
     const sentTexts = calls
       .filter((x) => x.url.includes("/sendMessage"))
       .map((x) => String(x.body.text || ""));
-    expect(sentTexts.some((text) => text.includes("1) Alpha"))).toBe(true);
+    expect(sentTexts.some((text) => text.includes("1) Alpha - Issue #101 - stabilize rollout"))).toBe(true);
     expect(sentTexts.some((text) => text.includes("Open session session-1"))).toBe(true);
     expect(sentTexts.some((text) => text.includes("Thanks, your answer was sent."))).toBe(true);
   });

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -3613,6 +3613,8 @@ describe("telegram bridge config and cache", () => {
 
       const map = new Map<string, string>();
       const notify = new Map<string, boolean>();
+      const alarms = new Map<string, boolean>();
+      map.set("chat:77:user:5", "session-77");
       const runtime = {
         config: {
           mode: "polling" as const,
@@ -3640,6 +3642,13 @@ describe("telegram bridge config and cache", () => {
               return;
             }
             notify.delete(key);
+          },
+          sessionAlarmSet: async (sessionId: string, enabled: boolean) => {
+            if (enabled) {
+              alarms.set(sessionId, true);
+              return;
+            }
+            alarms.delete(sessionId);
           },
         },
       };
@@ -3669,6 +3678,7 @@ describe("telegram bridge config and cache", () => {
       expect(sentTexts[2]).toBe("Notifications are enabled.");
       expect(sentTexts[3]).toBe("Notifications disabled for this chat.");
       expect(notify.get("chat:77")).toBeUndefined();
+      expect(alarms.get("session-77")).toBe(true);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -3797,6 +3807,7 @@ describe("telegram bridge config and cache", () => {
   test("notify callback toggles state and returns updated button state", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
+    const alarms = new Map<string, boolean>();
     try {
       globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
@@ -3812,6 +3823,8 @@ describe("telegram bridge config and cache", () => {
       };
 
       const notify = new Map<string, boolean>();
+      const map = new Map<string, string>();
+      map.set("chat:81", "session-81");
       const runtime = {
         config: {
           mode: "polling" as const,
@@ -3825,7 +3838,7 @@ describe("telegram bridge config and cache", () => {
           sessionStorePath: "/tmp/test-store.json",
         },
         store: {
-          get: async () => undefined,
+          get: async (key: string) => map.get(key),
           set: async () => undefined,
           delete: async () => undefined,
           notificationGet: async (key: string) => notify.get(key) === true,
@@ -3835,6 +3848,13 @@ describe("telegram bridge config and cache", () => {
               return;
             }
             notify.delete(key);
+          },
+          sessionAlarmSet: async (sessionId: string, enabled: boolean) => {
+            if (enabled) {
+              alarms.set(sessionId, true);
+              return;
+            }
+            alarms.delete(sessionId);
           },
         },
       };
@@ -3859,6 +3879,7 @@ describe("telegram bridge config and cache", () => {
     const top = markup?.inline_keyboard?.[0] || [];
     expect(top.map((item) => item.callback_data)).toEqual(["n:on", "n:off"]);
     expect((top[0]?.text || "").includes("✅")).toBe(true);
+    expect(alarms.get("session-81")).toBe(true);
   });
 
   test("/pending returns aggregated actionable items for the chat", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -947,6 +947,7 @@ describe("telegram bridge config and cache", () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
     const map = new Map<string, string>([["chat:79:user:6", "session-current"]]);
+    const alarms = new Map<string, boolean>();
     try {
       globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
@@ -993,6 +994,13 @@ describe("telegram bridge config and cache", () => {
           delete: async (key: string) => {
             map.delete(key);
           },
+          sessionAlarmSet: async (sessionId: string, enabled: boolean) => {
+            if (enabled) {
+              alarms.set(sessionId, true);
+              return;
+            }
+            alarms.delete(sessionId);
+          },
         },
       };
 
@@ -1015,6 +1023,154 @@ describe("telegram bridge config and cache", () => {
     expect(promptRun?.body.parts).toEqual([{ type: "text", text: "Deploy now" }]);
     const sentTexts = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
     expect(sentTexts.some((text) => text.includes("Deploy complete."))).toBe(true);
+    expect(alarms.get("session-current")).toBe(true);
+  });
+
+  test("prompt callback continues when callback query is already expired", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const map = new Map<string, string>([["chat:79:user:6", "session-current"]]);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-1", title: "Quick summary", text: "Summarize now", createdAt: 10 }],
+              project: [{ id: "p-1", title: "Deploy release", text: "Deploy now", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(
+            JSON.stringify({ ok: false, description: "Bad Request: query is too old and response timeout expired or query ID is invalid" }),
+            { status: 400 },
+          );
+        }
+        if (url.includes("/session/session-current/message")) {
+          return new Response(JSON.stringify({ parts: [{ type: "text", text: "Deploy complete." }] }), { status: 200 });
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async (key: string) => map.get(key),
+          set: async (key: string, value: string) => {
+            map.set(key, value);
+          },
+          delete: async (key: string) => {
+            map.delete(key);
+          },
+          sessionAlarmSet: async () => undefined,
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 14,
+        callback_query: {
+          id: "cb-prompt-expired",
+          data: "p:p-1",
+          from: { id: 6 },
+          message: { message_id: 14, chat: { id: 79 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sentTexts = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
+    expect(sentTexts.some((text) => text.includes("Deploy complete."))).toBe(true);
+    expect(sentTexts.some((text) => text.includes("something went wrong while processing that button"))).toBe(false);
+  });
+
+  test("prompt callback reports long-running prompt instead of generic callback error", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const map = new Map<string, string>([["chat:79:user:6", "session-current"]]);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/api/ext/saved-prompts")) {
+          return new Response(
+            JSON.stringify({
+              global: [{ id: "g-1", title: "Quick summary", text: "Summarize now", createdAt: 10 }],
+              project: [{ id: "p-1", title: "Deploy release", text: "Deploy now", createdAt: 20 }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/session-current/message")) {
+          throw new DOMException("The operation timed out.", "TimeoutError");
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async (key: string) => map.get(key),
+          set: async (key: string, value: string) => {
+            map.set(key, value);
+          },
+          delete: async (key: string) => {
+            map.delete(key);
+          },
+          sessionAlarmSet: async () => undefined,
+        },
+      };
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 13,
+        callback_query: {
+          id: "cb-prompt-timeout",
+          data: "p:p-1",
+          from: { id: 6 },
+          message: { message_id: 13, chat: { id: 79 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const sentTexts = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
+    expect(sentTexts.some((text) => text.includes("Prompt started in session session-current"))).toBe(true);
+    expect(sentTexts.some((text) => text.includes("something went wrong while processing that button"))).toBe(false);
   });
 
   test("/prompts uses deterministic ordering when createdAt is invalid", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4251,7 +4251,7 @@ describe("telegram bridge config and cache", () => {
 
       const notify = new Map<string, boolean>();
       const map = new Map<string, string>();
-      map.set("chat:81", "session-81");
+      map.set("chat:81:user:5", "session-81");
       const runtime = {
         config: {
           mode: "polling" as const,

--- a/app-prefixable/tests/telegram-settings.test.ts
+++ b/app-prefixable/tests/telegram-settings.test.ts
@@ -177,6 +177,52 @@ describe("telegram settings extended API", () => {
     expect(stored.sessionAlarms?.["session-alarm-a"]).toBe(true)
   })
 
+  test("enabling session alarm auto-enables Telegram notify for mapped chats", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "telegram-settings-"))
+    const path = join(dir, "telegram-settings.json")
+    const storePath = join(dir, "telegram-sessions.json")
+    cleanupPaths.push(dir)
+
+    process.env.TELEGRAM_SETTINGS_PATH = path
+    process.env.TELEGRAM_SESSION_STORE_PATH = storePath
+
+    await writeFile(
+      storePath,
+      `${JSON.stringify({
+        version: 2,
+        sessions: {
+          "chat:99:user:4": "session-sync",
+          "chat:99:user:7": "session-sync",
+          "chat:100": "session-sync",
+          "chat:101": "session-other",
+        },
+        notifications: {},
+        sessionAlarms: {},
+      }, null, 2)}\n`,
+    )
+
+    const set = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "PUT",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: "session-sync", enabled: true }),
+      }),
+    )
+
+    expect(set?.status).toBe(200)
+    const stored = JSON.parse(await Bun.file(storePath).text()) as {
+      notifications?: Record<string, boolean>
+      sessionAlarms?: Record<string, boolean>
+    }
+    expect(stored.sessionAlarms?.["session-sync"]).toBe(true)
+    expect(stored.notifications?.["chat:99"]).toBe(true)
+    expect(stored.notifications?.["chat:100"]).toBe(true)
+    expect(stored.notifications?.["chat:101"]).toBeUndefined()
+  })
+
   test("session alarm endpoint validates session id and enabled payload", async () => {
     const dir = await mkdtemp(join(tmpdir(), "telegram-settings-"))
     cleanupPaths.push(dir)

--- a/shared/extended-api.ts
+++ b/shared/extended-api.ts
@@ -32,6 +32,29 @@ function sessionAlarmSessionIdError(sessionId: string) {
   }
 }
 
+function notifyChatKeyFromSessionKey(value: string) {
+  const match = value.match(/^chat:(-?\d+)(?::user:-?\d+)?$/)
+  if (!match) return
+  const chatId = Number.parseInt(match[1] || "", 10)
+  if (!Number.isFinite(chatId)) return
+  return `chat:${chatId}`
+}
+
+async function enableTelegramNotifyForSession(store: TelegramSessionStore, sessionId: string) {
+  if (!store.sessionKeys || !store.notificationSet) return
+  const keys = await store.sessionKeys(sessionId)
+  if (!keys.length) return
+  const chats = new Set<string>()
+  for (const key of keys) {
+    const chatKey = notifyChatKeyFromSessionKey(key)
+    if (!chatKey) continue
+    chats.add(chatKey)
+  }
+  for (const chatKey of chats) {
+    await store.notificationSet(chatKey, true)
+  }
+}
+
 function evictTelegramSessionStoresIfNeeded() {
   while (telegramSessionStores.size > MAX_TELEGRAM_SESSION_STORES) {
     const oldest = telegramSessionStores.keys().next().value
@@ -678,6 +701,11 @@ export async function handleExtendedEndpoint(
     )
     if (ok === false) {
       return Response.json({ error: "failed to update telegram session alarm" }, { status: 500 })
+    }
+    if (enabled) {
+      await enableTelegramNotifyForSession(store, sessionId).catch((error) => {
+        console.error("[ExtAPI] telegram notify sync on session alarm enable failed", { sessionId, error })
+      })
     }
     return Response.json({ sessionId, enabled })
   }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -973,7 +973,9 @@ function sessionActionCallback(action: "switch" | "recent", sessionId: string): 
 }
 
 function parseSessionActionCallbackData(input: string): SessionActionCallbackData | undefined {
-  const parsed = input.match(/^a:([sr]):([^\s:]{1,58})$/)
+  const maxSessionIdLength = callbackDataMax - "a:s:".length
+  if (maxSessionIdLength < 1) return
+  const parsed = input.match(new RegExp(`^a:([sr]):([^\\s:]{1,${maxSessionIdLength}})$`))
   if (!parsed) return
   const action = parsed[1]
   const sessionId = parsed[2]?.trim() || ""
@@ -997,7 +999,9 @@ function projectClearCallback(): string {
 
 function parseProjectActionCallbackData(input: string): ProjectActionCallbackData | undefined {
   if (input === "d:c") return { action: "clear" }
-  const parsed = input.match(/^d:s:([^\s:]{1,58})$/)
+  const maxSessionIdLength = callbackDataMax - "d:s:".length
+  if (maxSessionIdLength < 1) return
+  const parsed = input.match(new RegExp(`^d:s:([^\\s:]{1,${maxSessionIdLength}})$`))
   if (!parsed) return
   const sessionId = parsed[1]?.trim() || ""
   if (!sessionId) return
@@ -2577,6 +2581,7 @@ function lookupSavedPrompt(input: string, prompts: SavedPrompt[]): { prompt?: Sa
 
 async function runSavedPrompt(runtime: Runtime, chatId: number, key: string, prompt: SavedPrompt) {
   const config = runtime.config
+  let activeSessionId = ""
   const enableAlarm = async (sessionId: string) => {
     if (!runtime.store.sessionAlarmSet) return
     await runtime.store.sessionAlarmSet(sessionId, true).catch((error) => {
@@ -2584,6 +2589,7 @@ async function runSavedPrompt(runtime: Runtime, chatId: number, key: string, pro
     })
   }
   const run = async (sessionId: string) => {
+    activeSessionId = sessionId
     await enableAlarm(sessionId)
     await resolvePendingForSession(runtime, chatId, sessionId)
     return sendPrompt(config, sessionId, prompt.text)
@@ -2601,7 +2607,8 @@ async function runSavedPrompt(runtime: Runtime, chatId: number, key: string, pro
     if (!isTimeoutError(error)) {
       throw error
     }
-    await sendTelegramMessage(config, chatId, `Prompt started in session ${sessionId}, but the reply is taking longer than expected. Check the web UI for progress.`)
+    const timedOutSession = activeSessionId || sessionId
+    await sendTelegramMessage(config, chatId, `Prompt started in session ${timedOutSession}, but the reply is taking longer than expected. Check the web UI for progress.`)
     return
   })
   if (!reply) return
@@ -2827,11 +2834,12 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
 
     if (parsed.kind === "notify") {
       const key = notificationKey(chatId)
+      const mappedKey = telegramSessionKey(chatId, userId)
       await answerCallback(runtime.config, callbackId, notifyCallbackAckText)
       state.acknowledged = true
       if (parsed.mode === "on") {
         await setNotificationEnabled(runtime, key, true)
-        await enableMappedSessionAlarm(runtime, key)
+        await enableMappedSessionAlarm(runtime, mappedKey)
       }
       if (parsed.mode === "off") {
         await setNotificationEnabled(runtime, key, false)

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1256,6 +1256,15 @@ export function isTimeoutError(error: unknown): boolean {
   return false
 }
 
+function isExpiredCallbackQueryError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const message = error.message.toLowerCase()
+  if (!message.includes("answercallbackquery")) return false
+  if (message.includes("query is too old")) return true
+  if (message.includes("query id is invalid")) return true
+  return false
+}
+
 async function retry<T>(
   name: string,
   fn: () => Promise<T>,
@@ -1301,7 +1310,11 @@ async function telegramRequest(config: BridgeConfig, method: string, body: Recor
     return data.result
   }
 
-  return retry(`telegram:${method}`, run)
+  return retry(`telegram:${method}`, run, 2, 400, (error) => {
+    if (method !== "answerCallbackQuery") return true
+    if (isExpiredCallbackQueryError(error)) return false
+    return true
+  })
 }
 
 export function joinOpenCodeUrl(openCodeUrl: string, path: string): URL {
@@ -2229,17 +2242,34 @@ function lookupSavedPrompt(input: string, prompts: SavedPrompt[]): { prompt?: Sa
 
 async function runSavedPrompt(runtime: Runtime, chatId: number, key: string, prompt: SavedPrompt) {
   const config = runtime.config
+  const enableAlarm = async (sessionId: string) => {
+    if (!runtime.store.sessionAlarmSet) return
+    await runtime.store.sessionAlarmSet(sessionId, true).catch((error) => {
+      console.error("[TelegramBridge] failed to auto-enable session alarm for saved prompt", { sessionId, error })
+    })
+  }
+  const run = async (sessionId: string) => {
+    await enableAlarm(sessionId)
+    await resolvePendingForSession(runtime, chatId, sessionId)
+    return sendPrompt(config, sessionId, prompt.text)
+  }
   const sessionId = await sessionForChat(runtime, key)
-  await resolvePendingForSession(runtime, chatId, sessionId)
-  const reply = await sendPrompt(config, sessionId, prompt.text).catch(async (error) => {
+  const reply = await run(sessionId).catch(async (error) => {
     if (!isMissingSession(error)) {
       throw error
     }
     sessions.delete(key)
     await runtime.store.delete(key)
     const next = await sessionForChat(runtime, key)
-    return sendPrompt(config, next, prompt.text)
+    return run(next)
+  }).catch(async (error) => {
+    if (!isTimeoutError(error)) {
+      throw error
+    }
+    await sendTelegramMessage(config, chatId, `Prompt started in session ${sessionId}, but the reply is taking longer than expected. Check the web UI for progress.`)
+    return
   })
+  if (!reply) return
   await sendTelegramMessage(config, chatId, reply)
 }
 
@@ -2415,6 +2445,8 @@ async function answerCallback(config: BridgeConfig, callbackId: string, text: st
     callback_query_id: callbackId,
     text,
     show_alert: false,
+  }).catch((error) => {
+    if (!isExpiredCallbackQueryError(error)) throw error
   })
 }
 
@@ -2565,6 +2597,10 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
         await sendTelegramMessage(runtime.config, chatId, "That question is no longer pending. Wait for the next prompt or use /status.")
       })
   } catch (error) {
+    if (isExpiredCallbackQueryError(error)) {
+      notifyDebug("callback query expired before acknowledgement", { chatId, userId, callbackId })
+      return
+    }
     console.error("[TelegramBridge] callback handling failed", { chatId, userId, callbackId, error })
     const recovery = [
       ...(state.acknowledged ? [] : [answerCallback(runtime.config, callbackId, "Sorry, this button could not be processed right now.")]),

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -835,6 +835,10 @@ type SwitchCallbackData =
   | { action: "page"; page: number }
   | { action: "select"; index: number; token: string }
 
+type SessionActionCallbackData =
+  | { action: "switch"; sessionId: string }
+  | { action: "recent"; sessionId: string }
+
 function switchToken(sessionId: string): string {
   return shortId(sessionId).slice(0, 8).padStart(6, "0")
 }
@@ -859,6 +863,41 @@ function parseSwitchCallbackData(input: string): SwitchCallbackData | undefined 
   const index = Number.parseInt(selected[1] || "", 10)
   if (!Number.isFinite(index) || index < 1) return
   return { action: "select", index: index - 1, token: selected[2] || "" }
+}
+
+function sessionActionCallback(action: "switch" | "recent", sessionId: string): string | undefined {
+  const id = sessionId.trim()
+  if (!id) return
+  if (/[\s:]/.test(id)) return
+  const value = action === "switch" ? `a:s:${id}` : `a:r:${id}`
+  if (value.length > callbackDataMax) return
+  return value
+}
+
+function parseSessionActionCallbackData(input: string): SessionActionCallbackData | undefined {
+  const parsed = input.match(/^a:([sr]):([^\s:]{1,58})$/)
+  if (!parsed) return
+  const action = parsed[1]
+  const sessionId = parsed[2]?.trim() || ""
+  if (!sessionId) return
+  if (action === "s") return { action: "switch", sessionId }
+  if (action === "r") return { action: "recent", sessionId }
+}
+
+function sessionTitleText(sessionId: string, title?: string): string {
+  const single = (title || "").replace(/\s+/g, " ").trim()
+  if (!single) return sessionId
+  return truncateTelegramInlineText(single, sessionTitleInlineMax)
+}
+
+function taskFinishedMarkup(sessionId: string): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } | undefined {
+  const switchData = sessionActionCallback("switch", sessionId)
+  const recentData = sessionActionCallback("recent", sessionId)
+  const row: Array<{ text: string; callback_data: string }> = []
+  if (switchData) row.push({ text: "Switch session", callback_data: switchData })
+  if (recentData) row.push({ text: "Latest message", callback_data: recentData })
+  if (!row.length) return
+  return { inline_keyboard: [row] }
 }
 
 function questionMarkup(question: TelegramPendingQuestion): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } | undefined {
@@ -1541,7 +1580,7 @@ function normalizeRecentCount(args: string[]): { count?: number; error?: string 
   return { count: Math.min(parsed, recentMaxCount) }
 }
 
-function parseRecentText(parts: unknown): string {
+function parseRecentText(parts: unknown, max = recentPartTextMax): string {
   if (!Array.isArray(parts)) return ""
   const text = parts
     .map((part) => {
@@ -1557,7 +1596,8 @@ function parseRecentText(parts: unknown): string {
     .replace(/\s+/g, " ")
     .trim()
   if (!text) return ""
-  return truncateTelegramInlineText(text, recentPartTextMax)
+  if (!Number.isFinite(max) || max <= 0) return text
+  return truncateTelegramInlineText(text, max)
 }
 
 async function recentText(config: BridgeConfig, sessionId: string, count: number): Promise<string> {
@@ -1578,6 +1618,7 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
   const data = await res.json().catch(() => [])
   const rows = Array.isArray(data) ? data : []
   const assistants = new Map<string, string>()
+  const assistantRows: string[] = []
   const users: Array<{ id: string; text: string }> = []
   for (const entry of rows) {
     if (!entry || typeof entry !== "object") continue
@@ -1591,12 +1632,26 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     const role = info.role === "assistant" || info.role === "user" ? info.role : ""
     const text = parseRecentText(row.parts)
     if (!id || !role || !text) continue
-    if (role === "assistant" && parentID && !assistants.has(parentID)) {
-      assistants.set(parentID, text)
+    if (role === "assistant") {
+      if (parentID && !assistants.has(parentID)) {
+        assistants.set(parentID, text)
+      }
+      assistantRows.push(text)
       continue
     }
     if (role !== "user") continue
     users.push({ id, text })
+  }
+  if (!users.length && assistantRows.length) {
+    const list = assistantRows.slice(-safeCount)
+    const lines = [`Recent assistant messages for session ${sessionId} (showing ${list.length} of ${assistantRows.length}):`]
+    for (let i = 0; i < list.length; i++) {
+      const item = list[i]
+      if (!item) continue
+      lines.push("")
+      lines.push(`${i + 1}. Assistant: ${item}`)
+    }
+    return truncateTelegramText(lines.join("\n"), recentPayloadMax)
   }
   if (!users.length) {
     return `No recent chat messages found for session ${sessionId}. Send a new message first.`
@@ -1612,6 +1667,46 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     lines.push(`   Assistant: ${reply}`)
   }
   return truncateTelegramText(lines.join("\n"), recentPayloadMax)
+}
+
+async function latestMessageText(config: BridgeConfig, sessionId: string): Promise<string> {
+  const url = opencodeUrl(config, `/session/${encodeURIComponent(sessionId)}/message`)
+  url.searchParams.set("limit", "40")
+  if (config.directory) {
+    url.searchParams.set("directory", config.directory)
+  }
+  const res = await fetch(url, {
+    method: "GET",
+    signal: AbortSignal.timeout(20_000),
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`OpenCode session messages failed (${res.status}): ${body.slice(0, 300)}`)
+  }
+  const data = await res.json().catch(() => [])
+  const rows = Array.isArray(data) ? data : []
+  const messages: Array<{ role: "assistant" | "user"; text: string }> = []
+  for (const entry of rows) {
+    if (!entry || typeof entry !== "object") continue
+    const row = entry as { info?: unknown; parts?: unknown }
+    const info = row.info && typeof row.info === "object"
+      ? row.info as { role?: unknown }
+      : undefined
+    if (!info) continue
+    const role = info.role === "assistant" || info.role === "user" ? info.role : ""
+    const text = parseRecentText(row.parts, Number.POSITIVE_INFINITY)
+    if (!role || !text) continue
+    messages.push({ role, text })
+  }
+  const latest = [...messages].reverse().find((item) => item.role === "assistant")
+    || [...messages].reverse().find((item) => item.role === "user")
+  if (!latest) {
+    return `No recent chat messages found for session ${sessionId}. Send a new message first.`
+  }
+  const title = await safeSessionTitle(config, sessionId)
+  const label = sessionTitleText(sessionId, title)
+  const role = latest.role === "assistant" ? "Assistant" : "You"
+  return `Latest message in ${label}:\n\n${role}: ${latest.text}`
 }
 
 async function sessionExists(config: BridgeConfig, sessionId: string): Promise<boolean> {
@@ -1755,6 +1850,29 @@ async function handleSwitchCallback(runtime: Runtime, chatId: number, userId: nu
   const title = await safeSessionTitle(runtime.config, next)
   await answerCallback(runtime.config, callbackId, "Switched.")
   await sendTelegramMessage(runtime.config, chatId, `Switched to session: ${formatSessionDisplay(next, title)}`)
+}
+
+async function handleSessionActionCallback(runtime: Runtime, chatId: number, userId: number, callbackId: string, parsed: SessionActionCallbackData) {
+  if (parsed.action === "recent") {
+    await answerCallback(runtime.config, callbackId, "Fetching latest message...")
+    const text = await latestMessageText(runtime.config, parsed.sessionId)
+    await sendTelegramMessage(runtime.config, chatId, text)
+    return
+  }
+
+  const exists = await sessionExists(runtime.config, parsed.sessionId)
+  if (!exists) {
+    await answerCallback(runtime.config, callbackId, "Session no longer exists.")
+    await sendTelegramMessage(runtime.config, chatId, "That session was not found. Use /switch to choose an active session.")
+    return
+  }
+  const key = telegramSessionKey(chatId, userId)
+  await runtime.store.set(key, parsed.sessionId)
+  cacheSession(runtime.config, key, parsed.sessionId)
+  await rememberSession(runtime, key, parsed.sessionId)
+  const title = await safeSessionTitle(runtime.config, parsed.sessionId)
+  await answerCallback(runtime.config, callbackId, "Switched.")
+  await sendTelegramMessage(runtime.config, chatId, `Switched to session: ${sessionTitleText(parsed.sessionId, title)}`)
 }
 
 export function cacheSession(config: BridgeConfig, chatId: string, sessionId: string) {
@@ -2320,6 +2438,12 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       state.acknowledged = true
       return
     }
+    const sessionAction = parseSessionActionCallbackData(data)
+    if (sessionAction) {
+      await handleSessionActionCallback(runtime, chatId, userId, callbackId, sessionAction)
+      state.acknowledged = true
+      return
+    }
     const parsed = parseCallbackData(data)
     if (!parsed) {
       await answerCallback(runtime.config, callbackId, "Unsupported button payload.")
@@ -2749,8 +2873,16 @@ async function notifySessionKeys(
         notifyDebug("proactive send skipped: debounced", { sessionId, kind, chatId, dedupeKey })
         continue
       }
-      const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId)}`
+      const title = kind === "task-finished" ? await safeSessionTitle(runtime.config, sessionId) : undefined
+      const message = kind === "task-finished"
+        ? `${text}\n\nSession: ${sessionTitleText(sessionId, title)}`
+        : `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId)}`
+      const markup = kind === "task-finished" ? taskFinishedMarkup(sessionId) : undefined
       await queueChatUpdate(String(chatId), async () => {
+        if (markup) {
+          await sendTelegramMessageWithMarkup(runtime.config, chatId, message, markup)
+          return
+        }
         await sendTelegramMessage(runtime.config, chatId, message)
       })
       stampNotification(chatId, dedupeKey, sessionId)

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -510,6 +510,14 @@ function notificationKey(chatId: number): string {
   return telegramSessionKey(chatId)
 }
 
+async function enableMappedSessionAlarm(runtime: Runtime, chatKey: string) {
+  if (!runtime.store.sessionAlarmSet) return
+  const mapped = await runtime.store.get(chatKey)
+  const sessionId = mapped || sessionFromCache(runtime.config, chatKey)
+  if (!sessionId) return
+  await runtime.store.sessionAlarmSet(sessionId, true)
+}
+
 async function notificationTargets(runtime: Runtime): Promise<string[]> {
   if (!runtime.store.notificationKeys) return []
   const keys = await runtime.store.notificationKeys()
@@ -2299,6 +2307,7 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       state.acknowledged = true
       if (parsed.mode === "on") {
         await setNotificationEnabled(runtime, key, true)
+        await enableMappedSessionAlarm(runtime, key)
       }
       if (parsed.mode === "off") {
         await setNotificationEnabled(runtime, key, false)
@@ -2518,6 +2527,7 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
       const notifyKey = notificationKey(chatId)
       if (mode === "on") {
         await setNotificationEnabled(runtime, notifyKey, true)
+        await enableMappedSessionAlarm(runtime, key)
         const enabled = await notificationEnabled(runtime, notifyKey)
         await sendTelegramMessageWithMarkup(config, chatId, notifyText(enabled, "on"), notifyMarkup(enabled))
         return true

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1,5 +1,7 @@
 import { createTelegramSessionStore, telegramSessionKey, type TelegramPendingQuestion } from "./telegram-session-store"
-import { loadTelegramBridgeSettings, writeTelegramRuntimeState } from "./telegram-settings"
+import { loadTelegramBridgeSettings, updateTelegramSettings, writeTelegramRuntimeState } from "./telegram-settings"
+import { appendFile, mkdir } from "node:fs/promises"
+import { dirname } from "node:path"
 
 type TelegramUpdate = {
   update_id: number
@@ -43,6 +45,78 @@ type BridgeConfig = {
   webhookSecret?: string
   webhookUrl?: string
   sessionStorePath: string
+}
+
+const rawConsole = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+}
+
+let fileLoggerInstalled = false
+let fileLoggerPath = ""
+let fileLoggerWrites = Promise.resolve()
+
+function bridgeLogFilePath() {
+  return (process.env.TELEGRAM_LOG_FILE || "").trim()
+}
+
+function formatLogArg(value: unknown): string {
+  if (value instanceof Error) {
+    const parts = [value.name, value.message].filter(Boolean)
+    const head = parts.join(": ")
+    if (!value.stack) return head
+    return `${head}\n${value.stack}`
+  }
+  if (typeof value === "string") return value
+  if (typeof value === "number") return String(value)
+  if (typeof value === "boolean") return value ? "true" : "false"
+  if (value === null) return "null"
+  if (value === undefined) return "undefined"
+  return JSON.stringify(value, (_key, item) => {
+    if (item instanceof Error) {
+      return {
+        name: item.name,
+        message: item.message,
+        stack: item.stack,
+      }
+    }
+    return item
+  })
+}
+
+function writeBridgeLogLine(level: "INFO" | "WARN" | "ERROR", args: unknown[]) {
+  if (!fileLoggerPath) return
+  const line = `${new Date().toISOString()} [${level}] ${args.map((item) => formatLogArg(item)).join(" ")}\n`
+  fileLoggerWrites = fileLoggerWrites
+    .then(() => appendFile(fileLoggerPath, line))
+    .catch((error) => {
+      rawConsole.warn("[TelegramBridge] failed to write log file", { path: fileLoggerPath, error })
+    })
+}
+
+async function enableBridgeFileLogging() {
+  const path = bridgeLogFilePath()
+  if (!path) return
+  fileLoggerPath = path
+  await mkdir(dirname(path), { recursive: true }).catch((error) => {
+    rawConsole.warn("[TelegramBridge] failed to prepare log directory", { path, error })
+  })
+  if (fileLoggerInstalled) return
+  fileLoggerInstalled = true
+  console.log = (...args: unknown[]) => {
+    rawConsole.log(...args)
+    writeBridgeLogLine("INFO", args)
+  }
+  console.warn = (...args: unknown[]) => {
+    rawConsole.warn(...args)
+    writeBridgeLogLine("WARN", args)
+  }
+  console.error = (...args: unknown[]) => {
+    rawConsole.error(...args)
+    writeBridgeLogLine("ERROR", args)
+  }
+  writeBridgeLogLine("INFO", ["[TelegramBridge] file logging enabled", { path }])
 }
 
 type Runtime = {
@@ -98,6 +172,7 @@ type CachedSession = {
 type CachedSessionInfo = {
   exists: boolean
   title: string | null
+  parentID: string | null
   expiresAt: number
 }
 
@@ -208,6 +283,11 @@ const telegramCommands = Object.freeze([
     name: "switch",
     text: "Switch this chat/user mapping to an existing session",
     args: "[session-id|index]",
+  }),
+  Object.freeze({
+    name: "project",
+    text: "Show or set OpenCode project directory",
+    args: "[path|clear|status]",
   }),
   Object.freeze({
     name: "notify",
@@ -356,6 +436,24 @@ function notifyDebug(message: string, data?: Record<string, unknown>) {
     return
   }
   console.log(`[TelegramBridge][notify] ${message}`, data)
+}
+
+function bridgeDebugEnabled() {
+  const raw = (process.env.TELEGRAM_BRIDGE_DEBUG || "").trim().toLowerCase()
+  if (raw === "1") return true
+  if (raw === "true") return true
+  if (raw === "yes") return true
+  if (notificationDebugEnabled()) return true
+  return false
+}
+
+function bridgeDebug(message: string, data?: Record<string, unknown>) {
+  if (!bridgeDebugEnabled()) return
+  if (!data) {
+    console.log(`[TelegramBridge][debug] ${message}`)
+    return
+  }
+  console.log(`[TelegramBridge][debug] ${message}`, data)
 }
 
 async function notificationEnabled(runtime: Runtime, key: string): Promise<boolean> {
@@ -562,9 +660,7 @@ async function sessionTargets(runtime: Runtime, sessionId: string): Promise<stri
 }
 
 async function pendingTargets(runtime: Runtime, sessionId: string): Promise<string[]> {
-  const alarmEnabled = runtime.store.sessionAlarmGet
-    ? await runtime.store.sessionAlarmGet(sessionId)
-    : true
+  const alarmEnabled = await sessionAlarmEnabled(runtime, sessionId)
   if (!alarmEnabled) {
     notifyDebug("pending targets skipped: session alarm disabled", { sessionId })
     return []
@@ -583,9 +679,7 @@ async function pendingTargets(runtime: Runtime, sessionId: string): Promise<stri
 }
 
 async function eventTargets(runtime: Runtime, sessionId: string): Promise<string[]> {
-  const alarmEnabled = runtime.store.sessionAlarmGet
-    ? await runtime.store.sessionAlarmGet(sessionId)
-    : true
+  const alarmEnabled = await sessionAlarmEnabled(runtime, sessionId)
   if (!alarmEnabled) {
     notifyDebug("event targets skipped: session alarm disabled", { sessionId })
     return []
@@ -839,6 +933,10 @@ type SessionActionCallbackData =
   | { action: "switch"; sessionId: string }
   | { action: "recent"; sessionId: string }
 
+type ProjectActionCallbackData =
+  | { action: "session"; sessionId: string }
+  | { action: "clear" }
+
 function switchToken(sessionId: string): string {
   return shortId(sessionId).slice(0, 8).padStart(6, "0")
 }
@@ -882,6 +980,93 @@ function parseSessionActionCallbackData(input: string): SessionActionCallbackDat
   if (!sessionId) return
   if (action === "s") return { action: "switch", sessionId }
   if (action === "r") return { action: "recent", sessionId }
+}
+
+function projectSessionCallback(sessionId: string): string | undefined {
+  const id = sessionId.trim()
+  if (!id) return
+  if (/[\s:]/.test(id)) return
+  const value = `d:s:${id}`
+  if (value.length > callbackDataMax) return
+  return value
+}
+
+function projectClearCallback(): string {
+  return "d:c"
+}
+
+function parseProjectActionCallbackData(input: string): ProjectActionCallbackData | undefined {
+  if (input === "d:c") return { action: "clear" }
+  const parsed = input.match(/^d:s:([^\s:]{1,58})$/)
+  if (!parsed) return
+  const sessionId = parsed[1]?.trim() || ""
+  if (!sessionId) return
+  return { action: "session", sessionId }
+}
+
+function compactDirectoryLabel(directory: string): string {
+  const normalized = directory.replace(/\\+/g, "/").replace(/\/+$/, "")
+  if (!normalized) return directory
+  const parts = normalized.split("/").filter(Boolean)
+  if (!parts.length) return normalized
+  const tail = parts[parts.length - 1] || normalized
+  if (tail.length <= 28) return tail
+  return truncateTelegramInlineText(tail, 28)
+}
+
+async function projectChoices(runtime: Runtime, chatKey: string, current?: string): Promise<Array<{ sessionId: string; directory: string; title?: string }>> {
+  const list = await switchCandidates(runtime, chatKey, current)
+  if (!list.length) return []
+  const unique: Array<{ sessionId: string; directory: string; title?: string }> = []
+  const seen = new Set<string>()
+  for (const sessionId of list) {
+    if (unique.length >= 8) break
+    const directory = await sessionDirectory(runtime.config, sessionId)
+    if (!directory || seen.has(directory)) continue
+    seen.add(directory)
+    const title = await safeSessionTitle(runtime.config, sessionId)
+    unique.push({ sessionId, directory, title })
+  }
+  return unique
+}
+
+function projectPickerText(current?: string): string {
+  if (!current) {
+    return "Project directory override is not set. Using session-derived context."
+  }
+  return `Current project directory override: ${current}`
+}
+
+async function projectPicker(runtime: Runtime, chatKey: string, current?: string): Promise<{
+  text: string
+  replyMarkup?: { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> }
+}> {
+  const active = runtime.config.directory?.trim() || ""
+  const choices = await projectChoices(runtime, chatKey, current)
+  const rows = choices
+    .map((choice, index) => {
+      const callback = projectSessionCallback(choice.sessionId)
+      if (!callback) return
+      const marker = active === choice.directory ? " [current]" : ""
+      const title = choice.title ? ` - ${truncateTelegramInlineText(choice.title, 18)}` : ""
+      return [{
+        text: truncateTelegramInlineText(`${index + 1}. ${compactDirectoryLabel(choice.directory)}${title}${marker}`, inlineButtonTextMax),
+        callback_data: callback,
+      }]
+    })
+    .filter((item) => item !== undefined) as Array<Array<{ text: string; callback_data: string }>>
+  if (active) {
+    rows.push([{ text: "Clear project override", callback_data: projectClearCallback() }])
+  }
+  if (!rows.length) {
+    return {
+      text: `${projectPickerText(active || undefined)}\n\nNo recent project directories found from session history. Use /project <path> to set one directly.`,
+    }
+  }
+  return {
+    text: `${projectPickerText(active || undefined)}\n\nChoose a project directory from recent sessions, or use /project <path>.`,
+    replyMarkup: { inline_keyboard: rows },
+  }
 }
 
 function sessionTitleText(sessionId: string, title?: string): string {
@@ -931,15 +1116,26 @@ function parsePendingQuestion(properties: Record<string, unknown>): TelegramPend
       const value = row as Record<string, unknown>
       const header = typeof value.header === "string" ? value.header.trim() : ""
       const question = typeof value.question === "string" ? value.question.trim() : ""
-      const options = Array.isArray(value.options)
+      const parsedOptions = Array.isArray(value.options)
         ? value.options
           .map((item) => {
-            if (!item || typeof item !== "object") return ""
-            const option = item as { label?: unknown }
-            return typeof option.label === "string" ? option.label.trim() : ""
+            if (typeof item === "string") {
+              const label = item.trim()
+              if (!label) return
+              return { label, description: "" }
+            }
+            if (!item || typeof item !== "object") return
+            const option = item as { label?: unknown; description?: unknown }
+            const label = typeof option.label === "string" ? option.label.trim() : ""
+            if (!label) return
+            const description = typeof option.description === "string" ? option.description.trim() : ""
+            return { label, description }
           })
-          .filter(Boolean)
+          .filter((item) => item !== undefined)
         : []
+      const options = parsedOptions.map((item) => item.label)
+      const optionDescriptions = parsedOptions.map((item) => item.description)
+      const hasDescriptions = optionDescriptions.some(Boolean)
       const multiple = value.multiple === true
       const custom = value.custom !== false
       if (!header && !question && !options.length) return
@@ -947,6 +1143,7 @@ function parsePendingQuestion(properties: Record<string, unknown>): TelegramPend
         header,
         question,
         options,
+        optionDescriptions: hasDescriptions ? optionDescriptions : undefined,
         multiple,
         custom,
       }
@@ -975,6 +1172,13 @@ function permissionText(properties: Record<string, unknown>): string {
   return `Permission request: ${permission} (${patterns.join(", ")})`
 }
 
+function optionLine(row: TelegramPendingQuestion["questions"][number], index: number): string {
+  const label = row.options[index] || ""
+  const description = row.optionDescriptions?.[index] || ""
+  if (!description) return `${index + 1}) ${label}`
+  return `${index + 1}) ${label} - ${description}`
+}
+
 function questionPromptText(question: TelegramPendingQuestion): string {
   const lines = ["Question pending:"]
   for (let i = 0; i < question.questions.length; i++) {
@@ -991,7 +1195,7 @@ function questionPromptText(question: TelegramPendingQuestion): string {
     const detail = row.question && row.question !== row.header ? row.question : ""
     if (detail) lines.push(detail)
     for (let index = 0; index < row.options.length; index++) {
-      lines.push(`${index + 1}) ${row.options[index]}`)
+      lines.push(optionLine(row, index))
     }
     if (!row.options.length && row.custom) {
       lines.push("Reply with your answer as text.")
@@ -1029,7 +1233,7 @@ function questionStepText(question: TelegramPendingQuestion, hasButtons = false)
   const detail = row.question && row.question !== row.header ? row.question : ""
   if (detail) lines.push(detail)
   for (let optionIndex = 0; optionIndex < row.options.length; optionIndex++) {
-    lines.push(`${optionIndex + 1}) ${row.options[optionIndex]}`)
+    lines.push(optionLine(row, optionIndex))
   }
   if (!row.options.length && row.custom) {
     lines.push("Reply with your answer as text.")
@@ -1477,7 +1681,7 @@ function cacheSessionInfo(config: BridgeConfig, sessionId: string, info: Session
   const now = Date.now()
   const expiresAt = now + config.sessionCacheTtlMs
   sessionInfo.delete(sessionId)
-  sessionInfo.set(sessionId, { exists: info.exists, title: info.title || null, expiresAt })
+  sessionInfo.set(sessionId, { exists: info.exists, title: info.title || null, parentID: info.parentID || null, expiresAt })
   pruneExpiredSessionInfo(now)
   for (const key of sessionInfo.keys()) {
     if (sessionInfo.size <= config.sessionCacheMax * 2) return
@@ -1495,7 +1699,25 @@ function cachedSessionLookup(sessionId: string): SessionLookup | undefined {
   return {
     exists: cached.exists,
     title: cached.title || undefined,
+    parentID: cached.parentID || undefined,
   }
+}
+
+function trimSessionId(value: unknown): string | undefined {
+  if (typeof value !== "string") return
+  const text = value.trim()
+  if (!text) return
+  return text
+}
+
+function sessionParentFromPayload(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== "object") return
+  const row = raw as { parentID?: unknown; info?: unknown }
+  const direct = trimSessionId(row.parentID)
+  if (direct) return direct
+  if (!row.info || typeof row.info !== "object") return
+  const info = row.info as { parentID?: unknown }
+  return trimSessionId(info.parentID)
 }
 
 function formatSessionDisplay(sessionId: string, title?: string): string {
@@ -1536,6 +1758,7 @@ function normalizeSessionLookupId(sessionId: string): string | undefined {
 type SessionLookup = {
   exists: boolean
   title?: string
+  parentID?: string
 }
 
 async function readSessionInfo(config: BridgeConfig, sessionId: string): Promise<SessionLookup> {
@@ -1554,11 +1777,70 @@ async function readSessionInfo(config: BridgeConfig, sessionId: string): Promise
     const body = await res.text().catch(() => "")
     throw new Error(`OpenCode session lookup failed (${res.status}): ${body.slice(0, 300)}`)
   }
-  const payload = await res.json().catch(() => ({})) as { title?: unknown }
+  const payload = await res.json().catch(() => ({})) as { title?: unknown; parentID?: unknown; info?: unknown }
   return {
     exists: true,
     title: trimSessionTitle(payload.title),
+    parentID: sessionParentFromPayload(payload),
   }
+}
+
+async function readSessionInfoCached(config: BridgeConfig, sessionId: string): Promise<SessionLookup> {
+  const id = normalizeSessionLookupId(sessionId)
+  if (!id) return { exists: false }
+  const cached = cachedSessionLookup(id)
+  if (cached) return cached
+  const loaded = await readSessionInfo(config, id)
+  cacheSessionInfo(config, id, loaded)
+  return loaded
+}
+
+async function rootAncestorSessionId(config: BridgeConfig, sessionId: string): Promise<string> {
+  const start = normalizeSessionLookupId(sessionId)
+  if (!start) return sessionId
+  const seen = new Set<string>([start])
+  let root = start
+  let walk = start
+  for (let i = 0; i < 12; i++) {
+    const info = await readSessionInfoCached(config, walk).catch(() => undefined)
+    const parent = normalizeSessionLookupId(info?.parentID || "")
+    if (!parent) return root
+    if (seen.has(parent)) return root
+    seen.add(parent)
+    root = parent
+    walk = parent
+  }
+  return root
+}
+
+async function sessionAlarmEnabled(runtime: Runtime, sessionId: string): Promise<boolean> {
+  const fromDisk = async (id: string) => {
+    const path = runtime.config.sessionStorePath
+    if (!path) return false
+    const data = await Bun.file(path).json().catch(() => undefined) as { sessionAlarms?: Record<string, unknown> } | undefined
+    if (!data?.sessionAlarms) return false
+    return data.sessionAlarms[id] === true
+  }
+
+  if (!runtime.store.sessionAlarmGet) return true
+  const direct = await runtime.store.sessionAlarmGet(sessionId)
+  if (direct) return true
+  if (await fromDisk(sessionId)) {
+    notifyDebug("session alarm loaded from disk", { sessionId })
+    return true
+  }
+  const root = await rootAncestorSessionId(runtime.config, sessionId).catch(() => sessionId)
+  if (root === sessionId) return false
+  const inherited = await runtime.store.sessionAlarmGet(root)
+  if (inherited) {
+    notifyDebug("session alarm inherited from root", { sessionId, rootSessionId: root })
+    return true
+  }
+  if (await fromDisk(root)) {
+    notifyDebug("session alarm inherited from root via disk", { sessionId, rootSessionId: root })
+    return true
+  }
+  return false
 }
 
 async function sessionTitle(config: BridgeConfig, sessionId: string): Promise<string | undefined> {
@@ -1591,6 +1873,25 @@ function normalizeRecentCount(args: string[]): { count?: number; error?: string 
     return { error: usage }
   }
   return { count: Math.min(parsed, recentMaxCount) }
+}
+
+function projectCommandMode(args: string[]): { mode: "status" | "clear" | "set"; directory?: string } {
+  const raw = args.join(" ").trim()
+  if (!raw) return { mode: "status" }
+  const lower = raw.toLowerCase()
+  if (lower === "status") return { mode: "status" }
+  if (lower === "clear") return { mode: "clear" }
+  if (lower === "off") return { mode: "clear" }
+  if (lower === "none") return { mode: "clear" }
+  if (lower === "null") return { mode: "clear" }
+  return { mode: "set", directory: raw }
+}
+
+async function persistDirectoryOverride(directory?: string): Promise<boolean> {
+  const payload = directory ? { directory } : { directory: null }
+  const updated = await updateTelegramSettings(payload).catch(() => undefined)
+  if (!updated) return false
+  return updated.ok === true
 }
 
 function parseRecentText(parts: unknown, max = recentPartTextMax): string {
@@ -1886,6 +2187,40 @@ async function handleSessionActionCallback(runtime: Runtime, chatId: number, use
   const title = await safeSessionTitle(runtime.config, parsed.sessionId)
   await answerCallback(runtime.config, callbackId, "Switched.")
   await sendTelegramMessage(runtime.config, chatId, `Switched to session: ${sessionTitleText(parsed.sessionId, title)}`)
+}
+
+async function handleProjectActionCallback(runtime: Runtime, chatId: number, userId: number, callbackId: string, parsed: ProjectActionCallbackData) {
+  const key = telegramSessionKey(chatId, userId)
+  if (parsed.action === "clear") {
+    await answerCallback(runtime.config, callbackId, "Clearing project override...")
+    runtime.config.directory = undefined
+    const persisted = await persistDirectoryOverride()
+    if (!persisted) {
+      await sendTelegramMessage(runtime.config, chatId, "Cleared project directory override for this running bridge, but failed to persist settings. It may return after restart.")
+      return
+    }
+    await sendTelegramMessage(runtime.config, chatId, "Cleared project directory override. Bridge now uses session-derived context.")
+    return
+  }
+
+  await answerCallback(runtime.config, callbackId, "Switching project...")
+  const directory = await sessionDirectory(runtime.config, parsed.sessionId)
+  if (!directory) {
+    await sendTelegramMessage(runtime.config, chatId, `Could not resolve project directory from session ${parsed.sessionId}. Try /project <path> manually.`)
+    return
+  }
+  runtime.config.directory = directory
+  const persisted = await persistDirectoryOverride(directory)
+  if (!persisted) {
+    await sendTelegramMessage(runtime.config, chatId, `Project directory override set to ${directory} for this running bridge, but failed to persist settings.`)
+    return
+  }
+  const picker = await projectPicker(runtime, key, await runtime.store.get(key) || sessionFromCache(runtime.config, key))
+  if (!picker.replyMarkup) {
+    await sendTelegramMessage(runtime.config, chatId, `Project directory override set to: ${directory}`)
+    return
+  }
+  await sendTelegramMessageWithMarkup(runtime.config, chatId, `Project directory override set to: ${directory}\n\n${picker.text}`, picker.replyMarkup)
 }
 
 export function cacheSession(config: BridgeConfig, chatId: string, sessionId: string) {
@@ -2457,6 +2792,7 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
   const callbackId = callback?.id
   const data = callback?.data?.trim() || ""
   if (!callbackId) return
+  bridgeDebug("callback received", { chatId, userId, callbackId, data: data || undefined })
   const state = { acknowledged: false }
   try {
     if (!chatId || !userId || !data) {
@@ -2473,6 +2809,12 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
     const sessionAction = parseSessionActionCallbackData(data)
     if (sessionAction) {
       await handleSessionActionCallback(runtime, chatId, userId, callbackId, sessionAction)
+      state.acknowledged = true
+      return
+    }
+    const projectAction = parseProjectActionCallbackData(data)
+    if (projectAction) {
+      await handleProjectActionCallback(runtime, chatId, userId, callbackId, projectAction)
       state.acknowledged = true
       return
     }
@@ -2628,12 +2970,14 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
   const text = message?.text?.trim()
 
   if (!chatId || !text) return
+  bridgeDebug("text message received", { chatId, userId, text })
 
   const key = telegramSessionKey(chatId, userId)
 
   const runCommand = async () => {
     const command = parseCommand(text)
     if (!command) return false
+    bridgeDebug("command parsed", { chatId, userId, command: command.name, args: command.args })
     const known = commandEntry(command.name)
     if (known?.name === "help") {
       await sendTelegramMessage(config, chatId, helpText())
@@ -2650,6 +2994,15 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
       await runtime.store.set(key, next)
       cacheSession(config, key, next)
       await rememberSession(runtime, key, next)
+      if (runtime.store.sessionAlarmSet) {
+        const notifyKey = notificationKey(chatId)
+        const enabled = await notificationEnabled(runtime, notifyKey)
+        if (enabled) {
+          await runtime.store.sessionAlarmSet(next, true).catch((error) => {
+            console.error("[TelegramBridge] failed to auto-enable alarm for /new session", { chatId, sessionId: next, error })
+          })
+        }
+      }
       await sendTelegramMessage(config, chatId, `Started a new session: ${formatSessionDisplay(next)}`)
       return true
     }
@@ -2706,6 +3059,42 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
       await rememberSession(runtime, key, next)
       const title = await safeSessionTitle(config, next)
       await sendTelegramMessage(config, chatId, `Switched to session: ${formatSessionDisplay(next, title)}`)
+      return true
+    }
+    if (known?.name === "project") {
+      const parsed = projectCommandMode(command.args)
+      if (parsed.mode === "status") {
+        const current = await runtime.store.get(key) || sessionFromCache(config, key)
+        const picker = await projectPicker(runtime, key, current)
+        if (!picker.replyMarkup) {
+          await sendTelegramMessage(config, chatId, picker.text)
+          return true
+        }
+        await sendTelegramMessageWithMarkup(config, chatId, picker.text, picker.replyMarkup)
+        return true
+      }
+      if (parsed.mode === "clear") {
+        runtime.config.directory = undefined
+        const persisted = await persistDirectoryOverride()
+        if (!persisted) {
+          await sendTelegramMessage(config, chatId, "Cleared project directory override for this running bridge, but failed to persist settings. It may return after restart.")
+          return true
+        }
+        await sendTelegramMessage(config, chatId, "Cleared project directory override. Bridge now uses session-derived context.")
+        return true
+      }
+      const directory = parsed.directory
+      if (!directory) {
+        await sendTelegramMessage(config, chatId, "Usage: /project [path], /project clear, or /project status")
+        return true
+      }
+      runtime.config.directory = directory
+      const persisted = await persistDirectoryOverride(directory)
+      if (!persisted) {
+        await sendTelegramMessage(config, chatId, `Set project directory override for this running bridge to ${directory}, but failed to persist settings.`)
+        return true
+      }
+      await sendTelegramMessage(config, chatId, `Project directory override set to: ${directory}`)
       return true
     }
     if (known?.name === "notify") {
@@ -2783,6 +3172,7 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
   try {
     const handled = await runCommand()
     if (handled) return
+    bridgeDebug("routing text as prompt", { chatId, userId })
 
     const match = await readPendingQuestionMatch(runtime, chatId, userId)
     if (match) {
@@ -2831,6 +3221,7 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
     }
 
     const sessionId = await sessionForChat(runtime, key)
+    bridgeDebug("resolved chat session for prompt", { chatId, userId, sessionId })
     await resolvePendingForSession(runtime, chatId, sessionId)
     const reply = await sendPrompt(config, sessionId, text).catch(async (error) => {
       if (!isMissingSession(error)) {
@@ -2840,7 +3231,15 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
       await runtime.store.delete(key)
       const next = await sessionForChat(runtime, key)
       return sendPrompt(config, next, text)
+    }).catch(async (error) => {
+      if (!isTimeoutError(error)) {
+        throw error
+      }
+      bridgeDebug("prompt request timed out", { chatId, userId, sessionId })
+      await sendTelegramMessage(config, chatId, `Prompt started in session ${sessionId}, but the reply is taking longer than expected. Check the web UI for progress.`)
+      return
     })
+    if (!reply) return
     await sendTelegramMessage(config, chatId, reply)
   } catch (error) {
     console.error("[TelegramBridge] request handling failed", { chatId, error })
@@ -3058,6 +3457,7 @@ export async function consumeOutboundEventStream(runtime: Runtime, body: Readabl
 
 export async function handleBridgeEvent(runtime: Runtime, event: { type: string; properties: Record<string, unknown> }) {
   const sessionId = typeof event.properties.sessionID === "string" ? event.properties.sessionID : ""
+  bridgeDebug("bridge event received", { type: event.type, sessionId: sessionId || undefined })
   if (event.type === "session.deleted") {
     const info = event.properties.info && typeof event.properties.info === "object"
       ? event.properties.info as { id?: unknown }
@@ -3273,6 +3673,7 @@ async function runWebhook(runtime: Runtime) {
 }
 
 export async function startTelegramBridge() {
+  await enableBridgeFileLogging()
   const config = parseConfig()
   await writeTelegramRuntimeState(config).catch((error) => {
     console.warn("[TelegramBridge] failed to write runtime state", error)
@@ -3284,6 +3685,9 @@ export async function startTelegramBridge() {
   console.log(`[TelegramBridge] Telegram alarm channel: ${config.telegramAlarmChannelEnabled !== false ? "enabled" : "disabled"}`)
   if (notificationDebugEnabled()) {
     console.log("[TelegramBridge] Notification debug logging enabled (TELEGRAM_NOTIFY_DEBUG=1)")
+  }
+  if (bridgeDebugEnabled()) {
+    console.log("[TelegramBridge] Bridge debug logging enabled (TELEGRAM_BRIDGE_DEBUG=1)")
   }
   if (config.directory) {
     console.log(`[TelegramBridge] OpenCode directory: ${config.directory}`)

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -341,6 +341,23 @@ function parseTelegramKey(key: string): { chatId: number; userId?: number } | un
   return { chatId, userId }
 }
 
+function notificationDebugEnabled() {
+  const raw = (process.env.TELEGRAM_NOTIFY_DEBUG || "").trim().toLowerCase()
+  if (raw === "1") return true
+  if (raw === "true") return true
+  if (raw === "yes") return true
+  return false
+}
+
+function notifyDebug(message: string, data?: Record<string, unknown>) {
+  if (!notificationDebugEnabled()) return
+  if (!data) {
+    console.log(`[TelegramBridge][notify] ${message}`)
+    return
+  }
+  console.log(`[TelegramBridge][notify] ${message}`, data)
+}
+
 async function notificationEnabled(runtime: Runtime, key: string): Promise<boolean> {
   if (runtime.store.notificationGet) {
     return runtime.store.notificationGet(key)
@@ -548,7 +565,10 @@ async function pendingTargets(runtime: Runtime, sessionId: string): Promise<stri
   const alarmEnabled = runtime.store.sessionAlarmGet
     ? await runtime.store.sessionAlarmGet(sessionId)
     : true
-  if (!alarmEnabled) return []
+  if (!alarmEnabled) {
+    notifyDebug("pending targets skipped: session alarm disabled", { sessionId })
+    return []
+  }
 
   const targets = new Set<string>()
   const mapped = await sessionTargets(runtime, sessionId)
@@ -566,12 +586,18 @@ async function eventTargets(runtime: Runtime, sessionId: string): Promise<string
   const alarmEnabled = runtime.store.sessionAlarmGet
     ? await runtime.store.sessionAlarmGet(sessionId)
     : true
-  if (!alarmEnabled) return []
+  if (!alarmEnabled) {
+    notifyDebug("event targets skipped: session alarm disabled", { sessionId })
+    return []
+  }
 
   const optedIn = await notificationTargets(runtime)
   if (optedIn.length) return optedIn
   const keys = await sessionTargets(runtime, sessionId)
-  if (!keys.length) return []
+  if (!keys.length) {
+    notifyDebug("event targets empty: no mapped session keys", { sessionId })
+    return []
+  }
 
   const targets = new Set<string>()
   for (const key of keys) {
@@ -2675,8 +2701,14 @@ async function notifySessionKeys(
   notifyKind?: string,
 ) {
   const pending = await pendingTargets(runtime, sessionId)
-  if (!pending.length) return
+  if (!pending.length) {
+    notifyDebug("session event skipped: no pending targets", { sessionId, kind })
+    return
+  }
   const notify = await eventTargets(runtime, sessionId)
+  if (!notify.length) {
+    notifyDebug("session event has no proactive targets", { sessionId, kind, pendingTargets: pending.length })
+  }
   const notifyChats = new Set<number>()
   for (const key of notify) {
     const parsed = parseTelegramKey(key)
@@ -2709,13 +2741,20 @@ async function notifySessionKeys(
       if (!notifyChats.has(chatId)) continue
       if (proactiveChats.has(chatId)) continue
       proactiveChats.add(chatId)
-      if (!proactiveTelegramEnabled(runtime.config)) continue
-      if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId)) continue
+      if (!proactiveTelegramEnabled(runtime.config)) {
+        notifyDebug("proactive send skipped: telegram alarm channel disabled", { sessionId, kind, chatId })
+        continue
+      }
+      if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId)) {
+        notifyDebug("proactive send skipped: debounced", { sessionId, kind, chatId, dedupeKey })
+        continue
+      }
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId)}`
       await queueChatUpdate(String(chatId), async () => {
         await sendTelegramMessage(runtime.config, chatId, message)
       })
       stampNotification(chatId, dedupeKey, sessionId)
+      notifyDebug("proactive send delivered", { sessionId, kind, chatId, dedupeKey })
     } catch (error) {
       console.error("[TelegramBridge] outbound notify failed", { sessionId, key, kind, error })
     }
@@ -2724,8 +2763,18 @@ async function notifySessionKeys(
 
 async function notifyQuestion(runtime: Runtime, sessionId: string, question: TelegramPendingQuestion) {
   const pending = await pendingTargets(runtime, sessionId)
-  if (!pending.length) return
+  if (!pending.length) {
+    notifyDebug("question event skipped: no pending targets", { sessionId, requestId: question.requestId })
+    return
+  }
   const notify = await eventTargets(runtime, sessionId)
+  if (!notify.length) {
+    notifyDebug("question event has no proactive targets", {
+      sessionId,
+      requestId: question.requestId,
+      pendingTargets: pending.length,
+    })
+  }
   const notifyChats = new Set<number>()
   for (const key of notify) {
     const parsed = parseTelegramKey(key)
@@ -2769,13 +2818,34 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, question: Tel
       if (!notifyChats.has(chatId)) continue
       if (proactiveChats.has(chatId)) continue
       proactiveChats.add(chatId)
-      if (!proactiveTelegramEnabled(runtime.config)) continue
-      if (!shouldNotify(runtime.config, chatId, kind, sessionId)) continue
+      if (!proactiveTelegramEnabled(runtime.config)) {
+        notifyDebug("question proactive send skipped: telegram alarm channel disabled", {
+          sessionId,
+          requestId: question.requestId,
+          chatId,
+        })
+        continue
+      }
+      if (!shouldNotify(runtime.config, chatId, kind, sessionId)) {
+        notifyDebug("question proactive send skipped: debounced", {
+          sessionId,
+          requestId: question.requestId,
+          chatId,
+          dedupeKey: kind,
+        })
+        continue
+      }
       await queueChatUpdate(String(chatId), async () => {
         await sendTelegramQuestionPrompt(runtime.config, chatId, question)
         await sendTelegramMessage(runtime.config, chatId, `Open ${sessionLabel(runtime.config, sessionId)}`)
       })
       stampNotification(chatId, kind, sessionId)
+      notifyDebug("question proactive send delivered", {
+        sessionId,
+        requestId: question.requestId,
+        chatId,
+        dedupeKey: kind,
+      })
     } catch (error) {
       console.error("[TelegramBridge] outbound question notify failed", { sessionId, key, error })
     }
@@ -3043,6 +3113,10 @@ export async function startTelegramBridge() {
   const runtime = { config, store }
   console.log(`[TelegramBridge] OpenCode API: ${config.openCodeUrl}`)
   console.log(`[TelegramBridge] Session store: ${config.sessionStorePath}`)
+  console.log(`[TelegramBridge] Telegram alarm channel: ${config.telegramAlarmChannelEnabled !== false ? "enabled" : "disabled"}`)
+  if (notificationDebugEnabled()) {
+    console.log("[TelegramBridge] Notification debug logging enabled (TELEGRAM_NOTIFY_DEBUG=1)")
+  }
   if (config.directory) {
     console.log(`[TelegramBridge] OpenCode directory: ${config.directory}`)
   }


### PR DESCRIPTION
## Summary
- make `/notify on` automatically enable the alarm flag for the currently mapped session so chat opt-in immediately results in proactive Telegram alerts
- apply the same session-alarm sync for both text command flow and inline `n:on` callback flow to keep behavior consistent
- extend telegram bridge tests to verify `/notify on` now sets session alarm state in both command and callback paths

## Testing
- bun test tests/telegram-bridge.test.ts