### PR TITLE
feat: add reorder controls for queued followups

### DIFF
--- a/app-prefixable/src/components/followup-dock.tsx
+++ b/app-prefixable/src/components/followup-dock.tsx
@@ -12,6 +12,8 @@ export function FollowupDock(props: {
   onSend: (id: string) => void;
   onEdit: (id: string) => void;
   onDelete: (id: string) => void;
+  onMoveUp: (id: string) => void;
+  onMoveDown: (id: string) => void;
 }) {
   const [collapsed, setCollapsed] = createSignal(true);
   const contentId = `followup-dock-${createUniqueId()}`;
@@ -92,8 +94,11 @@ export function FollowupDock(props: {
           aria-label="Queued followup messages"
         >
           <For each={props.items}>
-            {(item) => {
+            {(item, i) => {
               const sending = () => props.sending === item.id;
+              const busy = () => !!props.sending || !!props.processing || !!props.loading;
+              const first = () => i() === 0;
+              const last = () => i() === props.items.length - 1;
               return (
                 <div class="flex items-center gap-2 min-w-0">
                   <span class="text-sm truncate flex-1" style={{ color: "var(--text-base)" }}>
@@ -102,8 +107,26 @@ export function FollowupDock(props: {
                   <Button
                     type="button"
                     size="sm"
+                    variant="ghost"
+                    disabled={busy() || first()}
+                    onClick={() => props.onMoveUp(item.id)}
+                  >
+                    Up
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy() || last()}
+                    onClick={() => props.onMoveDown(item.id)}
+                  >
+                    Down
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
                     variant="secondary"
-                    disabled={!!props.sending || !!props.processing || !!props.loading}
+                    disabled={busy()}
                     onClick={() => props.onSend(item.id)}
                   >
                     Send now

--- a/app-prefixable/src/components/followup-dock.tsx
+++ b/app-prefixable/src/components/followup-dock.tsx
@@ -23,6 +23,7 @@ export function FollowupDock(props: {
   const label = createMemo(() =>
     count() === 0 ? "No followups queued" : count() === 1 ? "1 followup queued" : `${count()} followups queued`,
   );
+  const busy = createMemo(() => !!props.sending || !!props.processing || !!props.loading);
 
   function toggle() {
     setCollapsed((v) => !v);
@@ -96,7 +97,6 @@ export function FollowupDock(props: {
           <For each={props.items}>
             {(item, i) => {
               const sending = () => props.sending === item.id;
-              const busy = () => !!props.sending || !!props.processing || !!props.loading;
               const first = () => i() === 0;
               const last = () => i() === props.items.length - 1;
               return (
@@ -109,6 +109,8 @@ export function FollowupDock(props: {
                     size="sm"
                     variant="ghost"
                     disabled={busy() || first()}
+                    aria-label="Move followup up"
+                    title="Move followup up"
                     onClick={() => props.onMoveUp(item.id)}
                   >
                     Up
@@ -118,6 +120,8 @@ export function FollowupDock(props: {
                     size="sm"
                     variant="ghost"
                     disabled={busy() || last()}
+                    aria-label="Move followup down"
+                    title="Move followup down"
                     onClick={() => props.onMoveDown(item.id)}
                   >
                     Down

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -501,6 +501,21 @@ export function Session() {
     );
   }
 
+  function moveFollowup(id: string, delta: -1 | 1) {
+    const sid = sessionId();
+    if (!sid) return;
+    const list = followups();
+    const index = list.findIndex((item) => item.id === id);
+    if (index < 0) return;
+    const nextIndex = index + delta;
+    if (nextIndex < 0 || nextIndex >= list.length) return;
+    const next = [...list];
+    const current = next[index];
+    next[index] = next[nextIndex];
+    next[nextIndex] = current;
+    setSessionFollowups(sid, next);
+  }
+
   // Double-Escape to abort: track last Escape press timestamp
   const lastEsc = { ts: 0 };
 
@@ -2735,6 +2750,8 @@ export function Session() {
                 onSend={sendFollowupNow}
                 onEdit={editFollowup}
                 onDelete={removeFollowup}
+                onMoveUp={(id) => moveFollowup(id, -1)}
+                onMoveDown={(id) => moveFollowup(id, 1)}
               />
             </Show>
           </div>


### PR DESCRIPTION
## Summary
- add Up/Down controls in the followup queue dock so users can reorder queued followup messages directly from chat
- wire new move handlers from the session page to swap followup positions and persist the updated order in session followup state
- disable move actions while the queue is busy (sending/processing/loading) and at list boundaries to prevent invalid moves

Closes #343