### PR TITLE
fix: stabilize Telegram proactive actions and latest-message routing

### DIFF
--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -5731,6 +5731,12 @@ describe("telegram bridge config and cache", () => {
       .filter((x) => x.url.includes("/sendMessage"))
       .map((x) => String(x.body.text || ""));
     expect(sentTexts).toEqual(["Task finished: the session is now idle.\n\nOpen session session-1"]);
+    const markup = calls.find((x) => x.url.includes("/sendMessage"))?.body.reply_markup as {
+      inline_keyboard?: Array<Array<{ callback_data?: string }>>
+    } | undefined
+    const callbacks = (markup?.inline_keyboard?.[0] || []).map((item) => String(item.callback_data || ""))
+    expect(callbacks.some((item) => /^u:s:[a-z0-9]{6,24}$/.test(item))).toBe(true)
+    expect(callbacks.includes("u:recent")).toBe(true)
   });
 
   test("handleBridgeEvent clears tracked status on session.deleted without sessionID", async () => {
@@ -6640,6 +6646,88 @@ describe("telegram bridge config and cache", () => {
 
     const callbackAck = calls.find((x) => x.url.includes("/answerCallbackQuery"));
     expect(String(callbackAck?.body.text || "")).toContain("could not be processed");
+  });
+
+  test("task-finished switch button remaps directly to originating session", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const storeMap = new Map<string, string>();
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/session-1")) {
+          return new Response(JSON.stringify({ id: "session-1", title: "Build deploy" }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async (key: string) => storeMap.get(key),
+          set: async (key: string, value: string) => {
+            storeMap.set(key, value);
+          },
+          delete: async () => undefined,
+          sessionKeys: async () => ["chat:77:user:5"],
+          notificationGet: async () => true,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "session.status",
+        properties: { sessionID: "session-1", status: { type: "busy" } },
+      });
+      await handleBridgeEvent(runtime, {
+        type: "session.status",
+        properties: { sessionID: "session-1", status: { type: "idle" } },
+      });
+
+      const taskFinished = calls.find((x) =>
+        x.url.includes("/sendMessage") && String(x.body.text || "").includes("Task finished:"),
+      );
+      const switchCallback = String(
+        ((taskFinished?.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined)
+          ?.inline_keyboard?.[0]?.find((item) => String(item.callback_data || "").startsWith("u:s:"))?.callback_data) || "",
+      );
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 88,
+        callback_query: {
+          id: "cb-task-switch",
+          data: switchCallback,
+          from: { id: 5 },
+          message: { message_id: 99, chat: { id: 77 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(storeMap.get("chat:77:user:5")).toBe("session-1");
+    const switchedText = calls
+      .filter((x) => x.url.includes("/sendMessage"))
+      .map((x) => String(x.body.text || ""))
+      .find((text) => text.includes("Switched to session:"));
+    expect(switchedText || "").toContain("session-1");
   });
 
   test("callback query submits selected option and confirms success", async () => {

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -5099,7 +5099,7 @@ describe("telegram bridge config and cache", () => {
         const markup = x.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined
         const row = markup?.inline_keyboard?.[0] || []
         const callbacks = row.map((item) => String(item.callback_data || ""))
-        return callbacks.includes("s:p:1") && callbacks.includes("u:recent")
+        return callbacks.includes("s:p:1") && callbacks.some((item) => /^u:r:[a-z0-9]{6,24}$/.test(item))
       })
     expect(hasUtilityButtons).toBe(true)
     const items = inbox.get("chat:88") || [];
@@ -5878,7 +5878,7 @@ describe("telegram bridge config and cache", () => {
     } | undefined
     const callbacks = (markup?.inline_keyboard?.[0] || []).map((item) => String(item.callback_data || ""))
     expect(callbacks.some((item) => /^u:s:[a-z0-9]{6,24}$/.test(item))).toBe(true)
-    expect(callbacks.includes("u:recent")).toBe(true)
+    expect(callbacks.some((item) => /^u:r:[a-z0-9]{6,24}$/.test(item))).toBe(true)
   });
 
   test("handleBridgeEvent clears tracked status on session.deleted without sessionID", async () => {
@@ -6871,6 +6871,100 @@ describe("telegram bridge config and cache", () => {
       .find((text) => text.includes("Switched to session:"));
     expect(switchedText || "").toContain("session-1");
   });
+
+  test("task-finished latest-message button uses originating session", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    const storeMap = new Map<string, string>([["chat:77:user:5", "session-other"]]);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        if (url.includes("/answerCallbackQuery")) {
+          return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+        }
+        if (url.includes("/session/session-1/message")) {
+          return new Response(JSON.stringify([
+            { info: { id: "u-2", role: "user" }, parts: [{ type: "text", text: "right session" }] },
+            { info: { id: "a-2", role: "assistant", parentID: "u-2" }, parts: [{ type: "text", text: "right reply" }] },
+          ]), { status: 200 });
+        }
+        if (url.includes("/session/session-other/message")) {
+          return new Response(JSON.stringify([
+            { info: { id: "u-1", role: "user" }, parts: [{ type: "text", text: "wrong session" }] },
+            { info: { id: "a-1", role: "assistant", parentID: "u-1" }, parts: [{ type: "text", text: "wrong reply" }] },
+          ]), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 0,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async (key: string) => storeMap.get(key),
+          set: async (key: string, value: string) => {
+            storeMap.set(key, value);
+          },
+          delete: async () => undefined,
+          sessionKeys: async () => ["chat:77:user:5"],
+          notificationGet: async () => true,
+        },
+      };
+
+      await handleBridgeEvent(runtime, {
+        type: "session.status",
+        properties: { sessionID: "session-1", status: { type: "busy" } },
+      });
+      await handleBridgeEvent(runtime, {
+        type: "session.status",
+        properties: { sessionID: "session-1", status: { type: "idle" } },
+      });
+
+      const taskFinished = calls.find((x) =>
+        x.url.includes("/sendMessage") && String(x.body.text || "").includes("Task finished:"),
+      );
+      const recentCallback = String(
+        ((taskFinished?.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined)
+          ?.inline_keyboard?.[0]?.find((item) => String(item.callback_data || "").startsWith("u:r:"))?.callback_data) || "",
+      );
+
+      await handleCallbackUpdate(runtime, {
+        update_id: 89,
+        callback_query: {
+          id: "cb-task-recent",
+          data: recentCallback,
+          from: { id: 5 },
+          message: { message_id: 100, chat: { id: 77 } },
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls.some((x) => x.url.includes("/session/session-1/message"))).toBe(true);
+    expect(calls.some((x) => x.url.includes("/session/session-other/message"))).toBe(false);
+    const recentText = calls
+      .filter((x) => x.url.includes("/sendMessage"))
+      .map((x) => String(x.body.text || ""))
+      .find((text) => text.includes("Recent activity for session")) || "";
+    expect(recentText).toContain("session-1");
+    expect(recentText).toContain("right session");
+  });
+
 
   test("callback query submits selected option and confirms success", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -2737,6 +2737,77 @@ describe("telegram bridge config and cache", () => {
     expect(text).not.toContain("You: First question");
   });
 
+  test("/recent 1 returns newest exchange when newest-first payload omits timestamps", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current/message")) {
+          return new Response(
+            JSON.stringify([
+              {
+                info: { id: "a-2", role: "assistant", parentID: "u-2" },
+                parts: [{ type: "text", text: "Second answer" }],
+              },
+              {
+                info: { id: "u-2", role: "user" },
+                parts: [{ type: "text", text: "Second question" }],
+              },
+              {
+                info: { id: "a-1", role: "assistant", parentID: "u-1" },
+                parts: [{ type: "text", text: "First answer" }],
+              },
+              {
+                info: { id: "u-1", role: "user" },
+                parts: [{ type: "text", text: "First question" }],
+              },
+            ]),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/recent 1", chat: { id: 101 }, from: { id: 4 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const text = String(calls.filter((x) => x.url.includes("/sendMessage")).at(-1)?.body.text || "");
+    expect(text).toContain("showing 1 of 2");
+    expect(text).toContain("You: Second question");
+    expect(text).toContain("Assistant: Second answer");
+    expect(text).not.toContain("You: First question");
+  });
+
   test("/recent reports empty state when no message history exists", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -5099,7 +5099,7 @@ describe("telegram bridge config and cache", () => {
         const markup = x.body.reply_markup as { inline_keyboard?: Array<Array<{ callback_data?: string }>> } | undefined
         const row = markup?.inline_keyboard?.[0] || []
         const callbacks = row.map((item) => String(item.callback_data || ""))
-        return callbacks.includes("s:p:1") && callbacks.some((item) => /^u:r:[a-z0-9]{6,24}$/.test(item))
+        return callbacks.some((item) => /^u:s:[a-z0-9]{6,24}$/.test(item)) && callbacks.some((item) => /^u:r:[a-z0-9]{6,24}$/.test(item))
       })
     expect(hasUtilityButtons).toBe(true)
     const items = inbox.get("chat:88") || [];

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -2808,6 +2808,77 @@ describe("telegram bridge config and cache", () => {
     expect(text).not.toContain("You: First question");
   });
 
+  test("/recent 1 uses row timestamps when user timestamps are missing", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        calls.push({ url, body });
+        if (url.includes("/session/session-current/message")) {
+          return new Response(
+            JSON.stringify([
+              {
+                info: { id: "u-1", role: "user" },
+                parts: [{ type: "text", text: "First question" }],
+              },
+              {
+                info: { id: "a-1", role: "assistant", parentID: "u-1", time: { created: "100" } },
+                parts: [{ type: "text", text: "First answer" }],
+              },
+              {
+                info: { id: "u-2", role: "user" },
+                parts: [{ type: "text", text: "Second question" }],
+              },
+              {
+                info: { id: "a-2", role: "assistant", parentID: "u-2", time: { created: "200" } },
+                parts: [{ type: "text", text: "Second answer" }],
+              },
+            ]),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/sendMessage")) {
+          return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch ${url}`);
+      };
+
+      const runtime = {
+        config: {
+          mode: "polling" as const,
+          token: "token",
+          openCodeUrl: "http://127.0.0.1:4096",
+          sessionCacheMax: 10,
+          sessionCacheTtlMs: 10_000,
+          notificationDebounceMs: 20_000,
+          port: 4097,
+          webhookPath: "/webhook",
+          sessionStorePath: "/tmp/test-store.json",
+        },
+        store: {
+          get: async () => "session-current",
+          set: async () => undefined,
+          delete: async () => undefined,
+        },
+      };
+
+      await handleTextUpdate(runtime, {
+        update_id: 1,
+        message: { message_id: 1, text: "/recent 1", chat: { id: 101 }, from: { id: 4 } },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const text = String(calls.filter((x) => x.url.includes("/sendMessage")).at(-1)?.body.text || "");
+    expect(text).toContain("showing 1 of 2");
+    expect(text).toContain("You: Second question");
+    expect(text).toContain("Assistant: Second answer");
+    expect(text).not.toContain("You: First question");
+  });
+
   test("/recent reports empty state when no message history exists", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const originalFetch = globalThis.fetch;

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1704,6 +1704,21 @@ function parseRecentText(parts: unknown): string {
   return truncateTelegramInlineText(text, recentPartTextMax)
 }
 
+function parseRecentCreated(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const raw = value.trim()
+    if (!raw) return 0
+    if (/^\d+$/.test(raw)) {
+      const parsed = Number.parseInt(raw, 10)
+      if (Number.isFinite(parsed)) return parsed
+    }
+    const parsedDate = Date.parse(raw)
+    if (Number.isFinite(parsedDate)) return parsedDate
+  }
+  return 0
+}
+
 async function recentText(config: BridgeConfig, sessionId: string, count: number): Promise<string> {
   const safeCount = Math.max(1, Math.min(count, recentMaxCount))
   const url = opencodeUrl(config, `/session/${encodeURIComponent(sessionId)}/message`)
@@ -1725,6 +1740,8 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
   const users: Array<{ id: string; text: string; created: number }> = []
   const rowIndex = new Map<string, number>()
   const assistantParents: Array<{ index: number; parentID: string }> = []
+  let firstCreated = 0
+  let lastCreated = 0
   for (let index = 0; index < rows.length; index++) {
     const entry = rows[index]
     if (!entry || typeof entry !== "object") continue
@@ -1739,12 +1756,11 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     const time = "time" in info && info.time && typeof info.time === "object"
       ? info.time as { created?: unknown }
       : undefined
-    const createdRaw = time?.created
-    const created = typeof createdRaw === "number" && Number.isFinite(createdRaw)
-      ? createdRaw
-      : typeof createdRaw === "string" && createdRaw.trim().length
-        ? Number.parseInt(createdRaw, 10)
-        : 0
+    const created = parseRecentCreated(time?.created)
+      || parseRecentCreated((info as { created?: unknown }).created)
+      || parseRecentCreated((row as { time?: { created?: unknown } }).time?.created)
+    if (!firstCreated && created > 0) firstCreated = created
+    if (created > 0) lastCreated = created
     if (id) {
       rowIndex.set(id, index)
     }
@@ -1776,7 +1792,10 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     if (item.index > parentIndex) return acc + 1
     return acc
   }, 0)
-  const newestFirst = assistantBeforeParent > assistantAfterParent
+  const newestFirstByTime = firstCreated > 0 && lastCreated > 0 && firstCreated !== lastCreated
+    ? firstCreated > lastCreated
+    : undefined
+  const newestFirst = newestFirstByTime ?? (assistantBeforeParent > assistantAfterParent)
   const ordered = hasCreated
     ? users.slice().sort((a, b) => {
       if (a.created !== b.created) return a.created - b.created

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -263,6 +263,7 @@ const fallbackPending = new Map<string, TelegramPendingItem[]>()
 const pendingQuestions = new Map<string, TelegramPendingQuestion[]>()
 const sessionHistory = new Map<string, string[]>()
 const sessionInfo = new Map<string, CachedSessionInfo>()
+const switchTargets = new Map<string, { sessionRef: string; expiresAt: number }>()
 
 let pendingEntrySeq = 0
 
@@ -288,6 +289,7 @@ const inlineButtonTextMax = 48
 const callbackDataMax = 64
 const telegramMessageSoftLimit = 3900
 const recentPayloadMax = telegramMessageSoftLimit * 3
+const switchTargetTtlMs = 30 * 60 * 1000
 
 const telegramCommands = Object.freeze([
   Object.freeze({
@@ -911,6 +913,7 @@ type SwitchCallbackData =
 
 type UtilityCallbackData =
   | { action: "recent" }
+  | { action: "switch"; token: string }
 
 function switchToken(sessionId: string): string {
   return shortId(sessionId).slice(0, 8).padStart(6, "0")
@@ -938,18 +941,54 @@ function parseSwitchCallbackData(input: string): SwitchCallbackData | undefined 
   return { action: "select", index: index - 1, token: selected[2] || "" }
 }
 
+function pruneSwitchTargets(now: number) {
+  for (const [token, value] of switchTargets) {
+    if (value.expiresAt > now) continue
+    switchTargets.delete(token)
+  }
+}
+
+function utilitySwitchSessionCallbackData(sourceId: string, sessionId: string): string {
+  const now = Date.now()
+  pruneSwitchTargets(now)
+  const sessionRef = encodeSessionRef({ sourceId, sessionId })
+  const tokenSeed = `${sessionRef}:${now}:${pendingEntrySeq++}`
+  const token = `${shortId(tokenSeed)}${Math.abs(pendingEntrySeq).toString(36)}`.slice(0, 12)
+  switchTargets.set(token, { sessionRef, expiresAt: now + switchTargetTtlMs })
+  return `u:s:${token}`
+}
+
+function resolveUtilitySwitchTarget(token: string): string | undefined {
+  const now = Date.now()
+  pruneSwitchTargets(now)
+  const stored = switchTargets.get(token)
+  if (!stored) return
+  if (stored.expiresAt <= now) {
+    switchTargets.delete(token)
+    return
+  }
+  return stored.sessionRef
+}
+
 function utilityRecentCallbackData(): string {
   return "u:recent"
 }
 
 function parseUtilityCallbackData(input: string): UtilityCallbackData | undefined {
   if (input === "u:recent") return { action: "recent" }
+  const switchSession = input.match(/^u:s:([a-z0-9]{6,24})$/)
+  if (switchSession) {
+    return { action: "switch", token: switchSession[1] || "" }
+  }
 }
 
-function proactiveActionsMarkup(): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+function proactiveActionsMarkup(kind: "default" | "task-finished", sourceId: string, sessionId: string): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  const switchCallback = kind === "task-finished"
+    ? utilitySwitchSessionCallbackData(sourceId, sessionId)
+    : switchPageCallback(0)
   return {
     inline_keyboard: [[
-      { text: "Switch session", callback_data: switchPageCallback(0) },
+      { text: "Switch session", callback_data: switchCallback },
       { text: "Latest message", callback_data: utilityRecentCallbackData() },
     ]],
   }
@@ -2510,6 +2549,35 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       return
     }
     const utility = parseUtilityCallbackData(data)
+    if (utility?.action === "switch") {
+      const storedRef = resolveUtilitySwitchTarget(utility.token)
+      if (!storedRef) {
+        await answerCallback(runtime.config, callbackId, "This switch button expired. Use /switch.")
+        state.acknowledged = true
+        return
+      }
+      const ref = decodeSessionRef(storedRef)
+      if (!ref) {
+        await answerCallback(runtime.config, callbackId, "That session entry is invalid.")
+        state.acknowledged = true
+        return
+      }
+      const scoped = sourceForSessionRef(runtime, ref)
+      if (!scoped) {
+        await answerCallback(runtime.config, callbackId, sourceUnavailableText(ref.sourceId))
+        state.acknowledged = true
+        return
+      }
+      const key = telegramSessionKey(chatId, userId)
+      await runtime.store.set(key, storedRef)
+      cacheSession(runtime.config, key, storedRef)
+      await rememberSession(runtime, key, storedRef)
+      const title = await safeSessionTitle(scoped, ref.sessionId, ref.sourceId)
+      await answerCallback(runtime.config, callbackId, "Switched.")
+      state.acknowledged = true
+      await sendTelegramMessage(runtime.config, chatId, `Switched to session: ${formatSessionDisplay(ref.sessionId, title, ref.sourceId)}`)
+      return
+    }
     if (utility?.action === "recent") {
       const key = telegramSessionKey(chatId, userId)
       const current = await runtime.store.get(key) || sessionFromCache(runtime.config, key)
@@ -3027,8 +3095,9 @@ async function notifySessionKeys(
       if (!proactiveTelegramEnabled(runtime.config)) continue
       if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId, sourceId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId, sourceId)}`
+      const markup = proactiveActionsMarkup(kind === "task-finished" ? "task-finished" : "default", sourceId, sessionId)
       await queueChatUpdate(String(chatId), async () => {
-        await sendTelegramMessageWithMarkup(runtime.config, chatId, message, proactiveActionsMarkup())
+        await sendTelegramMessageWithMarkup(runtime.config, chatId, message, markup)
       })
       stampNotification(chatId, dedupeKey, sessionId, sourceId)
     } catch (error) {
@@ -3094,7 +3163,7 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, sourceId: str
           runtime.config,
           chatId,
           `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`,
-          proactiveActionsMarkup(),
+          proactiveActionsMarkup("default", sourceId, sessionId),
         )
       })
       stampNotification(chatId, kind, sessionId, sourceId)
@@ -3405,4 +3474,5 @@ export function resetSessionCacheForTest() {
   pendingQuestions.clear()
   sessionHistory.clear()
   sessionInfo.clear()
+  switchTargets.clear()
 }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -263,8 +263,8 @@ const fallbackPending = new Map<string, TelegramPendingItem[]>()
 const pendingQuestions = new Map<string, TelegramPendingQuestion[]>()
 const sessionHistory = new Map<string, string[]>()
 const sessionInfo = new Map<string, CachedSessionInfo>()
-const switchTargets = new Map<string, { sessionRef: string; expiresAt: number }>()
-const recentTargets = new Map<string, { sessionRef: string; expiresAt: number }>()
+const switchTargets = new Map<string, { sessionRef: string; chatId: number; expiresAt: number }>()
+const recentTargets = new Map<string, { sessionRef: string; chatId: number; expiresAt: number }>()
 
 let pendingEntrySeq = 0
 
@@ -953,22 +953,23 @@ function pruneUtilityTargets(now: number) {
   }
 }
 
-function utilitySwitchSessionCallbackData(sourceId: string, sessionId: string): string {
+function utilitySwitchSessionCallbackData(sourceId: string, sessionId: string, chatId: number): string {
   const now = Date.now()
   pruneUtilityTargets(now)
   const sessionRef = encodeSessionRef({ sourceId, sessionId })
   const seq = Math.abs(pendingEntrySeq++)
   const tokenSeed = `${sessionRef}:${now}:${seq}`
   const token = `${shortId(tokenSeed)}${seq.toString(36)}`.slice(0, 12).padStart(6, "0")
-  switchTargets.set(token, { sessionRef, expiresAt: now + switchTargetTtlMs })
+  switchTargets.set(token, { sessionRef, chatId, expiresAt: now + switchTargetTtlMs })
   return `u:s:${token}`
 }
 
-function resolveUtilitySwitchTarget(token: string): string | undefined {
+function resolveUtilitySwitchTarget(token: string, chatId: number): string | undefined {
   const now = Date.now()
   pruneUtilityTargets(now)
   const stored = switchTargets.get(token)
   if (!stored) return
+  if (stored.chatId !== chatId) return
   if (stored.expiresAt <= now) {
     switchTargets.delete(token)
     return
@@ -976,22 +977,23 @@ function resolveUtilitySwitchTarget(token: string): string | undefined {
   return stored.sessionRef
 }
 
-function utilityRecentSessionCallbackData(sourceId: string, sessionId: string): string {
+function utilityRecentSessionCallbackData(sourceId: string, sessionId: string, chatId: number): string {
   const now = Date.now()
   pruneUtilityTargets(now)
   const sessionRef = encodeSessionRef({ sourceId, sessionId })
   const seq = Math.abs(pendingEntrySeq++)
   const tokenSeed = `${sessionRef}:recent:${now}:${seq}`
   const token = `${shortId(tokenSeed)}${seq.toString(36)}`.slice(0, 12).padStart(6, "0")
-  recentTargets.set(token, { sessionRef, expiresAt: now + switchTargetTtlMs })
+  recentTargets.set(token, { sessionRef, chatId, expiresAt: now + switchTargetTtlMs })
   return `u:r:${token}`
 }
 
-function resolveRecentTarget(token: string): string | undefined {
+function resolveRecentTarget(token: string, chatId: number): string | undefined {
   const now = Date.now()
   pruneUtilityTargets(now)
   const stored = recentTargets.get(token)
   if (!stored) return
+  if (stored.chatId !== chatId) return
   if (stored.expiresAt <= now) {
     recentTargets.delete(token)
     return
@@ -1011,9 +1013,9 @@ function parseUtilityCallbackData(input: string): UtilityCallbackData | undefine
   }
 }
 
-function proactiveActionsMarkup(sourceId: string, sessionId: string): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
-  const switchCallback = utilitySwitchSessionCallbackData(sourceId, sessionId)
-  const recentCallback = utilityRecentSessionCallbackData(sourceId, sessionId)
+function proactiveActionsMarkup(sourceId: string, sessionId: string, chatId: number): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  const switchCallback = utilitySwitchSessionCallbackData(sourceId, sessionId, chatId)
+  const recentCallback = utilityRecentSessionCallbackData(sourceId, sessionId, chatId)
   return {
     inline_keyboard: [[
       { text: "Switch session", callback_data: switchCallback },
@@ -2615,9 +2617,9 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
     }
     const utility = parseUtilityCallbackData(data)
     if (utility?.action === "switch") {
-      const storedRef = resolveUtilitySwitchTarget(utility.token)
+      const storedRef = resolveUtilitySwitchTarget(utility.token, chatId)
       if (!storedRef) {
-        await answerCallback(runtime.config, callbackId, "This switch button expired. Use /switch.")
+        await answerCallback(runtime.config, callbackId, "This switch button is invalid or expired. Use /switch.")
         state.acknowledged = true
         return
       }
@@ -2633,20 +2635,20 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
         state.acknowledged = true
         return
       }
+      await answerCallback(runtime.config, callbackId, "Switching...")
+      state.acknowledged = true
       const key = telegramSessionKey(chatId, userId)
       await runtime.store.set(key, storedRef)
       cacheSession(runtime.config, key, storedRef)
       await rememberSession(runtime, key, storedRef)
       const title = await safeSessionTitle(scoped, ref.sessionId, ref.sourceId)
-      await answerCallback(runtime.config, callbackId, "Switched.")
-      state.acknowledged = true
       await sendTelegramMessage(runtime.config, chatId, `Switched to session: ${formatSessionDisplay(ref.sessionId, title, ref.sourceId)}`)
       return
     }
     if (utility?.action === "recent") {
-      const tokenRef = utility.token ? resolveRecentTarget(utility.token) : undefined
+      const tokenRef = utility.token ? resolveRecentTarget(utility.token, chatId) : undefined
       if (utility.token && !tokenRef) {
-        await answerCallback(runtime.config, callbackId, "This latest-message button expired.")
+        await answerCallback(runtime.config, callbackId, "This latest-message button is invalid or expired.")
         state.acknowledged = true
         return
       }
@@ -3166,7 +3168,7 @@ async function notifySessionKeys(
       if (!proactiveTelegramEnabled(runtime.config)) continue
       if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId, sourceId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId, sourceId)}`
-      const markup = proactiveActionsMarkup(sourceId, sessionId)
+      const markup = proactiveActionsMarkup(sourceId, sessionId, chatId)
       await queueChatUpdate(String(chatId), async () => {
         await sendTelegramMessageWithMarkup(runtime.config, chatId, message, markup)
       })
@@ -3234,7 +3236,7 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, sourceId: str
           runtime.config,
           chatId,
           `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`,
-          proactiveActionsMarkup(sourceId, sessionId),
+          proactiveActionsMarkup(sourceId, sessionId, chatId),
         )
       })
       stampNotification(chatId, kind, sessionId, sourceId)

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1794,7 +1794,7 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     if (!entry || typeof entry !== "object") continue
     const row = entry as { info?: unknown; parts?: unknown }
     const info = row.info && typeof row.info === "object"
-      ? row.info as { id?: unknown; role?: unknown; parentID?: unknown }
+      ? row.info as { id?: unknown; role?: unknown; parentID?: unknown; time?: unknown; created?: unknown }
       : undefined
     if (!info) continue
     const id = typeof info.id === "string" ? info.id : ""

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1723,7 +1723,10 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
   const rows = Array.isArray(data) ? data : []
   const assistants = new Map<string, string>()
   const users: Array<{ id: string; text: string; created: number }> = []
-  for (const entry of rows) {
+  const rowIndex = new Map<string, number>()
+  const assistantParents: Array<{ index: number; parentID: string }> = []
+  for (let index = 0; index < rows.length; index++) {
+    const entry = rows[index]
     if (!entry || typeof entry !== "object") continue
     const row = entry as { info?: unknown; parts?: unknown }
     const info = row.info && typeof row.info === "object"
@@ -1736,7 +1739,18 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     const time = "time" in info && info.time && typeof info.time === "object"
       ? info.time as { created?: unknown }
       : undefined
-    const created = typeof time?.created === "number" && Number.isFinite(time.created) ? time.created : 0
+    const createdRaw = time?.created
+    const created = typeof createdRaw === "number" && Number.isFinite(createdRaw)
+      ? createdRaw
+      : typeof createdRaw === "string" && createdRaw.trim().length
+        ? Number.parseInt(createdRaw, 10)
+        : 0
+    if (id) {
+      rowIndex.set(id, index)
+    }
+    if (role === "assistant" && parentID) {
+      assistantParents.push({ index, parentID })
+    }
     const text = parseRecentText(row.parts)
     if (!id || !role || !text) continue
     if (role === "assistant" && parentID && !assistants.has(parentID)) {
@@ -1750,6 +1764,19 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     return `No recent chat messages found for session ${sessionId}. Send a new message first.`
   }
   const hasCreated = users.some((item) => item.created > 0)
+  const assistantBeforeParent = assistantParents.reduce((acc, item) => {
+    const parentIndex = rowIndex.get(item.parentID)
+    if (parentIndex === undefined) return acc
+    if (item.index < parentIndex) return acc + 1
+    return acc
+  }, 0)
+  const assistantAfterParent = assistantParents.reduce((acc, item) => {
+    const parentIndex = rowIndex.get(item.parentID)
+    if (parentIndex === undefined) return acc
+    if (item.index > parentIndex) return acc + 1
+    return acc
+  }, 0)
+  const newestFirst = assistantBeforeParent > assistantAfterParent
   const ordered = hasCreated
     ? users.slice().sort((a, b) => {
       if (a.created !== b.created) return a.created - b.created
@@ -1758,8 +1785,8 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     : users
   const list = hasCreated
     ? ordered.slice(-safeCount)
-    : safeCount === 1
-      ? ordered.slice(0, 1)
+    : newestFirst
+      ? ordered.slice(0, safeCount)
       : ordered.slice(-safeCount)
   const lines = [`Recent activity for session ${sessionId} (showing ${list.length} of ${users.length}):`]
   for (let i = 0; i < list.length; i++) {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -264,6 +264,7 @@ const pendingQuestions = new Map<string, TelegramPendingQuestion[]>()
 const sessionHistory = new Map<string, string[]>()
 const sessionInfo = new Map<string, CachedSessionInfo>()
 const switchTargets = new Map<string, { sessionRef: string; expiresAt: number }>()
+const recentTargets = new Map<string, { sessionRef: string; expiresAt: number }>()
 
 let pendingEntrySeq = 0
 
@@ -912,7 +913,7 @@ type SwitchCallbackData =
   | { action: "select"; index: number; token: string }
 
 type UtilityCallbackData =
-  | { action: "recent" }
+  | { action: "recent"; token?: string }
   | { action: "switch"; token: string }
 
 function switchToken(sessionId: string): string {
@@ -974,8 +975,34 @@ function utilityRecentCallbackData(): string {
   return "u:recent"
 }
 
+function utilityRecentSessionCallbackData(sourceId: string, sessionId: string): string {
+  const now = Date.now()
+  pruneSwitchTargets(now)
+  const sessionRef = encodeSessionRef({ sourceId, sessionId })
+  const tokenSeed = `${sessionRef}:recent:${now}:${pendingEntrySeq++}`
+  const token = `${shortId(tokenSeed)}${Math.abs(pendingEntrySeq).toString(36)}`.slice(0, 12)
+  recentTargets.set(token, { sessionRef, expiresAt: now + switchTargetTtlMs })
+  return `u:r:${token}`
+}
+
+function resolveRecentTarget(token: string): string | undefined {
+  const now = Date.now()
+  pruneSwitchTargets(now)
+  const stored = recentTargets.get(token)
+  if (!stored) return
+  if (stored.expiresAt <= now) {
+    recentTargets.delete(token)
+    return
+  }
+  return stored.sessionRef
+}
+
 function parseUtilityCallbackData(input: string): UtilityCallbackData | undefined {
   if (input === "u:recent") return { action: "recent" }
+  const recentSession = input.match(/^u:r:([a-z0-9]{6,24})$/)
+  if (recentSession) {
+    return { action: "recent", token: recentSession[1] || "" }
+  }
   const switchSession = input.match(/^u:s:([a-z0-9]{6,24})$/)
   if (switchSession) {
     return { action: "switch", token: switchSession[1] || "" }
@@ -986,10 +1013,11 @@ function proactiveActionsMarkup(kind: "default" | "task-finished", sourceId: str
   const switchCallback = kind === "task-finished"
     ? utilitySwitchSessionCallbackData(sourceId, sessionId)
     : switchPageCallback(0)
+  const recentCallback = utilityRecentSessionCallbackData(sourceId, sessionId)
   return {
     inline_keyboard: [[
       { text: "Switch session", callback_data: switchCallback },
-      { text: "Latest message", callback_data: utilityRecentCallbackData() },
+      { text: "Latest message", callback_data: recentCallback },
     ]],
   }
 }
@@ -2577,8 +2605,14 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       return
     }
     if (utility?.action === "recent") {
+      const tokenRef = utility.token ? resolveRecentTarget(utility.token) : undefined
+      if (utility.token && !tokenRef) {
+        await answerCallback(runtime.config, callbackId, "This latest-message button expired.")
+        state.acknowledged = true
+        return
+      }
       const key = telegramSessionKey(chatId, userId)
-      const current = await runtime.store.get(key) || sessionFromCache(runtime.config, key)
+      const current = tokenRef || await runtime.store.get(key) || sessionFromCache(runtime.config, key)
       if (!current) {
         await answerCallback(runtime.config, callbackId, "No active session mapping.")
         state.acknowledged = true
@@ -3473,4 +3507,5 @@ export function resetSessionCacheForTest() {
   sessionHistory.clear()
   sessionInfo.clear()
   switchTargets.clear()
+  recentTargets.clear()
 }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -942,7 +942,7 @@ function parseSwitchCallbackData(input: string): SwitchCallbackData | undefined 
   return { action: "select", index: index - 1, token: selected[2] || "" }
 }
 
-function pruneSwitchTargets(now: number) {
+function pruneUtilityTargets(now: number) {
   for (const [token, value] of switchTargets) {
     if (value.expiresAt > now) continue
     switchTargets.delete(token)
@@ -955,17 +955,18 @@ function pruneSwitchTargets(now: number) {
 
 function utilitySwitchSessionCallbackData(sourceId: string, sessionId: string): string {
   const now = Date.now()
-  pruneSwitchTargets(now)
+  pruneUtilityTargets(now)
   const sessionRef = encodeSessionRef({ sourceId, sessionId })
-  const tokenSeed = `${sessionRef}:${now}:${pendingEntrySeq++}`
-  const token = `${shortId(tokenSeed)}${Math.abs(pendingEntrySeq).toString(36)}`.slice(0, 12)
+  const seq = Math.abs(pendingEntrySeq++)
+  const tokenSeed = `${sessionRef}:${now}:${seq}`
+  const token = `${shortId(tokenSeed)}${seq.toString(36)}`.slice(0, 12).padStart(6, "0")
   switchTargets.set(token, { sessionRef, expiresAt: now + switchTargetTtlMs })
   return `u:s:${token}`
 }
 
 function resolveUtilitySwitchTarget(token: string): string | undefined {
   const now = Date.now()
-  pruneSwitchTargets(now)
+  pruneUtilityTargets(now)
   const stored = switchTargets.get(token)
   if (!stored) return
   if (stored.expiresAt <= now) {
@@ -977,17 +978,18 @@ function resolveUtilitySwitchTarget(token: string): string | undefined {
 
 function utilityRecentSessionCallbackData(sourceId: string, sessionId: string): string {
   const now = Date.now()
-  pruneSwitchTargets(now)
+  pruneUtilityTargets(now)
   const sessionRef = encodeSessionRef({ sourceId, sessionId })
-  const tokenSeed = `${sessionRef}:recent:${now}:${pendingEntrySeq++}`
-  const token = `${shortId(tokenSeed)}${Math.abs(pendingEntrySeq).toString(36)}`.slice(0, 12)
+  const seq = Math.abs(pendingEntrySeq++)
+  const tokenSeed = `${sessionRef}:recent:${now}:${seq}`
+  const token = `${shortId(tokenSeed)}${seq.toString(36)}`.slice(0, 12).padStart(6, "0")
   recentTargets.set(token, { sessionRef, expiresAt: now + switchTargetTtlMs })
   return `u:r:${token}`
 }
 
 function resolveRecentTarget(token: string): string | undefined {
   const now = Date.now()
-  pruneSwitchTargets(now)
+  pruneUtilityTargets(now)
   const stored = recentTargets.get(token)
   if (!stored) return
   if (stored.expiresAt <= now) {
@@ -1009,10 +1011,8 @@ function parseUtilityCallbackData(input: string): UtilityCallbackData | undefine
   }
 }
 
-function proactiveActionsMarkup(kind: "default" | "task-finished", sourceId: string, sessionId: string): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
-  const switchCallback = kind === "task-finished"
-    ? utilitySwitchSessionCallbackData(sourceId, sessionId)
-    : switchPageCallback(0)
+function proactiveActionsMarkup(sourceId: string, sessionId: string): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  const switchCallback = utilitySwitchSessionCallbackData(sourceId, sessionId)
   const recentCallback = utilityRecentSessionCallbackData(sourceId, sessionId)
   return {
     inline_keyboard: [[
@@ -3166,7 +3166,7 @@ async function notifySessionKeys(
       if (!proactiveTelegramEnabled(runtime.config)) continue
       if (!shouldNotify(runtime.config, chatId, dedupeKey, sessionId, sourceId)) continue
       const message = `${text}\n\nOpen ${sessionLabel(runtime.config, sessionId, sourceId)}`
-      const markup = proactiveActionsMarkup(kind === "task-finished" ? "task-finished" : "default", sourceId, sessionId)
+      const markup = proactiveActionsMarkup(sourceId, sessionId)
       await queueChatUpdate(String(chatId), async () => {
         await sendTelegramMessageWithMarkup(runtime.config, chatId, message, markup)
       })
@@ -3234,7 +3234,7 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, sourceId: str
           runtime.config,
           chatId,
           `Open ${sessionLabel(runtime.config, sessionId, sourceId)}`,
-          proactiveActionsMarkup("default", sourceId, sessionId),
+          proactiveActionsMarkup(sourceId, sessionId),
         )
       })
       stampNotification(chatId, kind, sessionId, sourceId)

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -291,6 +291,8 @@ const callbackDataMax = 64
 const telegramMessageSoftLimit = 3900
 const recentPayloadMax = telegramMessageSoftLimit * 3
 const switchTargetTtlMs = 30 * 60 * 1000
+const switchTargetMax = 2048
+const recentTargetMax = 2048
 
 const telegramCommands = Object.freeze([
   Object.freeze({
@@ -942,15 +944,22 @@ function parseSwitchCallbackData(input: string): SwitchCallbackData | undefined 
   return { action: "select", index: index - 1, token: selected[2] || "" }
 }
 
+function pruneUtilityTargetMap<T extends { expiresAt: number }>(targets: Map<string, T>, now: number, max: number) {
+  while (targets.size) {
+    const oldest = targets.entries().next().value as [string, T] | undefined
+    if (!oldest || oldest[1].expiresAt > now) break
+    targets.delete(oldest[0])
+  }
+  while (targets.size > max) {
+    const oldest = targets.keys().next().value as string | undefined
+    if (!oldest) break
+    targets.delete(oldest)
+  }
+}
+
 function pruneUtilityTargets(now: number) {
-  for (const [token, value] of switchTargets) {
-    if (value.expiresAt > now) continue
-    switchTargets.delete(token)
-  }
-  for (const [token, value] of recentTargets) {
-    if (value.expiresAt > now) continue
-    recentTargets.delete(token)
-  }
+  pruneUtilityTargetMap(switchTargets, now, switchTargetMax)
+  pruneUtilityTargetMap(recentTargets, now, recentTargetMax)
 }
 
 function utilitySwitchSessionCallbackData(sourceId: string, sessionId: string, chatId: number): string {
@@ -974,7 +983,9 @@ function resolveUtilitySwitchTarget(token: string, chatId: number): string | und
     switchTargets.delete(token)
     return
   }
-  return stored.sessionRef
+  const sessionRef = stored.sessionRef
+  switchTargets.delete(token)
+  return sessionRef
 }
 
 function utilityRecentSessionCallbackData(sourceId: string, sessionId: string, chatId: number): string {
@@ -998,7 +1009,9 @@ function resolveRecentTarget(token: string, chatId: number): string | undefined 
     recentTargets.delete(token)
     return
   }
-  return stored.sessionRef
+  const sessionRef = stored.sessionRef
+  recentTargets.delete(token)
+  return sessionRef
 }
 
 function parseUtilityCallbackData(input: string): UtilityCallbackData | undefined {

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1704,21 +1704,6 @@ function parseRecentText(parts: unknown): string {
   return truncateTelegramInlineText(text, recentPartTextMax)
 }
 
-function parseRecentCreated(value: unknown): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value
-  if (typeof value === "string") {
-    const raw = value.trim()
-    if (!raw) return 0
-    if (/^\d+$/.test(raw)) {
-      const parsed = Number.parseInt(raw, 10)
-      if (Number.isFinite(parsed)) return parsed
-    }
-    const parsedDate = Date.parse(raw)
-    if (Number.isFinite(parsedDate)) return parsedDate
-  }
-  return 0
-}
-
 async function recentText(config: BridgeConfig, sessionId: string, count: number): Promise<string> {
   const safeCount = Math.max(1, Math.min(count, recentMaxCount))
   const url = opencodeUrl(config, `/session/${encodeURIComponent(sessionId)}/message`)
@@ -1736,14 +1721,8 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
   }
   const data = await res.json().catch(() => [])
   const rows = Array.isArray(data) ? data : []
-  const assistants = new Map<string, string>()
-  const users: Array<{ id: string; text: string; created: number }> = []
-  const rowIndex = new Map<string, number>()
-  const assistantParents: Array<{ index: number; parentID: string }> = []
-  let firstCreated = 0
-  let lastCreated = 0
-  for (let index = 0; index < rows.length; index++) {
-    const entry = rows[index]
+  const items: Array<{ id: string; role: "user" | "assistant"; parentID?: string; text: string }> = []
+  for (const entry of rows) {
     if (!entry || typeof entry !== "object") continue
     const row = entry as { info?: unknown; parts?: unknown }
     const info = row.info && typeof row.info === "object"
@@ -1751,62 +1730,30 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
       : undefined
     if (!info) continue
     const id = typeof info.id === "string" ? info.id : ""
-    const parentID = typeof info.parentID === "string" ? info.parentID : ""
     const role = info.role === "assistant" || info.role === "user" ? info.role : ""
-    const time = "time" in info && info.time && typeof info.time === "object"
-      ? info.time as { created?: unknown }
-      : undefined
-    const created = parseRecentCreated(time?.created)
-      || parseRecentCreated((info as { created?: unknown }).created)
-      || parseRecentCreated((row as { time?: { created?: unknown } }).time?.created)
-    if (!firstCreated && created > 0) firstCreated = created
-    if (created > 0) lastCreated = created
-    if (id) {
-      rowIndex.set(id, index)
-    }
-    if (role === "assistant" && parentID) {
-      assistantParents.push({ index, parentID })
-    }
+    const parentID = typeof info.parentID === "string" ? info.parentID : ""
     const text = parseRecentText(row.parts)
     if (!id || !role || !text) continue
-    if (role === "assistant" && parentID && !assistants.has(parentID)) {
-      assistants.set(parentID, text)
+    if (role === "assistant") {
+      items.push({ id, role: "assistant", parentID, text })
       continue
     }
-    if (role !== "user") continue
-    users.push({ id, text, created })
+    items.push({ id, role: "user", text })
+  }
+  items.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: "base" }))
+  const assistants = new Map<string, string>()
+  const users: Array<{ id: string; text: string }> = []
+  for (const item of items) {
+    if (item.role === "assistant") {
+      if (item.parentID) assistants.set(item.parentID, item.text)
+      continue
+    }
+    users.push({ id: item.id, text: item.text })
   }
   if (!users.length) {
     return `No recent chat messages found for session ${sessionId}. Send a new message first.`
   }
-  const hasCreated = users.some((item) => item.created > 0)
-  const assistantBeforeParent = assistantParents.reduce((acc, item) => {
-    const parentIndex = rowIndex.get(item.parentID)
-    if (parentIndex === undefined) return acc
-    if (item.index < parentIndex) return acc + 1
-    return acc
-  }, 0)
-  const assistantAfterParent = assistantParents.reduce((acc, item) => {
-    const parentIndex = rowIndex.get(item.parentID)
-    if (parentIndex === undefined) return acc
-    if (item.index > parentIndex) return acc + 1
-    return acc
-  }, 0)
-  const newestFirstByTime = firstCreated > 0 && lastCreated > 0 && firstCreated !== lastCreated
-    ? firstCreated > lastCreated
-    : undefined
-  const newestFirst = newestFirstByTime ?? (assistantBeforeParent > assistantAfterParent)
-  const ordered = hasCreated
-    ? users.slice().sort((a, b) => {
-      if (a.created !== b.created) return a.created - b.created
-      return a.id.localeCompare(b.id)
-    })
-    : users
-  const list = hasCreated
-    ? ordered.slice(-safeCount)
-    : newestFirst
-      ? ordered.slice(0, safeCount)
-      : ordered.slice(-safeCount)
+  const list = users.slice(-safeCount)
   const lines = [`Recent activity for session ${sessionId} (showing ${list.length} of ${users.length}):`]
   for (let i = 0; i < list.length; i++) {
     const item = list[i]

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -947,6 +947,10 @@ function pruneSwitchTargets(now: number) {
     if (value.expiresAt > now) continue
     switchTargets.delete(token)
   }
+  for (const [token, value] of recentTargets) {
+    if (value.expiresAt > now) continue
+    recentTargets.delete(token)
+  }
 }
 
 function utilitySwitchSessionCallbackData(sourceId: string, sessionId: string): string {
@@ -969,10 +973,6 @@ function resolveUtilitySwitchTarget(token: string): string | undefined {
     return
   }
   return stored.sessionRef
-}
-
-function utilityRecentCallbackData(): string {
-  return "u:recent"
 }
 
 function utilityRecentSessionCallbackData(sourceId: string, sessionId: string): string {
@@ -1723,6 +1723,21 @@ function normalizeRecentCount(args: string[]): { count?: number; error?: string 
   return { count: Math.min(parsed, recentMaxCount) }
 }
 
+function parseRecentCreated(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const raw = value.trim()
+    if (!raw) return 0
+    if (/^\d+$/.test(raw)) {
+      const parsed = Number.parseInt(raw, 10)
+      if (Number.isFinite(parsed)) return parsed
+    }
+    const parsedDate = Date.parse(raw)
+    if (Number.isFinite(parsedDate)) return parsedDate
+  }
+  return 0
+}
+
 function parseRecentText(parts: unknown): string {
   if (!Array.isArray(parts)) return ""
   const text = parts
@@ -1759,7 +1774,7 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
   }
   const data = await res.json().catch(() => [])
   const rows = Array.isArray(data) ? data : []
-  const items: Array<{ id: string; role: "user" | "assistant"; parentID?: string; text: string }> = []
+  const items: Array<{ id: string; role: "user" | "assistant"; parentID?: string; text: string; created: number }> = []
   for (const entry of rows) {
     if (!entry || typeof entry !== "object") continue
     const row = entry as { info?: unknown; parts?: unknown }
@@ -1770,23 +1785,35 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
     const id = typeof info.id === "string" ? info.id : ""
     const role = info.role === "assistant" || info.role === "user" ? info.role : ""
     const parentID = typeof info.parentID === "string" ? info.parentID : ""
+    const time = "time" in info && info.time && typeof info.time === "object"
+      ? info.time as { created?: unknown }
+      : undefined
+    const created = parseRecentCreated(time?.created)
+      || parseRecentCreated((info as { created?: unknown }).created)
+      || parseRecentCreated((row as { time?: { created?: unknown } }).time?.created)
     const text = parseRecentText(row.parts)
     if (!id || !role || !text) continue
     if (role === "assistant") {
-      items.push({ id, role: "assistant", parentID, text })
+      items.push({ id, role: "assistant", parentID, text, created })
       continue
     }
-    items.push({ id, role: "user", text })
+    items.push({ id, role: "user", text, created })
   }
-  items.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: "base" }))
+  const hasCreated = items.some((item) => item.created > 0)
+  items.sort((a, b) => {
+    if (hasCreated && a.created > 0 && b.created > 0 && a.created !== b.created) {
+      return a.created - b.created
+    }
+    return a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: "base" })
+  })
   const assistants = new Map<string, string>()
-  const users: Array<{ id: string; text: string }> = []
+  const users: Array<{ id: string; text: string; created: number }> = []
   for (const item of items) {
     if (item.role === "assistant") {
       if (item.parentID) assistants.set(item.parentID, item.text)
       continue
     }
-    users.push({ id: item.id, text: item.text })
+    users.push({ id: item.id, text: item.text, created: item.created })
   }
   if (!users.length) {
     return `No recent chat messages found for session ${sessionId}. Send a new message first.`

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1749,13 +1749,18 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
   if (!users.length) {
     return `No recent chat messages found for session ${sessionId}. Send a new message first.`
   }
-  const ordered = users.some((item) => item.created > 0)
+  const hasCreated = users.some((item) => item.created > 0)
+  const ordered = hasCreated
     ? users.slice().sort((a, b) => {
       if (a.created !== b.created) return a.created - b.created
       return a.id.localeCompare(b.id)
     })
     : users
-  const list = ordered.slice(-safeCount)
+  const list = hasCreated
+    ? ordered.slice(-safeCount)
+    : safeCount === 1
+      ? ordered.slice(0, 1)
+      : ordered.slice(-safeCount)
   const lines = [`Recent activity for session ${sessionId} (showing ${list.length} of ${users.length}):`]
   for (let i = 0; i < list.length; i++) {
     const item = list[i]

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -1620,6 +1620,16 @@ function formatSessionDisplay(sessionId: string, title?: string, sourceId = "def
   return `${safe} (${scoped})`
 }
 
+function formatSessionTitleOnly(sessionId: string, title?: string, sourceId = "default"): string {
+  const single = typeof title === "string" ? title.replace(/\s+/g, " ").trim() : ""
+  if (single) {
+    const safe = truncateTelegramInlineText(single, sessionTitleInlineMax)
+    if (sourceId === "default") return safe
+    return `[${sourceLabel(sourceId)}] ${safe}`
+  }
+  return sourceId === "default" ? `session ${sessionId}` : `[${sourceLabel(sourceId)}] session ${sessionId}`
+}
+
 async function formatSessionList(runtime: Runtime, list: string[], current?: string): Promise<string[]> {
   const active = current?.trim()
   const details = await formatSessionRows(runtime, list)
@@ -1732,7 +1742,7 @@ function parseRecentText(parts: unknown): string {
   return truncateTelegramInlineText(text, recentPartTextMax)
 }
 
-async function recentText(config: BridgeConfig, sessionId: string, count: number): Promise<string> {
+async function recentText(config: BridgeConfig, sessionId: string, count: number, sourceId = "default"): Promise<string> {
   const safeCount = Math.max(1, Math.min(count, recentMaxCount))
   const url = opencodeUrl(config, `/session/${encodeURIComponent(sessionId)}/message`)
   url.searchParams.set("limit", String(Math.max(20, safeCount * 6)))
@@ -1781,8 +1791,10 @@ async function recentText(config: BridgeConfig, sessionId: string, count: number
   if (!users.length) {
     return `No recent chat messages found for session ${sessionId}. Send a new message first.`
   }
+  const title = await safeSessionTitle(config, sessionId, sourceId)
+  const name = formatSessionTitleOnly(sessionId, title, sourceId)
   const list = users.slice(-safeCount)
-  const lines = [`Recent activity for session ${sessionId} (showing ${list.length} of ${users.length}):`]
+  const lines = [`Recent activity for ${name} (showing ${list.length} of ${users.length}):`]
   for (let i = 0; i < list.length; i++) {
     const item = list[i]
     if (!item) continue
@@ -2632,7 +2644,7 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       }
       await answerCallback(runtime.config, callbackId, "Loading latest message...")
       state.acknowledged = true
-      const text = await recentText(scoped, ref.sessionId, 1)
+      const text = await recentText(scoped, ref.sessionId, 1, ref.sourceId)
       await sendTelegramMessage(runtime.config, chatId, text)
       return
     }
@@ -2859,7 +2871,7 @@ export async function handleTextUpdate(runtime: Runtime, update: TelegramUpdate)
         await sendTelegramMessage(config, chatId, sourceUnavailableText(ref.sourceId))
         return true
       }
-      const text = await recentText(scoped, ref.sessionId, parsed.count || recentDefaultCount)
+      const text = await recentText(scoped, ref.sessionId, parsed.count || recentDefaultCount, ref.sourceId)
       await sendTelegramMessage(config, chatId, text)
       return true
     }

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -290,7 +290,7 @@ const inlineButtonTextMax = 48
 const callbackDataMax = 64
 const telegramMessageSoftLimit = 3900
 const recentPayloadMax = telegramMessageSoftLimit * 3
-const switchTargetTtlMs = 30 * 60 * 1000
+const utilityTargetTtlMs = 30 * 60 * 1000
 const switchTargetMax = 2048
 const recentTargetMax = 2048
 
@@ -969,7 +969,7 @@ function utilitySwitchSessionCallbackData(sourceId: string, sessionId: string, c
   const seq = Math.abs(pendingEntrySeq++)
   const tokenSeed = `${sessionRef}:${now}:${seq}`
   const token = `${shortId(tokenSeed)}${seq.toString(36)}`.slice(0, 12).padStart(6, "0")
-  switchTargets.set(token, { sessionRef, chatId, expiresAt: now + switchTargetTtlMs })
+  switchTargets.set(token, { sessionRef, chatId, expiresAt: now + utilityTargetTtlMs })
   return `u:s:${token}`
 }
 
@@ -995,7 +995,7 @@ function utilityRecentSessionCallbackData(sourceId: string, sessionId: string, c
   const seq = Math.abs(pendingEntrySeq++)
   const tokenSeed = `${sessionRef}:recent:${now}:${seq}`
   const token = `${shortId(tokenSeed)}${seq.toString(36)}`.slice(0, 12).padStart(6, "0")
-  recentTargets.set(token, { sessionRef, chatId, expiresAt: now + switchTargetTtlMs })
+  recentTargets.set(token, { sessionRef, chatId, expiresAt: now + utilityTargetTtlMs })
   return `u:r:${token}`
 }
 


### PR DESCRIPTION
## Summary
- make proactive Telegram action buttons session-bound so `Switch session` and `Latest message` act on the originating alert session rather than whichever session is currently mapped
- harden `/recent` preview generation by ordering message pairs deterministically across payload variants, preferring timestamps when available and falling back to stable id ordering
- improve outbound wording to prefer session titles in idle/recent notifications while keeping safe fallbacks to session ids

## Testing
- bun test tests/telegram-bridge.test.ts