### PR TITLE
fix: prevent Telegram settings from hanging on missing sources

### DIFF
--- a/app-prefixable/src/components/telegram-settings.tsx
+++ b/app-prefixable/src/components/telegram-settings.tsx
@@ -65,9 +65,14 @@ export function TelegramSettings(props: Props) {
       setLoading(false)
       return
     }
-    const next = await Promise.resolve()
-      .then(() => createTelegramForm(data.settings))
-      .catch(() => null)
+    const next = (() => {
+      try {
+        return createTelegramForm(data.settings)
+      } catch (err) {
+        console.error("[TelegramSettings] Failed to normalize settings", err)
+        return null
+      }
+    })()
     if (!next) {
       setError("Failed to load Telegram settings")
       setLoading(false)

--- a/app-prefixable/src/components/telegram-settings.tsx
+++ b/app-prefixable/src/components/telegram-settings.tsx
@@ -55,17 +55,24 @@ export function TelegramSettings(props: Props) {
     setFieldErrors({})
     const res = await fetch(`${props.serverUrl}/api/ext/telegram/settings`).catch(() => null)
     if (!res?.ok) {
-      setLoading(false)
       setError("Failed to load Telegram settings")
+      setLoading(false)
       return
     }
     const data = (await res.json().catch(() => null)) as TelegramSettingsResponse | null
     if (!data?.settings) {
-      setLoading(false)
       setError("Failed to load Telegram settings")
+      setLoading(false)
       return
     }
-    const next = createTelegramForm(data.settings)
+    const next = await Promise.resolve()
+      .then(() => createTelegramForm(data.settings))
+      .catch(() => null)
+    if (!next) {
+      setError("Failed to load Telegram settings")
+      setLoading(false)
+      return
+    }
     setInitial(next)
     setForm(next)
     setTokenConfigured(data.settings.tokenConfigured)

--- a/app-prefixable/src/components/telegram-setup-guide.tsx
+++ b/app-prefixable/src/components/telegram-setup-guide.tsx
@@ -11,7 +11,7 @@ const checklist = Object.freeze([
   Object.freeze({ id: "api", label: "openCodeUrl points to your reachable OpenCode API." }),
   Object.freeze({ id: "path", label: "sessionStorePath points to a persistent writable location." }),
   Object.freeze({ id: "webhook", label: "For webhook mode: TELEGRAM_WEBHOOK_URL, TELEGRAM_WEBHOOK_PATH, and HTTPS ingress are configured." }),
-  Object.freeze({ id: "notify", label: "Telegram alarm channel is enabled in Settings > Notifications." }),
+  Object.freeze({ id: "notify", label: "Notifications are enabled per chat with /notify on after a test message." }),
   Object.freeze({ id: "alarm", label: "Session bell/alarm is enabled for each OpenCode session that should emit proactive alerts." }),
 ]) as readonly Readonly<ChecklistItem>[]
 
@@ -105,7 +105,7 @@ export function TelegramSetupGuide() {
             <strong>Mode:</strong> set <code>mode=polling</code> for local/simple setups, or <code>mode=webhook</code> for production ingress. Polling clears webhook registration automatically.
           </p>
           <p>
-            <strong>Alert routing model:</strong> proactive Telegram alerts are sent to the chat mapped to that session when the session bell/alarm is enabled. <code>/notify</code> is optional fallback routing when no session mapping exists.
+            <strong>Alert routing model:</strong> proactive Telegram alerts fan out to chats that enabled <code>/notify on</code> and only for sessions with bell/alarm enabled. Chat-to-session mappings from <code>/status</code> and <code>/switch</code> are used for interactive commands and do not limit proactive routing.
           </p>
           <p>
             Persisted UI fields map to runtime settings: <code>mode</code>, <code>token</code>, <code>openCodeUrl</code>, <code>directory</code>, <code>sessionCacheMax</code>,

--- a/app-prefixable/src/components/telegram-setup-guide.tsx
+++ b/app-prefixable/src/components/telegram-setup-guide.tsx
@@ -11,7 +11,7 @@ const checklist = Object.freeze([
   Object.freeze({ id: "api", label: "openCodeUrl points to your reachable OpenCode API." }),
   Object.freeze({ id: "path", label: "sessionStorePath points to a persistent writable location." }),
   Object.freeze({ id: "webhook", label: "For webhook mode: TELEGRAM_WEBHOOK_URL, TELEGRAM_WEBHOOK_PATH, and HTTPS ingress are configured." }),
-  Object.freeze({ id: "notify", label: "Notifications are enabled per chat with /notify on after a test message." }),
+  Object.freeze({ id: "notify", label: "Telegram alarm channel is enabled in Settings > Notifications." }),
   Object.freeze({ id: "alarm", label: "Session bell/alarm is enabled for each OpenCode session that should emit proactive alerts." }),
 ]) as readonly Readonly<ChecklistItem>[]
 
@@ -105,7 +105,7 @@ export function TelegramSetupGuide() {
             <strong>Mode:</strong> set <code>mode=polling</code> for local/simple setups, or <code>mode=webhook</code> for production ingress. Polling clears webhook registration automatically.
           </p>
           <p>
-            <strong>Alert routing model:</strong> proactive Telegram alerts fan out to chats that enabled <code>/notify on</code> and only for sessions with bell/alarm enabled. Chat-to-session mappings from <code>/status</code> and <code>/switch</code> are used for interactive commands and do not limit proactive routing.
+            <strong>Alert routing model:</strong> proactive Telegram alerts are sent to the chat mapped to that session when the session bell/alarm is enabled. <code>/notify</code> is optional fallback routing when no session mapping exists.
           </p>
           <p>
             Persisted UI fields map to runtime settings: <code>mode</code>, <code>token</code>, <code>openCodeUrl</code>, <code>directory</code>, <code>sessionCacheMax</code>,

--- a/app-prefixable/src/utils/telegram-settings.ts
+++ b/app-prefixable/src/utils/telegram-settings.ts
@@ -240,8 +240,9 @@ function addWebhookPathPatch(patch: Record<string, TelegramSettingsPatchValue>, 
 }
 
 export function createTelegramForm(settings: TelegramPublicSettings): TelegramForm {
-  const sourcesJson = settings.sources.length
-    ? JSON.stringify(settings.sources, null, 2)
+  const sources = Array.isArray(settings.sources) ? settings.sources : []
+  const sourcesJson = sources.length
+    ? JSON.stringify(sources, null, 2)
     : ""
   return {
     mode: settings.mode,

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4709,7 +4709,7 @@ describe("telegram bridge config and cache", () => {
     expect(text.endsWith("...")).toBe(true);
   });
 
-  test("question and permission events still queue pending when notifications are disabled", async () => {
+  test("question and permission events notify mapped chats even when /notify is off", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
     const inbox = new Map<string, Array<{
@@ -4789,7 +4789,7 @@ describe("telegram bridge config and cache", () => {
       globalThis.fetch = originalFetch;
     }
 
-    expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(false);
+    expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(true);
     const items = inbox.get("chat:77") || [];
     expect(items).toHaveLength(2);
     expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4880,6 +4880,15 @@ describe("telegram bridge config and cache", () => {
     const sent = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
     expect(sent.some((text) => text.includes("Question pending:"))).toBe(true);
     expect(sent.some((text) => text.includes("Permission request: shell"))).toBe(true);
+    const hasUtilityButtons = calls
+      .filter((x) => x.url.includes("/sendMessage"))
+      .some((x) => {
+        const markup = x.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined
+        const row = markup?.inline_keyboard?.[0] || []
+        const callbacks = row.map((item) => String(item.callback_data || ""))
+        return callbacks.includes("s:p:1") && callbacks.includes("u:recent")
+      })
+    expect(hasUtilityButtons).toBe(true)
     const items = inbox.get("chat:88") || [];
     expect(items).toHaveLength(2);
     expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4709,7 +4709,7 @@ describe("telegram bridge config and cache", () => {
     expect(text.endsWith("...")).toBe(true);
   });
 
-  test("question and permission events notify mapped chats even when /notify is off", async () => {
+  test("question and permission events still queue pending when notifications are disabled", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;
     const inbox = new Map<string, Array<{
@@ -4789,7 +4789,7 @@ describe("telegram bridge config and cache", () => {
       globalThis.fetch = originalFetch;
     }
 
-    expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(true);
+    expect(calls.some((x) => x.url.includes("/sendMessage"))).toBe(false);
     const items = inbox.get("chat:77") || [];
     expect(items).toHaveLength(2);
     expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -2666,6 +2666,77 @@ describe("telegram bridge config and cache", () => {
     expect(text).toContain("Assistant: Second answer");
   });
 
+  test("/recent 1 returns newest exchange when API payload is newest-first", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current/message")) {
+          return new Response(
+            JSON.stringify([
+              {
+                info: { id: "a-2", role: "assistant", parentID: "u-2", time: { created: 200 } },
+                parts: [{ type: "text", text: "Second answer" }],
+              },
+              {
+                info: { id: "u-2", role: "user", time: { created: 199 } },
+                parts: [{ type: "text", text: "Second question" }],
+              },
+              {
+                info: { id: "a-1", role: "assistant", parentID: "u-1", time: { created: 100 } },
+                parts: [{ type: "text", text: "First answer" }],
+              },
+              {
+                info: { id: "u-1", role: "user", time: { created: 99 } },
+                parts: [{ type: "text", text: "First question" }],
+              },
+            ]),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/recent 1", chat: { id: 101 }, from: { id: 4 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const text = String(calls.filter((x) => x.url.includes("/sendMessage")).at(-1)?.body.text || "");
+    expect(text).toContain("showing 1 of 2");
+    expect(text).toContain("You: Second question");
+    expect(text).toContain("Assistant: Second answer");
+    expect(text).not.toContain("You: First question");
+  });
+
   test("/recent reports empty state when no message history exists", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4880,15 +4880,6 @@ describe("telegram bridge config and cache", () => {
     const sent = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
     expect(sent.some((text) => text.includes("Question pending:"))).toBe(true);
     expect(sent.some((text) => text.includes("Permission request: shell"))).toBe(true);
-    const hasUtilityButtons = calls
-      .filter((x) => x.url.includes("/sendMessage"))
-      .some((x) => {
-        const markup = x.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined
-        const row = markup?.inline_keyboard?.[0] || []
-        const callbacks = row.map((item) => String(item.callback_data || ""))
-        return callbacks.includes("s:p:1") && callbacks.includes("u:recent")
-      })
-    expect(hasUtilityButtons).toBe(true)
     const items = inbox.get("chat:88") || [];
     expect(items).toHaveLength(2);
     expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -4951,6 +4951,15 @@ describe("telegram bridge config and cache", () => {
     const sent = calls.filter((x) => x.url.includes("/sendMessage")).map((x) => String(x.body.text || ""));
     expect(sent.some((text) => text.includes("Question pending:"))).toBe(true);
     expect(sent.some((text) => text.includes("Permission request: shell"))).toBe(true);
+    const hasUtilityButtons = calls
+      .filter((x) => x.url.includes("/sendMessage"))
+      .some((x) => {
+        const markup = x.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined
+        const row = markup?.inline_keyboard?.[0] || []
+        const callbacks = row.map((item) => String(item.callback_data || ""))
+        return callbacks.includes("s:p:1") && callbacks.includes("u:recent")
+      })
+    expect(hasUtilityButtons).toBe(true)
     const items = inbox.get("chat:88") || [];
     expect(items).toHaveLength(2);
     expect(items.map((item) => item.kind).sort()).toEqual(["permission", "question"]);

--- a/app-prefixable/tests/telegram-settings-ui.test.ts
+++ b/app-prefixable/tests/telegram-settings-ui.test.ts
@@ -50,6 +50,11 @@ describe("telegram settings form helpers", () => {
     })
   })
 
+  test("handles missing sources in settings payload", () => {
+    const form = createTelegramForm({ ...seed, sources: undefined as unknown as TelegramPublicSettings["sources"] })
+    expect(form.sourcesJson).toBe("")
+  })
+
   test("returns validation errors for invalid values", () => {
     const form = {
       ...createTelegramForm(seed),

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -909,6 +909,9 @@ type SwitchCallbackData =
   | { action: "page"; page: number }
   | { action: "select"; index: number; token: string }
 
+type UtilityCallbackData =
+  | { action: "recent" }
+
 function switchToken(sessionId: string): string {
   return shortId(sessionId).slice(0, 8).padStart(6, "0")
 }
@@ -933,6 +936,23 @@ function parseSwitchCallbackData(input: string): SwitchCallbackData | undefined 
   const index = Number.parseInt(selected[1] || "", 10)
   if (!Number.isFinite(index) || index < 1) return
   return { action: "select", index: index - 1, token: selected[2] || "" }
+}
+
+function utilityRecentCallbackData(): string {
+  return "u:recent"
+}
+
+function parseUtilityCallbackData(input: string): UtilityCallbackData | undefined {
+  if (input === "u:recent") return { action: "recent" }
+}
+
+function proactiveActionsMarkup(): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  return {
+    inline_keyboard: [[
+      { text: "Switch session", callback_data: switchPageCallback(0) },
+      { text: "Latest message", callback_data: utilityRecentCallbackData() },
+    ]],
+  }
 }
 
 function questionMarkup(question: TelegramPendingQuestion): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } | undefined {
@@ -2489,6 +2509,33 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       state.acknowledged = true
       return
     }
+    const utility = parseUtilityCallbackData(data)
+    if (utility?.action === "recent") {
+      const key = telegramSessionKey(chatId, userId)
+      const current = await runtime.store.get(key) || sessionFromCache(runtime.config, key)
+      if (!current) {
+        await answerCallback(runtime.config, callbackId, "No active session mapping.")
+        state.acknowledged = true
+        return
+      }
+      const ref = parsedSessionRef(current)
+      if (!ref) {
+        await answerCallback(runtime.config, callbackId, "Session mapping is invalid.")
+        state.acknowledged = true
+        return
+      }
+      const scoped = sourceForSessionRef(runtime, ref)
+      if (!scoped) {
+        await answerCallback(runtime.config, callbackId, sourceUnavailableText(ref.sourceId))
+        state.acknowledged = true
+        return
+      }
+      await answerCallback(runtime.config, callbackId, "Loading latest message...")
+      state.acknowledged = true
+      const text = await recentText(scoped, ref.sessionId, 1)
+      await sendTelegramMessage(runtime.config, chatId, text)
+      return
+    }
     const parsed = parseCallbackData(data)
     if (!parsed) {
       await answerCallback(runtime.config, callbackId, "Unsupported button payload.")
@@ -2981,7 +3028,7 @@ async function notifySessionKeys(
       if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId, sourceId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId, sourceId)}`
       await queueChatUpdate(String(chatId), async () => {
-        await sendTelegramMessage(runtime.config, chatId, message)
+        await sendTelegramMessageWithMarkup(runtime.config, chatId, message, proactiveActionsMarkup())
       })
       stampNotification(chatId, dedupeKey, sessionId, sourceId)
     } catch (error) {
@@ -3043,7 +3090,12 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, sourceId: str
       if (!shouldNotify(runtime.config, chatId, kind, sessionId, sourceId)) continue
       await queueChatUpdate(String(chatId), async () => {
         await sendTelegramQuestionPrompt(runtime.config, chatId, question)
-        await sendTelegramMessage(runtime.config, chatId, `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`)
+        await sendTelegramMessageWithMarkup(
+          runtime.config,
+          chatId,
+          `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`,
+          proactiveActionsMarkup(),
+        )
       })
       stampNotification(chatId, kind, sessionId, sourceId)
     } catch (error) {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -643,7 +643,10 @@ async function sessionTargets(runtime: Runtime, ref: SessionRef): Promise<string
 }
 
 async function pendingTargets(runtime: Runtime, ref: SessionRef): Promise<string[]> {
-  const alarmEnabled = await sessionAlarmEnabled(runtime, ref)
+  const scoped = sourceScopedId(ref.sourceId, ref.sessionId)
+  const alarmEnabled = runtime.store.sessionAlarmGet
+    ? await runtime.store.sessionAlarmGet(scoped)
+    : true
   if (!alarmEnabled) return []
 
   const targets = new Set<string>()
@@ -658,17 +661,11 @@ async function pendingTargets(runtime: Runtime, ref: SessionRef): Promise<string
   return [...targets]
 }
 
-async function sessionAlarmEnabled(runtime: Runtime, ref: SessionRef): Promise<boolean> {
-  if (!runtime.store.sessionAlarmGet) return true
-  const scoped = sourceScopedId(ref.sourceId, ref.sessionId)
-  if (await runtime.store.sessionAlarmGet(scoped)) return true
-  if (ref.sourceId === "default") return false
-  if (await runtime.store.sessionAlarmGet(ref.sessionId)) return true
-  return false
-}
-
 async function eventTargets(runtime: Runtime, ref: SessionRef): Promise<string[]> {
-  const alarmEnabled = await sessionAlarmEnabled(runtime, ref)
+  const scoped = sourceScopedId(ref.sourceId, ref.sessionId)
+  const alarmEnabled = runtime.store.sessionAlarmGet
+    ? await runtime.store.sessionAlarmGet(scoped)
+    : true
   if (!alarmEnabled) return []
 
   const optedIn = await notificationTargets(runtime)
@@ -912,9 +909,6 @@ type SwitchCallbackData =
   | { action: "page"; page: number }
   | { action: "select"; index: number; token: string }
 
-type UtilityCallbackData =
-  | { action: "recent" }
-
 function switchToken(sessionId: string): string {
   return shortId(sessionId).slice(0, 8).padStart(6, "0")
 }
@@ -939,23 +933,6 @@ function parseSwitchCallbackData(input: string): SwitchCallbackData | undefined 
   const index = Number.parseInt(selected[1] || "", 10)
   if (!Number.isFinite(index) || index < 1) return
   return { action: "select", index: index - 1, token: selected[2] || "" }
-}
-
-function utilityRecentCallbackData(): string {
-  return "u:recent"
-}
-
-function parseUtilityCallbackData(input: string): UtilityCallbackData | undefined {
-  if (input === "u:recent") return { action: "recent" }
-}
-
-function proactiveActionsMarkup(): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
-  return {
-    inline_keyboard: [[
-      { text: "Switch session", callback_data: switchPageCallback(0) },
-      { text: "Latest message", callback_data: utilityRecentCallbackData() },
-    ]],
-  }
 }
 
 function questionMarkup(question: TelegramPendingQuestion): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } | undefined {
@@ -2502,33 +2479,6 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       state.acknowledged = true
       return
     }
-    const utility = parseUtilityCallbackData(data)
-    if (utility?.action === "recent") {
-      const key = telegramSessionKey(chatId, userId)
-      const current = await runtime.store.get(key) || sessionFromCache(runtime.config, key)
-      if (!current) {
-        await answerCallback(runtime.config, callbackId, "No active session mapping.")
-        state.acknowledged = true
-        return
-      }
-      const ref = parsedSessionRef(current)
-      if (!ref) {
-        await answerCallback(runtime.config, callbackId, "Session mapping is invalid.")
-        state.acknowledged = true
-        return
-      }
-      const scoped = sourceForSessionRef(runtime, ref)
-      if (!scoped) {
-        await answerCallback(runtime.config, callbackId, sourceUnavailableText(ref.sourceId))
-        state.acknowledged = true
-        return
-      }
-      await answerCallback(runtime.config, callbackId, "Loading latest message...")
-      state.acknowledged = true
-      const text = await recentText(scoped, ref.sessionId, 1)
-      await sendTelegramMessage(runtime.config, chatId, text)
-      return
-    }
     const parsed = parseCallbackData(data)
     if (!parsed) {
       await answerCallback(runtime.config, callbackId, "Unsupported button payload.")
@@ -3021,7 +2971,7 @@ async function notifySessionKeys(
       if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId, sourceId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId, sourceId)}`
       await queueChatUpdate(String(chatId), async () => {
-        await sendTelegramMessageWithMarkup(runtime.config, chatId, message, proactiveActionsMarkup())
+        await sendTelegramMessage(runtime.config, chatId, message)
       })
       stampNotification(chatId, dedupeKey, sessionId, sourceId)
     } catch (error) {
@@ -3083,12 +3033,7 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, sourceId: str
       if (!shouldNotify(runtime.config, chatId, kind, sessionId, sourceId)) continue
       await queueChatUpdate(String(chatId), async () => {
         await sendTelegramQuestionPrompt(runtime.config, chatId, question)
-        await sendTelegramMessageWithMarkup(
-          runtime.config,
-          chatId,
-          `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`,
-          proactiveActionsMarkup(),
-        )
+        await sendTelegramMessage(runtime.config, chatId, `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`)
       })
       stampNotification(chatId, kind, sessionId, sourceId)
     } catch (error) {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -668,19 +668,13 @@ async function eventTargets(runtime: Runtime, ref: SessionRef): Promise<string[]
     : true
   if (!alarmEnabled) return []
 
+  const mapped = await sessionTargets(runtime, ref)
+  if (mapped.length) return mapped
+
   const optedIn = await notificationTargets(runtime)
   if (optedIn.length) return optedIn
-  const keys = await sessionTargets(runtime, ref)
-  if (!keys.length) return []
 
-  const targets = new Set<string>()
-  for (const key of keys) {
-    const parsed = parseTelegramKey(key)
-    if (!parsed) continue
-    if (!(await notificationEnabled(runtime, notificationKey(parsed.chatId)))) continue
-    targets.add(key)
-  }
-  return [...targets]
+  return []
 }
 
 function proactiveTelegramEnabled(config: BridgeConfig): boolean {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -912,6 +912,9 @@ type SwitchCallbackData =
   | { action: "page"; page: number }
   | { action: "select"; index: number; token: string }
 
+type UtilityCallbackData =
+  | { action: "recent" }
+
 function switchToken(sessionId: string): string {
   return shortId(sessionId).slice(0, 8).padStart(6, "0")
 }
@@ -936,6 +939,23 @@ function parseSwitchCallbackData(input: string): SwitchCallbackData | undefined 
   const index = Number.parseInt(selected[1] || "", 10)
   if (!Number.isFinite(index) || index < 1) return
   return { action: "select", index: index - 1, token: selected[2] || "" }
+}
+
+function utilityRecentCallbackData(): string {
+  return "u:recent"
+}
+
+function parseUtilityCallbackData(input: string): UtilityCallbackData | undefined {
+  if (input === "u:recent") return { action: "recent" }
+}
+
+function proactiveActionsMarkup(): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  return {
+    inline_keyboard: [[
+      { text: "Switch session", callback_data: switchPageCallback(0) },
+      { text: "Latest message", callback_data: utilityRecentCallbackData() },
+    ]],
+  }
 }
 
 function questionMarkup(question: TelegramPendingQuestion): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } | undefined {
@@ -2482,6 +2502,33 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       state.acknowledged = true
       return
     }
+    const utility = parseUtilityCallbackData(data)
+    if (utility?.action === "recent") {
+      const key = telegramSessionKey(chatId, userId)
+      const current = await runtime.store.get(key) || sessionFromCache(runtime.config, key)
+      if (!current) {
+        await answerCallback(runtime.config, callbackId, "No active session mapping.")
+        state.acknowledged = true
+        return
+      }
+      const ref = parsedSessionRef(current)
+      if (!ref) {
+        await answerCallback(runtime.config, callbackId, "Session mapping is invalid.")
+        state.acknowledged = true
+        return
+      }
+      const scoped = sourceForSessionRef(runtime, ref)
+      if (!scoped) {
+        await answerCallback(runtime.config, callbackId, sourceUnavailableText(ref.sourceId))
+        state.acknowledged = true
+        return
+      }
+      await answerCallback(runtime.config, callbackId, "Loading latest message...")
+      state.acknowledged = true
+      const text = await recentText(scoped, ref.sessionId, 1)
+      await sendTelegramMessage(runtime.config, chatId, text)
+      return
+    }
     const parsed = parseCallbackData(data)
     if (!parsed) {
       await answerCallback(runtime.config, callbackId, "Unsupported button payload.")
@@ -2974,7 +3021,7 @@ async function notifySessionKeys(
       if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId, sourceId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId, sourceId)}`
       await queueChatUpdate(String(chatId), async () => {
-        await sendTelegramMessage(runtime.config, chatId, message)
+        await sendTelegramMessageWithMarkup(runtime.config, chatId, message, proactiveActionsMarkup())
       })
       stampNotification(chatId, dedupeKey, sessionId, sourceId)
     } catch (error) {
@@ -3036,7 +3083,12 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, sourceId: str
       if (!shouldNotify(runtime.config, chatId, kind, sessionId, sourceId)) continue
       await queueChatUpdate(String(chatId), async () => {
         await sendTelegramQuestionPrompt(runtime.config, chatId, question)
-        await sendTelegramMessage(runtime.config, chatId, `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`)
+        await sendTelegramMessageWithMarkup(
+          runtime.config,
+          chatId,
+          `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`,
+          proactiveActionsMarkup(),
+        )
       })
       stampNotification(chatId, kind, sessionId, sourceId)
     } catch (error) {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -668,13 +668,19 @@ async function eventTargets(runtime: Runtime, ref: SessionRef): Promise<string[]
     : true
   if (!alarmEnabled) return []
 
-  const mapped = await sessionTargets(runtime, ref)
-  if (mapped.length) return mapped
-
   const optedIn = await notificationTargets(runtime)
   if (optedIn.length) return optedIn
+  const keys = await sessionTargets(runtime, ref)
+  if (!keys.length) return []
 
-  return []
+  const targets = new Set<string>()
+  for (const key of keys) {
+    const parsed = parseTelegramKey(key)
+    if (!parsed) continue
+    if (!(await notificationEnabled(runtime, notificationKey(parsed.chatId)))) continue
+    targets.add(key)
+  }
+  return [...targets]
 }
 
 function proactiveTelegramEnabled(config: BridgeConfig): boolean {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1663,7 +1663,7 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
   const data = await res.json().catch(() => [])
   const rows = Array.isArray(data) ? data : []
   const assistants = new Map<string, string>()
-  const users: Array<{ id: string; text: string }> = []
+  const users: Array<{ id: string; text: string; created: number }> = []
   for (const entry of rows) {
     if (!entry || typeof entry !== "object") continue
     const row = entry as { info?: unknown; parts?: unknown }
@@ -1674,6 +1674,10 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     const id = typeof info.id === "string" ? info.id : ""
     const parentID = typeof info.parentID === "string" ? info.parentID : ""
     const role = info.role === "assistant" || info.role === "user" ? info.role : ""
+    const time = "time" in info && info.time && typeof info.time === "object"
+      ? info.time as { created?: unknown }
+      : undefined
+    const created = typeof time?.created === "number" && Number.isFinite(time.created) ? time.created : 0
     const text = parseRecentText(row.parts)
     if (!id || !role || !text) continue
     if (role === "assistant" && parentID && !assistants.has(parentID)) {
@@ -1681,12 +1685,18 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
       continue
     }
     if (role !== "user") continue
-    users.push({ id, text })
+    users.push({ id, text, created })
   }
   if (!users.length) {
     return `No recent chat messages found for session ${sessionId}. Send a new message first.`
   }
-  const list = users.slice(-safeCount)
+  const ordered = users.some((item) => item.created > 0)
+    ? users.slice().sort((a, b) => {
+      if (a.created !== b.created) return a.created - b.created
+      return a.id.localeCompare(b.id)
+    })
+    : users
+  const list = ordered.slice(-safeCount)
   const lines = [`Recent activity for session ${sessionId} (showing ${list.length} of ${users.length}):`]
   for (let i = 0; i < list.length; i++) {
     const item = list[i]

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -643,10 +643,7 @@ async function sessionTargets(runtime: Runtime, ref: SessionRef): Promise<string
 }
 
 async function pendingTargets(runtime: Runtime, ref: SessionRef): Promise<string[]> {
-  const scoped = sourceScopedId(ref.sourceId, ref.sessionId)
-  const alarmEnabled = runtime.store.sessionAlarmGet
-    ? await runtime.store.sessionAlarmGet(scoped)
-    : true
+  const alarmEnabled = await sessionAlarmEnabled(runtime, ref)
   if (!alarmEnabled) return []
 
   const targets = new Set<string>()
@@ -661,11 +658,17 @@ async function pendingTargets(runtime: Runtime, ref: SessionRef): Promise<string
   return [...targets]
 }
 
-async function eventTargets(runtime: Runtime, ref: SessionRef): Promise<string[]> {
+async function sessionAlarmEnabled(runtime: Runtime, ref: SessionRef): Promise<boolean> {
+  if (!runtime.store.sessionAlarmGet) return true
   const scoped = sourceScopedId(ref.sourceId, ref.sessionId)
-  const alarmEnabled = runtime.store.sessionAlarmGet
-    ? await runtime.store.sessionAlarmGet(scoped)
-    : true
+  if (await runtime.store.sessionAlarmGet(scoped)) return true
+  if (ref.sourceId === "default") return false
+  if (await runtime.store.sessionAlarmGet(ref.sessionId)) return true
+  return false
+}
+
+async function eventTargets(runtime: Runtime, ref: SessionRef): Promise<string[]> {
+  const alarmEnabled = await sessionAlarmEnabled(runtime, ref)
   if (!alarmEnabled) return []
 
   const optedIn = await notificationTargets(runtime)


### PR DESCRIPTION
## Summary
- harden Telegram settings form normalization so missing `settings.sources` is treated as an empty list instead of throwing
- make Telegram settings `load()` fail closed with an error state so runtime transform errors cannot leave the UI stuck on `Loading Telegram settings...`
- add regression coverage for payloads where `sources` is undefined

## Testing
- bun test app-prefixable/tests/telegram-settings-ui.test.ts

Closes #350