### PR TITLE
fix: stabilize proxy decoding and harden /__proxy CORS

### DIFF
--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -33,6 +33,19 @@ const validatedBasePath = validateBasePath(BASE_PATH)
 const basePathWithoutTrailing = validatedBasePath.endsWith("/") ? validatedBasePath.slice(0, -1) : validatedBasePath
 const basePathWithTrailing = validatedBasePath.endsWith("/") ? validatedBasePath : validatedBasePath + "/"
 
+function passApiResponse(response: Response) {
+  const responseHeaders = new Headers(response.headers)
+  // Bun fetch may return a decoded body while preserving original encoding headers.
+  // Remove these headers to avoid browser-side decode errors.
+  responseHeaders.delete("content-encoding")
+  responseHeaders.delete("content-length")
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  })
+}
+
 // Track WebSocket connections: client ws -> backend ws
 const wsConnections = new Map<object, WebSocket>()
 
@@ -114,11 +127,12 @@ const server = Bun.serve<{ target: string }>({
       }
 
       console.log("[Proxy] API:", req.method, strippedPath)
-      return fetch(target.toString(), {
+      const response = await fetch(target.toString(), {
         method: req.method,
         headers,
         body: req.body,
       })
+      return passApiResponse(response)
     }
 
     // Frontend routes - try to serve static file

--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -114,10 +114,11 @@ const server = Bun.serve<{ target: string }>({
       }
 
       console.log("[Proxy] API:", req.method, strippedPath)
+      const body = req.method === "GET" || req.method === "HEAD" ? undefined : req.body
       const response = await fetch(target.toString(), {
         method: req.method,
         headers,
-        body: req.body,
+        body,
       })
       return normalizeProxiedResponse(response)
     }

--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -1,6 +1,6 @@
 import { watch } from "fs"
 import { handleExtendedEndpoint, isApiPath } from "../shared/extended-api"
-import { handleProxyRequest } from "../shared/proxy"
+import { handleProxyRequest, normalizeProxiedResponse } from "../shared/proxy"
 
 const BASE_PATH = process.env.BASE_PATH || "/"
 const PORT = parseInt(process.env.PORT || "3000", 10)
@@ -32,19 +32,6 @@ function validateBasePath(path: string): string {
 const validatedBasePath = validateBasePath(BASE_PATH)
 const basePathWithoutTrailing = validatedBasePath.endsWith("/") ? validatedBasePath.slice(0, -1) : validatedBasePath
 const basePathWithTrailing = validatedBasePath.endsWith("/") ? validatedBasePath : validatedBasePath + "/"
-
-function passApiResponse(response: Response) {
-  const responseHeaders = new Headers(response.headers)
-  // Bun fetch may return a decoded body while preserving original encoding headers.
-  // Remove these headers to avoid browser-side decode errors.
-  responseHeaders.delete("content-encoding")
-  responseHeaders.delete("content-length")
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: responseHeaders,
-  })
-}
 
 // Track WebSocket connections: client ws -> backend ws
 const wsConnections = new Map<object, WebSocket>()
@@ -132,7 +119,7 @@ const server = Bun.serve<{ target: string }>({
         headers,
         body: req.body,
       })
-      return passApiResponse(response)
+      return normalizeProxiedResponse(response)
     }
 
     // Frontend routes - try to serve static file

--- a/app-prefixable/tests/proxy-response.test.ts
+++ b/app-prefixable/tests/proxy-response.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeProxiedResponse } from "../../shared/proxy"
+
+describe("normalizeProxiedResponse", () => {
+  test("removes decode-sensitive headers and keeps body/status", async () => {
+    const response = new Response("payload", {
+      status: 201,
+      statusText: "Created",
+      headers: {
+        "content-encoding": "gzip",
+        "content-length": "999",
+        "x-test": "ok",
+        "access-control-allow-origin": "https://example.com",
+      },
+    })
+
+    const normalized = normalizeProxiedResponse(response)
+
+    expect(normalized.status).toBe(201)
+    expect(normalized.statusText).toBe("Created")
+    expect(await normalized.text()).toBe("payload")
+    expect(normalized.headers.get("content-encoding")).toBeNull()
+    expect(normalized.headers.get("content-length")).toBeNull()
+    expect(normalized.headers.get("x-test")).toBe("ok")
+    expect(normalized.headers.get("access-control-allow-origin")).toBe("https://example.com")
+  })
+
+  test("adds wildcard cors only when requested", async () => {
+    const response = new Response("ok", {
+      headers: {
+        "access-control-allow-origin": "https://example.com",
+      },
+    })
+
+    const normalized = normalizeProxiedResponse(response, true)
+
+    expect(await normalized.text()).toBe("ok")
+    expect(normalized.headers.get("access-control-allow-origin")).toBe("*")
+  })
+})

