### PR TITLE
fix: prevent proxy decode failures in API responses

### DIFF
--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -114,10 +114,19 @@ const server = Bun.serve<{ target: string }>({
       }
 
       console.log("[Proxy] API:", req.method, strippedPath)
-      return fetch(target.toString(), {
+      const response = await fetch(target.toString(), {
         method: req.method,
         headers,
         body: req.body,
+      })
+
+      const responseHeaders = new Headers(response.headers)
+      responseHeaders.delete("content-encoding")
+      responseHeaders.delete("content-length")
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: responseHeaders,
       })
     }
 

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -181,10 +181,19 @@ const server = Bun.serve<{ path: string; search: string }>({
       // Regular API requests
       console.log("[Proxy] API:", req.method, path)
       try {
-        return await fetch(target.toString(), {
+        const response = await fetch(target.toString(), {
           method: req.method,
           headers,
           body: req.body,
+        })
+
+        const responseHeaders = new Headers(response.headers)
+        responseHeaders.delete("content-encoding")
+        responseHeaders.delete("content-length")
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: responseHeaders,
         })
       } catch (e) {
         console.error("[Proxy] API error:", e)


### PR DESCRIPTION
## Summary
- normalize proxied API responses in both dev and production UI servers by rebuilding the response after upstream fetch
- drop `content-encoding` and `content-length` headers when forwarding API responses so browsers do not attempt to decode already-decoded payloads
- restore reliable session/project API reads and writes that were failing with `TypeError: Decoding failed` (closes #363)