### PR TITLE
fix: show option subtitles in Telegram question prompts

### DIFF
--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -5962,7 +5962,13 @@ describe("telegram bridge config and cache", () => {
         properties: {
           id: "req-1",
           sessionID: "session-1",
-          questions: [{ header: "Pick one", options: [{ label: "Alpha" }, { label: "Beta" }] }],
+          questions: [{
+            header: "Pick one",
+            options: [
+              { label: "Alpha", description: "Issue #101 - stabilize rollout" },
+              { label: "Beta", description: "Issue #102 - add project picker" },
+            ],
+          }],
         },
       });
 
@@ -5979,7 +5985,7 @@ describe("telegram bridge config and cache", () => {
     const sentTexts = calls
       .filter((x) => x.url.includes("/sendMessage"))
       .map((x) => String(x.body.text || ""));
-    expect(sentTexts.some((text) => text.includes("1) Alpha"))).toBe(true);
+    expect(sentTexts.some((text) => text.includes("1) Alpha - Issue #101 - stabilize rollout"))).toBe(true);
     expect(sentTexts.some((text) => text.includes("Open session session-1"))).toBe(true);
     expect(sentTexts.some((text) => text.includes("Thanks, your answer was sent."))).toBe(true);
   });

--- a/app-prefixable/tests/telegram-session-store.test.ts
+++ b/app-prefixable/tests/telegram-session-store.test.ts
@@ -336,6 +336,7 @@ describe("telegram session store", () => {
           header: "Pick",
           question: "Pick",
           options: ["Alpha", "Beta"],
+          optionDescriptions: ["Issue #101", "Issue #102"],
           multiple: false,
           custom: true,
         },
@@ -347,6 +348,7 @@ describe("telegram session store", () => {
     const pending = await second.questionList?.("chat:77")
     expect(pending?.[0]?.requestId).toBe("req-1")
     expect(pending?.[0]?.questions[0]?.options).toEqual(["Alpha", "Beta"])
+    expect(pending?.[0]?.questions[0]?.optionDescriptions).toEqual(["Issue #101", "Issue #102"])
 
     await second.questionDelete?.("chat:77", "req-1")
     const third = createTelegramSessionStore(path)

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -858,15 +858,26 @@ function parsePendingQuestion(properties: Record<string, unknown>): TelegramPend
       const value = row as Record<string, unknown>
       const header = typeof value.header === "string" ? value.header.trim() : ""
       const question = typeof value.question === "string" ? value.question.trim() : ""
-      const options = Array.isArray(value.options)
+      const parsedOptions = Array.isArray(value.options)
         ? value.options
           .map((item) => {
-            if (!item || typeof item !== "object") return ""
-            const option = item as { label?: unknown }
-            return typeof option.label === "string" ? option.label.trim() : ""
+            if (typeof item === "string") {
+              const label = item.trim()
+              if (!label) return
+              return { label, description: "" }
+            }
+            if (!item || typeof item !== "object") return
+            const option = item as { label?: unknown; description?: unknown }
+            const label = typeof option.label === "string" ? option.label.trim() : ""
+            if (!label) return
+            const description = typeof option.description === "string" ? option.description.trim() : ""
+            return { label, description }
           })
-          .filter(Boolean)
+          .filter((item) => item !== undefined)
         : []
+      const options = parsedOptions.map((item) => item.label)
+      const optionDescriptions = parsedOptions.map((item) => item.description)
+      const hasDescriptions = optionDescriptions.some(Boolean)
       const multiple = value.multiple === true
       const custom = value.custom !== false
       if (!header && !question && !options.length) return
@@ -874,6 +885,7 @@ function parsePendingQuestion(properties: Record<string, unknown>): TelegramPend
         header,
         question,
         options,
+        optionDescriptions: hasDescriptions ? optionDescriptions : undefined,
         multiple,
         custom,
       }
@@ -902,6 +914,13 @@ function permissionText(properties: Record<string, unknown>): string {
   return `Permission request: ${permission} (${patterns.join(", ")})`
 }
 
+function optionLine(row: TelegramPendingQuestion["questions"][number], index: number): string {
+  const label = row.options[index] || ""
+  const description = row.optionDescriptions?.[index] || ""
+  if (!description) return `${index + 1}) ${label}`
+  return `${index + 1}) ${label} - ${description}`
+}
+
 function questionPromptText(question: TelegramPendingQuestion): string {
   const lines = ["Question pending:"]
   for (let i = 0; i < question.questions.length; i++) {
@@ -918,7 +937,7 @@ function questionPromptText(question: TelegramPendingQuestion): string {
     const detail = row.question && row.question !== row.header ? row.question : ""
     if (detail) lines.push(detail)
     for (let index = 0; index < row.options.length; index++) {
-      lines.push(`${index + 1}) ${row.options[index]}`)
+      lines.push(optionLine(row, index))
     }
     if (!row.options.length && row.custom) {
       lines.push("Reply with your answer as text.")
@@ -956,7 +975,7 @@ function questionStepText(question: TelegramPendingQuestion, hasButtons = false)
   const detail = row.question && row.question !== row.header ? row.question : ""
   if (detail) lines.push(detail)
   for (let optionIndex = 0; optionIndex < row.options.length; optionIndex++) {
-    lines.push(`${optionIndex + 1}) ${row.options[optionIndex]}`)
+    lines.push(optionLine(row, optionIndex))
   }
   if (!row.options.length && row.custom) {
     lines.push("Reply with your answer as text.")

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -64,14 +64,21 @@ function parsePendingQuestionEntry(value: unknown): TelegramPendingQuestionEntry
   const row = value as Record<string, unknown>
   const header = typeof row.header === "string" ? row.header : ""
   const question = typeof row.question === "string" ? row.question : ""
-  const options = Array.isArray(row.options)
-    ? row.options.filter((item) => typeof item === "string" && item).map((item) => item.trim()).filter(Boolean)
-    : []
   const rawDescriptions = Array.isArray(row.optionDescriptions)
     ? row.optionDescriptions
       .map((item) => (typeof item === "string" ? item.trim() : ""))
     : []
-  const optionDescriptions = options.map((_, i) => rawDescriptions[i] || "")
+  const options: string[] = []
+  const optionDescriptions: string[] = []
+  if (Array.isArray(row.options)) {
+    row.options.forEach((item, i) => {
+      if (typeof item !== "string") return
+      const option = item.trim()
+      if (!option) return
+      options.push(option)
+      optionDescriptions.push(rawDescriptions[i] || "")
+    })
+  }
   const multiple = row.multiple === true
   const custom = row.custom !== false
   if (!header.trim() && !question.trim() && !options.length) return

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -24,6 +24,7 @@ type TelegramPendingQuestionEntry = {
   header: string
   question: string
   options: string[]
+  optionDescriptions?: string[]
   multiple: boolean
   custom: boolean
 }
@@ -66,13 +67,20 @@ function parsePendingQuestionEntry(value: unknown): TelegramPendingQuestionEntry
   const options = Array.isArray(row.options)
     ? row.options.filter((item) => typeof item === "string" && item).map((item) => item.trim()).filter(Boolean)
     : []
+  const rawDescriptions = Array.isArray(row.optionDescriptions)
+    ? row.optionDescriptions
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+    : []
+  const optionDescriptions = options.map((_, i) => rawDescriptions[i] || "")
   const multiple = row.multiple === true
   const custom = row.custom !== false
   if (!header.trim() && !question.trim() && !options.length) return
+  const hasDescriptions = optionDescriptions.some(Boolean)
   return {
     header: header.trim(),
     question: question.trim(),
     options,
+    optionDescriptions: hasDescriptions ? optionDescriptions : undefined,
     multiple,
     custom,
   }


### PR DESCRIPTION
## Summary
- preserve Telegram question option descriptions when parsing/storing pending questions so subtitle text is not dropped
- render option subtitles in Telegram question prompt text (`1) label - subtitle`) while keeping reply mapping based on labels
- add regression tests for prompt rendering and pending-question persistence

## Verification
- bun test app-prefixable/tests/telegram-bridge.test.ts -t \"question prompt supports choice reply index and sends answer to OpenCode\"
- bun test app-prefixable/tests/telegram-session-store.test.ts -t \"persists pending question queue across store instances\"