--- a/app-prefixable/tests/proxy-response.test.ts
+++ b/app-prefixable/tests/proxy-response.test.ts
@@ -25,6 +25,20 @@ describe("normalizeProxiedResponse", () => {
     expect(normalized.headers.get("access-control-allow-origin")).toBe("https://example.com")
   })
 
+  test("keeps content-length when upstream response is unencoded", async () => {
+    const response = new Response("ok", {
+      headers: {
+        "content-length": "2",
+      },
+    })
+
+    const normalized = normalizeProxiedResponse(response)
+
+    expect(await normalized.text()).toBe("ok")
+    expect(normalized.headers.get("content-length")).toBe("2")
+    expect(normalized.headers.get("content-encoding")).toBeNull()
+  })
+
   test("sets explicit cors origin and vary when requested", async () => {
     const response = new Response("ok", {
       headers: {

--- a/app-prefixable/tests/proxy-response.test.ts
+++ b/app-prefixable/tests/proxy-response.test.ts
@@ -25,16 +25,17 @@ describe("normalizeProxiedResponse", () => {
     expect(normalized.headers.get("access-control-allow-origin")).toBe("https://example.com")
   })
 
-  test("adds wildcard cors only when requested", async () => {
+  test("sets explicit cors origin and vary when requested", async () => {
     const response = new Response("ok", {
       headers: {
         "access-control-allow-origin": "https://example.com",
       },
     })
 
-    const normalized = normalizeProxiedResponse(response, true)
+    const normalized = normalizeProxiedResponse(response, "https://ui.example.com")
 
     expect(await normalized.text()).toBe("ok")
-    expect(normalized.headers.get("access-control-allow-origin")).toBe("*")
+    expect(normalized.headers.get("access-control-allow-origin")).toBe("https://ui.example.com")
+    expect(normalized.headers.get("vary")).toBe("Origin")
   })
 })

--- a/app-prefixable/tests/proxy-response.test.ts
+++ b/app-prefixable/tests/proxy-response.test.ts
@@ -29,6 +29,7 @@ describe("normalizeProxiedResponse", () => {
     const response = new Response("ok", {
       headers: {
         "access-control-allow-origin": "https://example.com",
+        vary: "Accept-Encoding",
       },
     })
 
@@ -36,6 +37,19 @@ describe("normalizeProxiedResponse", () => {
 
     expect(await normalized.text()).toBe("ok")
     expect(normalized.headers.get("access-control-allow-origin")).toBe("https://ui.example.com")
-    expect(normalized.headers.get("vary")).toBe("Origin")
+    expect(normalized.headers.get("vary")).toBe("Accept-Encoding, Origin")
+  })
+
+  test("keeps existing Origin vary token without duplication", async () => {
+    const response = new Response("ok", {
+      headers: {
+        vary: "Accept-Encoding, Origin",
+      },
+    })
+
+    const normalized = normalizeProxiedResponse(response, "https://ui.example.com")
+
+    expect(await normalized.text()).toBe("ok")
+    expect(normalized.headers.get("vary")).toBe("Accept-Encoding, Origin")
   })
 })

--- a/app-prefixable/tests/proxy-response.test.ts
+++ b/app-prefixable/tests/proxy-response.test.ts
@@ -66,4 +66,18 @@ describe("normalizeProxiedResponse", () => {
     expect(await normalized.text()).toBe("ok")
     expect(normalized.headers.get("vary")).toBe("Accept-Encoding, Origin")
   })
+
+  test("preserves wildcard vary when cors origin is applied", async () => {
+    const response = new Response("ok", {
+      headers: {
+        vary: "*",
+      },
+    })
+
+    const normalized = normalizeProxiedResponse(response, "https://ui.example.com")
+
+    expect(await normalized.text()).toBe("ok")
+    expect(normalized.headers.get("vary")).toBe("*")
+    expect(normalized.headers.get("access-control-allow-origin")).toBe("https://ui.example.com")
+  })
 })

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -44,6 +44,19 @@ const validatedBasePath = validateBasePath(BASE_PATH)
 const basePathWithoutTrailing = validatedBasePath.endsWith("/") ? validatedBasePath.slice(0, -1) : validatedBasePath
 const basePathWithTrailing = validatedBasePath.endsWith("/") ? validatedBasePath : validatedBasePath + "/"
 
+function passApiResponse(response: Response) {
+  const responseHeaders = new Headers(response.headers)
+  // Bun fetch may return a decoded body while preserving original encoding headers.
+  // Remove these headers to avoid browser-side decode errors.
+  responseHeaders.delete("content-encoding")
+  responseHeaders.delete("content-length")
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  })
+}
+
 // MIME types for static files
 const mimeTypes: Record<string, string> = {
   js: "application/javascript",
@@ -181,11 +194,12 @@ const server = Bun.serve<{ path: string; search: string }>({
       // Regular API requests
       console.log("[Proxy] API:", req.method, path)
       try {
-        return await fetch(target.toString(), {
+        const response = await fetch(target.toString(), {
           method: req.method,
           headers,
           body: req.body,
         })
+        return passApiResponse(response)
       } catch (e) {
         console.error("[Proxy] API error:", e)
         return new Response("API proxy error", { status: 502 })

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -181,10 +181,11 @@ const server = Bun.serve<{ path: string; search: string }>({
       // Regular API requests
       console.log("[Proxy] API:", req.method, path)
       try {
+        const body = req.method === "GET" || req.method === "HEAD" ? undefined : req.body
         const response = await fetch(target.toString(), {
           method: req.method,
           headers,
-          body: req.body,
+          body,
         })
         return normalizeProxiedResponse(response)
       } catch (e) {

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -10,7 +10,7 @@
  */
 
 import { handleExtendedEndpoint, isApiPath } from "../shared/extended-api"
-import { handleProxyRequest } from "../shared/proxy"
+import { handleProxyRequest, normalizeProxiedResponse } from "../shared/proxy"
 
 const BASE_PATH = process.env.NB_PREFIX || process.env.BASE_PATH || "/"
 const PORT = parseInt(process.env.PORT || "8080", 10)
@@ -43,19 +43,6 @@ function validateBasePath(path: string): string {
 const validatedBasePath = validateBasePath(BASE_PATH)
 const basePathWithoutTrailing = validatedBasePath.endsWith("/") ? validatedBasePath.slice(0, -1) : validatedBasePath
 const basePathWithTrailing = validatedBasePath.endsWith("/") ? validatedBasePath : validatedBasePath + "/"
-
-function passApiResponse(response: Response) {
-  const responseHeaders = new Headers(response.headers)
-  // Bun fetch may return a decoded body while preserving original encoding headers.
-  // Remove these headers to avoid browser-side decode errors.
-  responseHeaders.delete("content-encoding")
-  responseHeaders.delete("content-length")
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: responseHeaders,
-  })
-}
 
 // MIME types for static files
 const mimeTypes: Record<string, string> = {
@@ -199,7 +186,7 @@ const server = Bun.serve<{ path: string; search: string }>({
           headers,
           body: req.body,
         })
-        return passApiResponse(response)
+        return normalizeProxiedResponse(response)
       } catch (e) {
         console.error("[Proxy] API error:", e)
         return new Response("API proxy error", { status: 502 })

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -9,9 +9,12 @@
 export function normalizeProxiedResponse(response: Response, corsOrigin?: string) {
   const responseHeaders = new Headers(response.headers)
   // Bun fetch may return a decoded body while preserving original encoding headers.
-  // Remove these headers to avoid browser-side decode errors.
-  responseHeaders.delete("content-encoding")
-  responseHeaders.delete("content-length")
+  // Remove encoding/length headers only when a non-identity encoding is present.
+  const encoding = responseHeaders.get("content-encoding")?.trim().toLowerCase()
+  if (encoding && encoding !== "identity") {
+    responseHeaders.delete("content-encoding")
+    responseHeaders.delete("content-length")
+  }
   if (corsOrigin) {
     responseHeaders.set("Access-Control-Allow-Origin", corsOrigin)
     const vary = responseHeaders.get("Vary")

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -26,7 +26,7 @@ export function normalizeProxiedResponse(response: Response, addCors = false) {
  * Handle a proxied request to a remote server.
  * @param path - Pathname after /__proxy (for example: "/session" or "/event"). Query comes from req.url.
  * @param req - The incoming request
- * @returns Response
+ * @returns {Promise<Response>} The proxied response.
  */
 export async function handleProxyRequest(path: string, req: Request): Promise<Response> {
   // Handle CORS preflight for custom headers (x-proxy-target, x-api-key, etc.)

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -6,6 +6,22 @@
  * Handles both regular API requests and SSE streaming.
  */
 
+export function normalizeProxiedResponse(response: Response, addCors = false) {
+  const responseHeaders = new Headers(response.headers)
+  // Bun fetch may return a decoded body while preserving original encoding headers.
+  // Remove these headers to avoid browser-side decode errors.
+  responseHeaders.delete("content-encoding")
+  responseHeaders.delete("content-length")
+  if (addCors) {
+    responseHeaders.set("Access-Control-Allow-Origin", "*")
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  })
+}
+
 /**
  * Handle a proxied request to a remote server.
  * @param path - The API path after /__proxy (e.g. "/session", "/event?directory=...")
@@ -84,18 +100,7 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
       })
     }
 
-    // Forward the response with CORS headers.
-    // Remove Content-Encoding because fetch() already decompresses the body,
-    // so passing gzip/br encoding to the browser causes double-decode failures.
-    const responseHeaders = new Headers(response.headers)
-    responseHeaders.delete("content-encoding")
-    responseHeaders.delete("content-length") // length no longer matches after decompression
-    responseHeaders.set("Access-Control-Allow-Origin", "*")
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: responseHeaders,
-    })
+    return normalizeProxiedResponse(response, true)
   } catch (e) {
     console.error("[Proxy] Connection error:", e)
     return new Response(JSON.stringify({ error: "Proxy connection failed" }), {

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -14,7 +14,18 @@ export function normalizeProxiedResponse(response: Response, corsOrigin?: string
   responseHeaders.delete("content-length")
   if (corsOrigin) {
     responseHeaders.set("Access-Control-Allow-Origin", corsOrigin)
-    responseHeaders.set("Vary", "Origin")
+    const vary = responseHeaders.get("Vary")
+    if (!vary) {
+      responseHeaders.set("Vary", "Origin")
+    } else {
+      const values = vary
+        .split(",")
+        .map((x) => x.trim())
+        .filter(Boolean)
+      if (!values.some((x) => x.toLowerCase() === "origin")) {
+        responseHeaders.set("Vary", `${vary}, Origin`)
+      }
+    }
   }
   return new Response(response.body, {
     status: response.status,
@@ -27,6 +38,8 @@ function sameOrigin(req: Request) {
   const origin = req.headers.get("origin")
   if (!origin) return
   const requestOrigin = new URL(req.url).origin
+  // Intentionally restrict proxy CORS to same-origin browser requests.
+  // This prevents exposing /__proxy as a generic cross-origin proxy endpoint.
   if (origin !== requestOrigin) return
   return origin
 }

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -6,20 +6,29 @@
  * Handles both regular API requests and SSE streaming.
  */
 
-export function normalizeProxiedResponse(response: Response, addCors = false) {
+export function normalizeProxiedResponse(response: Response, corsOrigin?: string) {
   const responseHeaders = new Headers(response.headers)
   // Bun fetch may return a decoded body while preserving original encoding headers.
   // Remove these headers to avoid browser-side decode errors.
   responseHeaders.delete("content-encoding")
   responseHeaders.delete("content-length")
-  if (addCors) {
-    responseHeaders.set("Access-Control-Allow-Origin", "*")
+  if (corsOrigin) {
+    responseHeaders.set("Access-Control-Allow-Origin", corsOrigin)
+    responseHeaders.set("Vary", "Origin")
   }
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers: responseHeaders,
   })
+}
+
+function sameOrigin(req: Request) {
+  const origin = req.headers.get("origin")
+  if (!origin) return
+  const requestOrigin = new URL(req.url).origin
+  if (origin !== requestOrigin) return
+  return origin
 }
 
 /**
@@ -29,16 +38,21 @@ export function normalizeProxiedResponse(response: Response, addCors = false) {
  * @returns {Promise<Response>} The proxied response.
  */
 export async function handleProxyRequest(path: string, req: Request): Promise<Response> {
+  const corsOrigin = sameOrigin(req)
   // Handle CORS preflight for custom headers (x-proxy-target, x-api-key, etc.)
   if (req.method === "OPTIONS") {
+    const headers = new Headers({
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+      "Access-Control-Allow-Headers": req.headers.get("access-control-request-headers") || "*",
+      "Access-Control-Max-Age": "86400",
+    })
+    if (corsOrigin) {
+      headers.set("Access-Control-Allow-Origin", corsOrigin)
+      headers.set("Vary", "Origin")
+    }
     return new Response(null, {
       status: 204,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
-        "Access-Control-Allow-Headers": req.headers.get("access-control-request-headers") || "*",
-        "Access-Control-Max-Age": "86400",
-      },
+      headers,
     })
   }
 
@@ -80,7 +94,7 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
       body: req.method !== "GET" && req.method !== "HEAD" ? req.body : undefined,
     })
 
-    const corsHeaders = { "Access-Control-Allow-Origin": "*" }
+    const corsHeaders = corsOrigin ? { "Access-Control-Allow-Origin": corsOrigin, Vary: "Origin" } : {}
 
     if (isSSE) {
       if (!response.ok) {
@@ -100,7 +114,7 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
       })
     }
 
-    return normalizeProxiedResponse(response, true)
+    return normalizeProxiedResponse(response, corsOrigin)
   } catch (e) {
     console.error("[Proxy] Connection error:", e)
     return new Response(JSON.stringify({ error: "Proxy connection failed" }), {

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -24,9 +24,9 @@ export function normalizeProxiedResponse(response: Response, addCors = false) {
 
 /**
  * Handle a proxied request to a remote server.
- * @param path - The API path after /__proxy (e.g. "/session", "/event?directory=...")
+ * @param path - Pathname after /__proxy (for example: "/session" or "/event"). Query comes from req.url.
  * @param req - The incoming request
- * @returns Response or null if not a proxy request
+ * @returns Response
  */
 export async function handleProxyRequest(path: string, req: Request): Promise<Response> {
   // Handle CORS preflight for custom headers (x-proxy-target, x-api-key, etc.)

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -25,8 +25,13 @@ export function normalizeProxiedResponse(response: Response, corsOrigin?: string
         .split(",")
         .map((x) => x.trim())
         .filter(Boolean)
-      if (!values.some((x) => x.toLowerCase() === "origin")) {
-        responseHeaders.set("Vary", `${vary}, Origin`)
+      if (values.length === 1 && values[0] === "*") {
+        responseHeaders.set("Vary", "*")
+      } else {
+        if (!values.some((x) => x.toLowerCase() === "origin")) {
+          values.push("Origin")
+        }
+        responseHeaders.set("Vary", values.join(", "))
       }
     }
   }


### PR DESCRIPTION
## Summary
- normalize proxied API responses in both dev and production UI servers before returning to the browser
- strip decode-sensitive headers only when upstream sends non-identity `content-encoding`, preserving `content-length` for unencoded responses
- centralize proxy response normalization in `shared/proxy.ts` and add unit coverage for header/CORS/Vary behavior
- harden `/__proxy` CORS to same-origin browser requests (no wildcard ACAO), reducing open-proxy/SSRF exposure

## Behavior Notes
- `/__proxy` is now intentionally same-origin for browser CORS requests.
- Cross-origin browser use of `/__proxy` is no longer supported by default.

## Validation
- `bun run build` in `app-prefixable`
- `bun test tests/proxy-response.test.ts`