### PR TITLE
fix: restore icon-only markdown copy affordance

### DIFF
--- a/app-prefixable/src/components/markdown.tsx
+++ b/app-prefixable/src/components/markdown.tsx
@@ -38,7 +38,7 @@ renderer.code = ({ text, lang }) => {
   const code = escapeHtml(text)
   const className = lang ? ` class="language-${escapeHtml(lang)}"` : ""
 
-  return `<div class="markdown-code-block"><button class="markdown-copy-button" type="button" data-state="idle" aria-label="Copy code"><span class="markdown-copy-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V6a2 2 0 0 1 2-2h9"></path></svg></span><span class="markdown-copy-label" aria-hidden="true">Copy</span><span class="markdown-copy-live" aria-live="polite" aria-atomic="true">Copy</span></button><pre><code${className}>${code}</code></pre></div>`
+  return `<div class="markdown-code-block"><button class="markdown-copy-button" type="button" data-state="idle" aria-label="Copy code"><span class="markdown-copy-icon" aria-hidden="true">&#x29C9;</span><span class="markdown-copy-label" aria-hidden="true">Copy</span><span class="markdown-copy-live" aria-live="polite" aria-atomic="true">Copy</span></button><pre><code${className}>${code}</code></pre></div>`
 }
 
 function copyLabel(state: "idle" | "copied" | "failed") {

--- a/app-prefixable/src/components/markdown.tsx
+++ b/app-prefixable/src/components/markdown.tsx
@@ -84,10 +84,12 @@ function copyCode(button: HTMLButtonElement) {
     return
   }
 
-  Promise.resolve(navigator.clipboard.writeText(code)).then(
-    () => setCopyState(button, "copied"),
-    () => setCopyState(button, "failed"),
-  )
+  Promise.resolve()
+    .then(() => navigator.clipboard.writeText(code))
+    .then(
+      () => setCopyState(button, "copied"),
+      () => setCopyState(button, "failed"),
+    )
 }
 
 interface MarkdownProps {

--- a/app-prefixable/src/components/markdown.tsx
+++ b/app-prefixable/src/components/markdown.tsx
@@ -38,7 +38,7 @@ renderer.code = ({ text, lang }) => {
   const code = escapeHtml(text)
   const className = lang ? ` class="language-${escapeHtml(lang)}"` : ""
 
-  return `<div class="markdown-code-block"><button class="markdown-copy-button" type="button" data-state="idle" aria-label="Copy" aria-live="polite" aria-atomic="true">Copy</button><pre><code${className}>${code}</code></pre></div>`
+  return `<div class="markdown-code-block"><button class="markdown-copy-button" type="button" data-state="idle" aria-label="Copy code"><span class="markdown-copy-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V6a2 2 0 0 1 2-2h9"></path></svg></span><span class="markdown-copy-label" aria-hidden="true">Copy</span><span class="markdown-copy-live" aria-live="polite" aria-atomic="true">Copy</span></button><pre><code${className}>${code}</code></pre></div>`
 }
 
 function copyLabel(state: "idle" | "copied" | "failed") {
@@ -53,8 +53,14 @@ function setCopyState(button: HTMLButtonElement, state: "idle" | "copied" | "fai
 
   button.dataset.state = state
   const label = copyLabel(state)
-  button.textContent = label
-  button.setAttribute("aria-label", label)
+  button.setAttribute("aria-label", state === "idle" ? "Copy code" : label)
+
+  const text = button.querySelector(".markdown-copy-label")
+  if (text instanceof HTMLElement) text.textContent = label
+
+  const live = button.querySelector(".markdown-copy-live")
+  if (live instanceof HTMLElement) live.textContent = label
+
   if (state === "idle") {
     delete button.dataset.copyReset
     return
@@ -78,14 +84,10 @@ function copyCode(button: HTMLButtonElement) {
     return
   }
 
-  try {
-    navigator.clipboard.writeText(code).then(
-      () => setCopyState(button, "copied"),
-      () => setCopyState(button, "failed"),
-    )
-  } catch {
-    setCopyState(button, "failed")
-  }
+  Promise.resolve(navigator.clipboard.writeText(code)).then(
+    () => setCopyState(button, "copied"),
+    () => setCopyState(button, "failed"),
+  )
 }
 
 interface MarkdownProps {

--- a/app-prefixable/src/index.css
+++ b/app-prefixable/src/index.css
@@ -451,19 +451,58 @@
   }
 
   .markdown-code-block pre {
-    @apply mb-0 pt-12;
+    @apply mb-0 pt-10;
   }
 
   .markdown-copy-button {
-    @apply absolute right-3 top-3 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors;
+    @apply absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md border p-0 transition-colors;
     border-color: var(--border-strong);
     background: color-mix(in srgb, var(--surface-base) 88%, transparent);
-    color: var(--text-strong);
+    color: var(--icon-base);
     backdrop-filter: blur(2px);
   }
 
   .markdown-copy-button:hover {
     background: var(--surface-base);
+    color: var(--icon-strong);
+  }
+
+  .markdown-copy-button:focus-visible {
+    color: var(--icon-strong);
+  }
+
+  .markdown-copy-icon {
+    @apply flex items-center justify-center;
+  }
+
+  .markdown-copy-icon svg {
+    @apply h-3.5 w-3.5;
+  }
+
+  .markdown-copy-label {
+    @apply pointer-events-none absolute right-[calc(100%+0.35rem)] top-1/2 -translate-y-1/2 translate-x-0.5 rounded-md border px-2 py-1 text-xs font-medium;
+    border-color: var(--border-strong);
+    background: color-mix(in srgb, var(--surface-base) 92%, transparent);
+    color: var(--text-strong);
+    white-space: nowrap;
+    opacity: 0;
+    transition: opacity 120ms ease, transform 120ms ease;
+    backdrop-filter: blur(2px);
+  }
+
+  .markdown-copy-live {
+    @apply absolute -m-px h-px w-px overflow-hidden border-0 p-0;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .markdown-copy-button:hover .markdown-copy-label,
+  .markdown-copy-button:focus-visible .markdown-copy-label,
+  .markdown-copy-button[data-state="copied"] .markdown-copy-label,
+  .markdown-copy-button[data-state="failed"] .markdown-copy-label {
+    opacity: 1;
+    transform: translateX(0) translateY(-50%);
   }
 
   .markdown-copy-button[data-state="copied"] {
@@ -471,7 +510,17 @@
     color: var(--icon-success-base);
   }
 
+  .markdown-copy-button[data-state="copied"] .markdown-copy-label {
+    border-color: color-mix(in srgb, var(--icon-success-base) 40%, var(--border-strong));
+    color: var(--icon-success-base);
+  }
+
   .markdown-copy-button[data-state="failed"] {
+    border-color: color-mix(in srgb, var(--interactive-critical) 40%, var(--border-strong));
+    color: var(--interactive-critical);
+  }
+
+  .markdown-copy-button[data-state="failed"] .markdown-copy-label {
     border-color: color-mix(in srgb, var(--interactive-critical) 40%, var(--border-strong));
     color: var(--interactive-critical);
   }

--- a/app-prefixable/src/index.css
+++ b/app-prefixable/src/index.css
@@ -472,11 +472,10 @@
   }
 
   .markdown-copy-icon {
-    @apply flex items-center justify-center;
-  }
-
-  .markdown-copy-icon svg {
-    @apply h-3.5 w-3.5;
+    @apply flex h-3.5 w-3.5 items-center justify-center;
+    font-size: 0.95rem;
+    line-height: 1;
+    font-weight: 600;
   }
 
   .markdown-copy-label {


### PR DESCRIPTION
## Summary
- restore markdown code block copy control to an icon-first button instead of persistent text
- show a compact hover/focus label and keep copied/failed feedback visible with matching icon/label states
- preserve accessibility with aria-label updates and a live region for copy status announcements

Closes #362