### PR TITLE
fix: scope Telegram session alarms for multi-source sessions

### DIFF
--- a/app-prefixable/src/components/telegram-settings.tsx
+++ b/app-prefixable/src/components/telegram-settings.tsx
@@ -15,6 +15,7 @@ import {
   telegramHealthLabel,
   validateTelegramForm,
 } from "../utils/telegram-settings"
+import { invalidateTelegramSourceIdCache } from "../utils/extended-api"
 import { TelegramSetupGuide } from "./telegram-setup-guide"
 
 type Props = {
@@ -184,6 +185,7 @@ export function TelegramSettings(props: Props) {
       setError("Failed to save Telegram settings")
       return
     }
+    invalidateTelegramSourceIdCache(props.serverUrl)
     const next = createTelegramForm(data.settings)
     setInitial(next)
     setForm(next)

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -75,8 +75,10 @@ import type { DragEvent as SolidDragEvent } from "@thisbeyond/solid-dnd";
 import { ConstrainDragXAxis } from "../utils/solid-dnd";
 
 import {
-  notifySessionKey,
+  migrateNotifySessionKey,
+  notifyEnabledForSession,
   readNotifyMap,
+  writeNotifyMap,
   cleanupNotifyState,
   NOTIFY_STORAGE_KEY,
   readAlarmChannels,
@@ -1765,7 +1767,13 @@ export function Layout(props: ParentProps) {
           const sess = sync.session.get(sid);
           const nc = notifyCache();
           const notifyDir = sess?.directory || directory;
-          if (nc[notifySessionKey(sid, notifyDir)] !== true) return;
+          const enabled = notifyEnabledForSession(nc, sid, notifyDir);
+          if (!enabled) return;
+          const next = { ...nc };
+          if (migrateNotifySessionKey(next, sid, notifyDir)) {
+            writeNotifyMap(next);
+            setNotifyCache(next);
+          }
 
           const title = sess?.title || "Task complete";
           fireNotification(sid, title, getSessionSummary(sid), `session-complete-${sid}`);
@@ -1788,7 +1796,13 @@ export function Layout(props: ParentProps) {
         const bellSid = rootAncestorId(sync.session.get, sid);
         const bell = sync.session.get(bellSid);
         const bellDir = bell?.directory || sess?.directory || directory;
-        if (nc[notifySessionKey(bellSid, bellDir)] !== true) return;
+        const enabled = notifyEnabledForSession(nc, bellSid, bellDir);
+        if (!enabled) return;
+        const next = { ...nc };
+        if (migrateNotifySessionKey(next, bellSid, bellDir)) {
+          writeNotifyMap(next);
+          setNotifyCache(next);
+        }
         firedPermission.add(rid);
 
         const title = sess?.title || "Permission needed";
@@ -1824,7 +1838,13 @@ export function Layout(props: ParentProps) {
         const bellSid = rootAncestorId(sync.session.get, sid);
         const bell = sync.session.get(bellSid);
         const bellDir = bell?.directory || sess?.directory || directory;
-        if (nc[notifySessionKey(bellSid, bellDir)] !== true) return;
+        const enabled = notifyEnabledForSession(nc, bellSid, bellDir);
+        if (!enabled) return;
+        const next = { ...nc };
+        if (migrateNotifySessionKey(next, bellSid, bellDir)) {
+          writeNotifyMap(next);
+          setNotifyCache(next);
+        }
         firedQuestion.add(rid);
 
         const title = sess?.title || "Question from agent";

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1764,7 +1764,8 @@ export function Layout(props: ParentProps) {
 
           const sess = sync.session.get(sid);
           const nc = notifyCache();
-          if (nc[notifySessionKey(sid, directory)] !== true) return;
+          const notifyDir = sess?.directory || directory;
+          if (nc[notifySessionKey(sid, notifyDir)] !== true) return;
 
           const title = sess?.title || "Task complete";
           fireNotification(sid, title, getSessionSummary(sid), `session-complete-${sid}`);
@@ -1785,7 +1786,9 @@ export function Layout(props: ParentProps) {
         const sess = sync.session.get(sid);
         const nc = notifyCache();
         const bellSid = rootAncestorId(sync.session.get, sid);
-        if (nc[notifySessionKey(bellSid, directory)] !== true) return;
+        const bell = sync.session.get(bellSid);
+        const bellDir = bell?.directory || sess?.directory || directory;
+        if (nc[notifySessionKey(bellSid, bellDir)] !== true) return;
         firedPermission.add(rid);
 
         const title = sess?.title || "Permission needed";
@@ -1819,7 +1822,9 @@ export function Layout(props: ParentProps) {
         const sess = sync.session.get(sid);
         const nc = notifyCache();
         const bellSid = rootAncestorId(sync.session.get, sid);
-        if (nc[notifySessionKey(bellSid, directory)] !== true) return;
+        const bell = sync.session.get(bellSid);
+        const bellDir = bell?.directory || sess?.directory || directory;
+        if (nc[notifySessionKey(bellSid, bellDir)] !== true) return;
         firedQuestion.add(rid);
 
         const title = sess?.title || "Question from agent";

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -75,6 +75,7 @@ import type { DragEvent as SolidDragEvent } from "@thisbeyond/solid-dnd";
 import { ConstrainDragXAxis } from "../utils/solid-dnd";
 
 import {
+  notifySessionKey,
   readNotifyMap,
   cleanupNotifyState,
   NOTIFY_STORAGE_KEY,
@@ -1763,7 +1764,7 @@ export function Layout(props: ParentProps) {
 
           const sess = sync.session.get(sid);
           const nc = notifyCache();
-          if (nc[sid] !== true) return;
+          if (nc[notifySessionKey(sid, directory)] !== true) return;
 
           const title = sess?.title || "Task complete";
           fireNotification(sid, title, getSessionSummary(sid), `session-complete-${sid}`);
@@ -1784,7 +1785,7 @@ export function Layout(props: ParentProps) {
         const sess = sync.session.get(sid);
         const nc = notifyCache();
         const bellSid = rootAncestorId(sync.session.get, sid);
-        if (nc[bellSid] !== true) return;
+        if (nc[notifySessionKey(bellSid, directory)] !== true) return;
         firedPermission.add(rid);
 
         const title = sess?.title || "Permission needed";
@@ -1818,7 +1819,7 @@ export function Layout(props: ParentProps) {
         const sess = sync.session.get(sid);
         const nc = notifyCache();
         const bellSid = rootAncestorId(sync.session.get, sid);
-        if (nc[bellSid] !== true) return;
+        if (nc[notifySessionKey(bellSid, directory)] !== true) return;
         firedQuestion.add(rid);
 
         const title = sess?.title || "Question from agent";
@@ -1949,7 +1950,7 @@ export function Layout(props: ParentProps) {
     setSessions((prev) => prev.filter((s) => s.id !== session.id));
 
     // Clean up notification toggle state
-    cleanupNotifyState(session.id);
+    cleanupNotifyState(session.id, session.directory);
 
     client.session.update({
       sessionID: session.id,
@@ -1995,7 +1996,7 @@ export function Layout(props: ParentProps) {
     client.session.delete({ sessionID: session.id })
       .then(() => {
         setConfirmDeleteSession(null);
-        cleanupNotifyState(session.id);
+        cleanupNotifyState(session.id, session.directory);
         unpinSession(session.id);
         if (isActive(session.id)) {
           navigate(neighborId ? `/${dirSlug()}/session/${neighborId}` : `/${dirSlug()}/session`);

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -530,22 +530,26 @@ export function Session() {
   );
   const [notifyDenied, setNotifyDenied] = createSignal(false);
   const [notifySourceId, setNotifySourceId] = createSignal<string | undefined>();
+  const [notifySourceReady, setNotifySourceReady] = createSignal(false);
   const deniedTimer = { id: null as ReturnType<typeof setTimeout> | null };
   onCleanup(() => { if (deniedTimer.id !== null) clearTimeout(deniedTimer.id) });
 
   createEffect(() => {
     const dir = directory || base64Decode(params.dir);
+    setNotifySourceReady(false);
     let cancelled = false;
     onCleanup(() => { cancelled = true });
     resolveTelegramSourceId(url, dir).then((sourceId) => {
       if (cancelled) return;
       setNotifySourceId(sourceId);
+      setNotifySourceReady(true);
     });
   });
 
   // Re-read notification state when session changes, and seed from server alarm state
   createEffect(() => {
     const id = params.id;
+    const sourceReady = notifySourceReady();
     const sourceId = notifySourceId();
     const dir = directory || base64Decode(params.dir);
     setNotifyDenied(false);
@@ -557,6 +561,7 @@ export function Session() {
     const key = notifySessionKey(id, dir);
     const local = readNotifyMap()[key] === true;
     setNotifyEnabled(local);
+    if (!sourceReady) return;
     // Cancellation flag for stale responses
     let cancelled = false;
     onCleanup(() => { cancelled = true });
@@ -586,9 +591,12 @@ export function Session() {
     }
     const dir = directory || base64Decode(params.dir);
     resolveTelegramSourceId(url, dir).then((resolved) => {
-      if (!resolved) return;
-      setNotifySourceId(resolved);
-      setSessionAlarm(url, id, enabled, resolved);
+      if (resolved) {
+        setNotifySourceId(resolved);
+        setSessionAlarm(url, id, enabled, resolved);
+        return;
+      }
+      setSessionAlarm(url, id, enabled);
     });
   }
 

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -49,7 +49,7 @@ import {
   ImageAttachments,
   type ImageAttachment,
 } from "../components/image-attachments";
-import { readNotifyMap, writeNotifyMap } from "../utils/notify";
+import { notifySessionKey, readNotifyMap, writeNotifyMap } from "../utils/notify";
 import { getSessionAlarm, resolveTelegramSourceId, setSessionAlarm } from "../utils/extended-api";
 import { sessionQuestionRequest } from "../utils/session-tree-request";
 import { createRootSession } from "../utils/root-session";
@@ -524,7 +524,8 @@ export function Session() {
     (() => {
       const id = params.id;
       if (!id) return false;
-      return readNotifyMap()[id] === true;
+      const dir = directory || base64Decode(params.dir);
+      return readNotifyMap()[notifySessionKey(id, dir)] === true;
     })(),
   );
   const [notifyDenied, setNotifyDenied] = createSignal(false);
@@ -546,13 +547,15 @@ export function Session() {
   createEffect(() => {
     const id = params.id;
     const sourceId = notifySourceId();
+    const dir = directory || base64Decode(params.dir);
     setNotifyDenied(false);
     if (!id) {
       setNotifyEnabled(false);
       return;
     }
     // Seed from localStorage first for instant UI
-    const local = readNotifyMap()[id] === true;
+    const key = notifySessionKey(id, dir);
+    const local = readNotifyMap()[key] === true;
     setNotifyEnabled(local);
     // Cancellation flag for stale responses
     let cancelled = false;
@@ -566,9 +569,9 @@ export function Session() {
       // Sync localStorage to match server truth
       const map = readNotifyMap();
       if (state.enabled) {
-        map[id] = true;
+        map[key] = true;
       } else {
-        delete map[id];
+        delete map[key];
       }
       writeNotifyMap(map);
     });
@@ -590,7 +593,9 @@ export function Session() {
     // Turning off
     if (notifyEnabled()) {
       const map = readNotifyMap();
-      delete map[id];
+      const dir = directory || base64Decode(params.dir);
+      const key = notifySessionKey(id, dir);
+      delete map[key];
       writeNotifyMap(map);
       setNotifyEnabled(false);
       setNotifyDenied(false);
@@ -604,7 +609,8 @@ export function Session() {
     const perm = Notification.permission;
     if (perm === "granted") {
       const map = readNotifyMap();
-      map[id] = true;
+      const dir = directory || base64Decode(params.dir);
+      map[notifySessionKey(id, dir)] = true;
       writeNotifyMap(map);
       setNotifyEnabled(true);
       syncAlarmToServer(id, true);
@@ -620,7 +626,8 @@ export function Session() {
     Notification.requestPermission().then((result) => {
       if (result === "granted") {
         const map = readNotifyMap();
-        map[id] = true;
+        const dir = directory || base64Decode(params.dir);
+        map[notifySessionKey(id, dir)] = true;
         writeNotifyMap(map);
         setNotifyEnabled(true);
         syncAlarmToServer(id, true);

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -579,10 +579,16 @@ export function Session() {
 
   /** Mirror bell toggle to server-side alarm state (fire-and-forget). */
   function syncAlarmToServer(id: string, enabled: boolean) {
-    const dir = directory || base64Decode(params.dir);
-    resolveTelegramSourceId(url, dir).then((sourceId) => {
-      if (sourceId) setNotifySourceId(sourceId);
+    const sourceId = notifySourceId();
+    if (sourceId) {
       setSessionAlarm(url, id, enabled, sourceId);
+      return;
+    }
+    const dir = directory || base64Decode(params.dir);
+    resolveTelegramSourceId(url, dir).then((resolved) => {
+      if (!resolved) return;
+      setNotifySourceId(resolved);
+      setSessionAlarm(url, id, enabled, resolved);
     });
   }
 

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -50,7 +50,7 @@ import {
   type ImageAttachment,
 } from "../components/image-attachments";
 import { readNotifyMap, writeNotifyMap } from "../utils/notify";
-import { getSessionAlarm, setSessionAlarm } from "../utils/extended-api";
+import { getSessionAlarm, resolveTelegramSourceId, setSessionAlarm } from "../utils/extended-api";
 import { sessionQuestionRequest } from "../utils/session-tree-request";
 import { createRootSession } from "../utils/root-session";
 import {
@@ -528,12 +528,24 @@ export function Session() {
     })(),
   );
   const [notifyDenied, setNotifyDenied] = createSignal(false);
+  const [notifySourceId, setNotifySourceId] = createSignal<string | undefined>();
   const deniedTimer = { id: null as ReturnType<typeof setTimeout> | null };
   onCleanup(() => { if (deniedTimer.id !== null) clearTimeout(deniedTimer.id) });
+
+  createEffect(() => {
+    const dir = directory || base64Decode(params.dir);
+    let cancelled = false;
+    onCleanup(() => { cancelled = true });
+    resolveTelegramSourceId(url, dir).then((sourceId) => {
+      if (cancelled) return;
+      setNotifySourceId(sourceId);
+    });
+  });
 
   // Re-read notification state when session changes, and seed from server alarm state
   createEffect(() => {
     const id = params.id;
+    const sourceId = notifySourceId();
     setNotifyDenied(false);
     if (!id) {
       setNotifyEnabled(false);
@@ -546,7 +558,7 @@ export function Session() {
     let cancelled = false;
     onCleanup(() => { cancelled = true });
     // Then fetch server-side alarm state asynchronously
-    getSessionAlarm(url, id).then((state) => {
+    getSessionAlarm(url, id, sourceId).then((state) => {
       // Skip if effect was cleaned up, session changed, or user already toggled
       if (cancelled || !state || params.id !== id) return;
       if (notifyEnabled() !== local) return; // user toggled since fetch started
@@ -564,7 +576,11 @@ export function Session() {
 
   /** Mirror bell toggle to server-side alarm state (fire-and-forget). */
   function syncAlarmToServer(id: string, enabled: boolean) {
-    setSessionAlarm(url, id, enabled);
+    const dir = directory || base64Decode(params.dir);
+    resolveTelegramSourceId(url, dir).then((sourceId) => {
+      if (sourceId) setNotifySourceId(sourceId);
+      setSessionAlarm(url, id, enabled, sourceId);
+    });
   }
 
   function toggleNotify() {

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -539,6 +539,7 @@ export function Session() {
   const [notifyDenied, setNotifyDenied] = createSignal(false);
   const [notifySourceId, setNotifySourceId] = createSignal<string | undefined>();
   const [notifySourceReady, setNotifySourceReady] = createSignal(false);
+  const notifyVersion = { value: 0 };
   const deniedTimer = { id: null as ReturnType<typeof setTimeout> | null };
   onCleanup(() => { if (deniedTimer.id !== null) clearTimeout(deniedTimer.id) });
 
@@ -574,12 +575,13 @@ export function Session() {
     if (!sourceReady) return;
     // Cancellation flag for stale responses
     let cancelled = false;
+    const version = notifyVersion.value;
     onCleanup(() => { cancelled = true });
     // Then fetch server-side alarm state asynchronously
     getSessionAlarm(url, id, sourceId).then((state) => {
-      // Skip if effect was cleaned up, session changed, or user already toggled
+      // Skip if effect was cleaned up, session changed, or local state was updated
       if (cancelled || !state || params.id !== id) return;
-      if (notifyEnabled() !== local) return; // user toggled since fetch started
+      if (notifyVersion.value !== version) return;
       setNotifyEnabled(state.enabled);
       // Sync localStorage to match server truth
       const map = readNotifyMap();
@@ -616,6 +618,7 @@ export function Session() {
       const dir = directory || base64Decode(params.dir);
       writeNotifySessionEnabled(map, id, false, dir);
       writeNotifyMap(map);
+      notifyVersion.value += 1;
       setNotifyEnabled(false);
       setNotifyDenied(false);
       syncAlarmToServer(id, false);
@@ -631,6 +634,7 @@ export function Session() {
       const dir = directory || base64Decode(params.dir);
       writeNotifySessionEnabled(map, id, true, dir);
       writeNotifyMap(map);
+      notifyVersion.value += 1;
       setNotifyEnabled(true);
       syncAlarmToServer(id, true);
       return;
@@ -648,6 +652,7 @@ export function Session() {
         const dir = directory || base64Decode(params.dir);
         writeNotifySessionEnabled(map, id, true, dir);
         writeNotifyMap(map);
+        notifyVersion.value += 1;
         setNotifyEnabled(true);
         syncAlarmToServer(id, true);
         return;

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -580,7 +580,6 @@ export function Session() {
       // Skip if effect was cleaned up, session changed, or user already toggled
       if (cancelled || !state || params.id !== id) return;
       if (notifyEnabled() !== local) return; // user toggled since fetch started
-      if (migrated && local && !state.enabled) return;
       setNotifyEnabled(state.enabled);
       // Sync localStorage to match server truth
       const map = readNotifyMap();
@@ -603,7 +602,7 @@ export function Session() {
         setSessionAlarm(url, id, enabled, resolved);
         return;
       }
-      setSessionAlarm(url, id, enabled);
+      console.warn("[session] skip setSessionAlarm: telegram source id unresolved", { id, dir });
     });
   }
 

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -49,7 +49,13 @@ import {
   ImageAttachments,
   type ImageAttachment,
 } from "../components/image-attachments";
-import { notifySessionKey, readNotifyMap, writeNotifyMap } from "../utils/notify";
+import {
+  migrateNotifySessionKey,
+  notifyEnabledForSession,
+  readNotifyMap,
+  writeNotifyMap,
+  writeNotifySessionEnabled,
+} from "../utils/notify";
 import { getSessionAlarm, resolveTelegramSourceId, setSessionAlarm } from "../utils/extended-api";
 import { sessionQuestionRequest } from "../utils/session-tree-request";
 import { createRootSession } from "../utils/root-session";
@@ -525,7 +531,9 @@ export function Session() {
       const id = params.id;
       if (!id) return false;
       const dir = directory || base64Decode(params.dir);
-      return readNotifyMap()[notifySessionKey(id, dir)] === true;
+      const map = readNotifyMap();
+      if (migrateNotifySessionKey(map, id, dir)) writeNotifyMap(map);
+      return notifyEnabledForSession(map, id, dir);
     })(),
   );
   const [notifyDenied, setNotifyDenied] = createSignal(false);
@@ -558,8 +566,10 @@ export function Session() {
       return;
     }
     // Seed from localStorage first for instant UI
-    const key = notifySessionKey(id, dir);
-    const local = readNotifyMap()[key] === true;
+    const map = readNotifyMap();
+    const migrated = migrateNotifySessionKey(map, id, dir);
+    if (migrated) writeNotifyMap(map);
+    const local = notifyEnabledForSession(map, id, dir);
     setNotifyEnabled(local);
     if (!sourceReady) return;
     // Cancellation flag for stale responses
@@ -570,14 +580,11 @@ export function Session() {
       // Skip if effect was cleaned up, session changed, or user already toggled
       if (cancelled || !state || params.id !== id) return;
       if (notifyEnabled() !== local) return; // user toggled since fetch started
+      if (migrated && local && !state.enabled) return;
       setNotifyEnabled(state.enabled);
       // Sync localStorage to match server truth
       const map = readNotifyMap();
-      if (state.enabled) {
-        map[key] = true;
-      } else {
-        delete map[key];
-      }
+      writeNotifySessionEnabled(map, id, state.enabled, dir);
       writeNotifyMap(map);
     });
   });
@@ -608,8 +615,7 @@ export function Session() {
     if (notifyEnabled()) {
       const map = readNotifyMap();
       const dir = directory || base64Decode(params.dir);
-      const key = notifySessionKey(id, dir);
-      delete map[key];
+      writeNotifySessionEnabled(map, id, false, dir);
       writeNotifyMap(map);
       setNotifyEnabled(false);
       setNotifyDenied(false);
@@ -624,7 +630,7 @@ export function Session() {
     if (perm === "granted") {
       const map = readNotifyMap();
       const dir = directory || base64Decode(params.dir);
-      map[notifySessionKey(id, dir)] = true;
+      writeNotifySessionEnabled(map, id, true, dir);
       writeNotifyMap(map);
       setNotifyEnabled(true);
       syncAlarmToServer(id, true);
@@ -641,7 +647,7 @@ export function Session() {
       if (result === "granted") {
         const map = readNotifyMap();
         const dir = directory || base64Decode(params.dir);
-        map[notifySessionKey(id, dir)] = true;
+        writeNotifySessionEnabled(map, id, true, dir);
         writeNotifyMap(map);
         setNotifyEnabled(true);
         syncAlarmToServer(id, true);

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -18,7 +18,7 @@ import { useOptionalPermission } from "../context/permission"
 import { ServerDialog } from "../components/server-dialog"
 import { SETTINGS_BASE_TABS } from "./settings-tabs"
 import { TelegramSettings } from "../components/telegram-settings"
-import { writeFile } from "../utils/extended-api"
+import { invalidateTelegramSourceIdCache, writeFile } from "../utils/extended-api"
 import { ALARM_CHANNELS_STORAGE_KEY, readAlarmChannels, writeAlarmChannels, type AlarmChannels } from "../utils/notify"
 import type { TelegramHealthResponse, TelegramSettingsResponse } from "../utils/telegram-settings"
 import type { Config, PermissionActionConfig } from "../sdk/client"
@@ -154,6 +154,8 @@ export function Settings() {
       void loadTelegramAlarmState()
       return
     }
+
+    invalidateTelegramSourceIdCache(basePath.serverUrl)
 
     const data = await res.json().catch(() => null) as (TelegramSettingsResponse & {
       restartRequired?: boolean

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -182,12 +182,70 @@ export async function writeSavedPrompts(
 
 export interface SessionAlarmState {
   sessionId: string
+  sourceId: string
   enabled: boolean
 }
 
+const telegramSourceIdCache = new Map<string, string>()
+const telegramSourceIdPending = new Map<string, Promise<string | undefined>>()
+
+function sourceCacheKey(serverUrl: string, directory: string) {
+  return `${serverUrl}::${directory}`
+}
+
+function sourceFromSettings(data: unknown, directory?: string) {
+  if (!directory) return
+  if (!data || typeof data !== "object") return
+  const settings = (data as { settings?: unknown }).settings
+  if (!settings || typeof settings !== "object") return
+  const rootDirectory = (settings as { directory?: unknown }).directory
+  if (typeof rootDirectory === "string" && rootDirectory === directory) {
+    return "default"
+  }
+  const sources = (settings as { sources?: unknown }).sources
+  if (!Array.isArray(sources)) return
+  const match = sources.find((item) => {
+    if (!item || typeof item !== "object") return false
+    const source = item as { id?: unknown; directory?: unknown; enabled?: unknown }
+    if (source.enabled === false) return false
+    if (typeof source.id !== "string") return false
+    if (typeof source.directory !== "string") return false
+    return source.directory === directory
+  }) as { id?: string } | undefined
+  if (!match?.id) return
+  return match.id
+}
+
+export async function resolveTelegramSourceId(serverUrl: string, directory?: string): Promise<string | undefined> {
+  const dir = directory?.trim()
+  if (!dir) return
+  const key = sourceCacheKey(serverUrl, dir)
+  const cached = telegramSourceIdCache.get(key)
+  if (cached) return cached
+  const pending = telegramSourceIdPending.get(key)
+  if (pending) return pending
+  const next = fetch(`${serverUrl}/api/ext/telegram/settings`)
+    .then(async (res) => {
+      if (!res.ok) return
+      const data = (await res.json().catch(() => null)) as unknown
+      const sourceId = sourceFromSettings(data, dir)
+      if (!sourceId) return
+      telegramSourceIdCache.set(key, sourceId)
+      return sourceId
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      telegramSourceIdPending.delete(key)
+    })
+  telegramSourceIdPending.set(key, next)
+  return next
+}
+
 /** Read session alarm state from the server (Telegram bridge). Returns null on failure. */
-export async function getSessionAlarm(serverUrl: string, sessionId: string): Promise<SessionAlarmState | null> {
+export async function getSessionAlarm(serverUrl: string, sessionId: string, sourceId?: string): Promise<SessionAlarmState | null> {
   const params = new URLSearchParams({ sessionId })
+  const source = sourceId?.trim()
+  if (source) params.set("sourceId", source)
   const res = await fetch(`${serverUrl}/api/ext/telegram/session-alarm?${params}`).catch(() => null)
   if (!res) {
     console.warn("[extended-api] getSessionAlarm: network error for session", sessionId)
@@ -202,15 +260,20 @@ export async function getSessionAlarm(serverUrl: string, sessionId: string): Pro
     console.warn("[extended-api] getSessionAlarm: invalid response data")
     return null
   }
-  return { sessionId: data.sessionId || sessionId, enabled: data.enabled }
+  return {
+    sessionId: data.sessionId || sessionId,
+    sourceId: typeof (data as { sourceId?: unknown }).sourceId === "string" ? (data as { sourceId: string }).sourceId : source || "default",
+    enabled: data.enabled,
+  }
 }
 
 /** Update session alarm state on the server (Telegram bridge). Returns true on success. */
-export async function setSessionAlarm(serverUrl: string, sessionId: string, enabled: boolean): Promise<boolean> {
+export async function setSessionAlarm(serverUrl: string, sessionId: string, enabled: boolean, sourceId?: string): Promise<boolean> {
+  const source = sourceId?.trim()
   const res = await fetch(`${serverUrl}/api/ext/telegram/session-alarm`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sessionId, enabled }),
+    body: JSON.stringify(source ? { sessionId, sourceId: source, enabled } : { sessionId, enabled }),
   }).catch(() => null)
   if (!res) {
     console.warn("[extended-api] setSessionAlarm: network error for session", sessionId)

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -186,11 +186,37 @@ export interface SessionAlarmState {
   enabled: boolean
 }
 
-const telegramSourceIdCache = new Map<string, string>()
+const TELEGRAM_SOURCE_ID_CACHE_TTL_MS = 30_000
+
+const telegramSourceIdCache = new Map<string, { sourceId: string; expiresAt: number }>()
 const telegramSourceIdPending = new Map<string, Promise<string | undefined>>()
 
 function sourceCacheKey(serverUrl: string, directory: string) {
   return `${serverUrl}::${directory}`
+}
+
+export function invalidateTelegramSourceIdCache(serverUrl?: string, directory?: string) {
+  const url = serverUrl?.trim()
+  const dir = directory?.trim()
+  if (!url) {
+    telegramSourceIdCache.clear()
+    telegramSourceIdPending.clear()
+    return
+  }
+  if (!dir) {
+    for (const key of telegramSourceIdCache.keys()) {
+      if (!key.startsWith(`${url}::`)) continue
+      telegramSourceIdCache.delete(key)
+    }
+    for (const key of telegramSourceIdPending.keys()) {
+      if (!key.startsWith(`${url}::`)) continue
+      telegramSourceIdPending.delete(key)
+    }
+    return
+  }
+  const key = sourceCacheKey(url, dir)
+  telegramSourceIdCache.delete(key)
+  telegramSourceIdPending.delete(key)
 }
 
 function sourceFromSettings(data: unknown, directory?: string) {
@@ -221,7 +247,8 @@ export async function resolveTelegramSourceId(serverUrl: string, directory?: str
   if (!dir) return
   const key = sourceCacheKey(serverUrl, dir)
   const cached = telegramSourceIdCache.get(key)
-  if (cached) return cached
+  if (cached && cached.expiresAt > Date.now()) return cached.sourceId
+  if (cached) telegramSourceIdCache.delete(key)
   const pending = telegramSourceIdPending.get(key)
   if (pending) return pending
   const next = fetch(`${serverUrl}/api/ext/telegram/settings`)
@@ -230,7 +257,7 @@ export async function resolveTelegramSourceId(serverUrl: string, directory?: str
       const data = (await res.json().catch(() => null)) as unknown
       const sourceId = sourceFromSettings(data, dir)
       if (!sourceId) return
-      telegramSourceIdCache.set(key, sourceId)
+      telegramSourceIdCache.set(key, { sourceId, expiresAt: Date.now() + TELEGRAM_SOURCE_ID_CACHE_TTL_MS })
       return sourceId
     })
     .catch(() => undefined)

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -190,9 +190,14 @@ const TELEGRAM_SOURCE_ID_CACHE_TTL_MS = 30_000
 
 const telegramSourceIdCache = new Map<string, { sourceId: string; expiresAt: number }>()
 const telegramSourceIdPending = new Map<string, Promise<string | undefined>>()
+const telegramSourceIdGeneration = new Map<string, number>()
 
 function sourceCacheKey(serverUrl: string, directory: string) {
   return `${serverUrl}::${directory}`
+}
+
+function bumpSourceGeneration(key: string) {
+  telegramSourceIdGeneration.set(key, (telegramSourceIdGeneration.get(key) ?? 0) + 1)
 }
 
 export function invalidateTelegramSourceIdCache(serverUrl?: string, directory?: string) {
@@ -201,20 +206,30 @@ export function invalidateTelegramSourceIdCache(serverUrl?: string, directory?: 
   if (!url) {
     telegramSourceIdCache.clear()
     telegramSourceIdPending.clear()
+    telegramSourceIdGeneration.clear()
     return
   }
   if (!dir) {
+    const keys = new Set<string>()
     for (const key of telegramSourceIdCache.keys()) {
       if (!key.startsWith(`${url}::`)) continue
+      keys.add(key)
       telegramSourceIdCache.delete(key)
     }
     for (const key of telegramSourceIdPending.keys()) {
       if (!key.startsWith(`${url}::`)) continue
+      keys.add(key)
       telegramSourceIdPending.delete(key)
     }
+    for (const key of telegramSourceIdGeneration.keys()) {
+      if (!key.startsWith(`${url}::`)) continue
+      keys.add(key)
+    }
+    for (const key of keys) bumpSourceGeneration(key)
     return
   }
   const key = sourceCacheKey(url, dir)
+  bumpSourceGeneration(key)
   telegramSourceIdCache.delete(key)
   telegramSourceIdPending.delete(key)
 }
@@ -251,12 +266,14 @@ export async function resolveTelegramSourceId(serverUrl: string, directory?: str
   if (cached) telegramSourceIdCache.delete(key)
   const pending = telegramSourceIdPending.get(key)
   if (pending) return pending
+  const generation = telegramSourceIdGeneration.get(key) ?? 0
   const next = fetch(`${serverUrl}/api/ext/telegram/settings`)
     .then(async (res) => {
       if (!res.ok) return
       const data = (await res.json().catch(() => null)) as unknown
       const sourceId = sourceFromSettings(data, dir)
       if (!sourceId) return
+      if ((telegramSourceIdGeneration.get(key) ?? 0) !== generation) return
       telegramSourceIdCache.set(key, { sourceId, expiresAt: Date.now() + TELEGRAM_SOURCE_ID_CACHE_TTL_MS })
       return sourceId
     })

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -235,10 +235,12 @@ export function invalidateTelegramSourceIdCache(serverUrl?: string, directory?: 
 }
 
 function sourceFromSettings(data: unknown, directory?: string) {
-  if (!directory) return
   if (!data || typeof data !== "object") return
   const settings = (data as { settings?: unknown }).settings
   if (!settings || typeof settings !== "object") return
+  const multiSourceEnabled = (settings as { multiSourceEnabled?: unknown }).multiSourceEnabled
+  if (multiSourceEnabled !== true) return "default"
+  if (!directory) return
   const rootDirectory = (settings as { directory?: unknown }).directory
   if (typeof rootDirectory === "string" && rootDirectory === directory) {
     return "default"

--- a/app-prefixable/src/utils/notify.ts
+++ b/app-prefixable/src/utils/notify.ts
@@ -16,6 +16,37 @@ export function notifySessionKey(id: string, directory?: string) {
   return `${dir}::${id}`
 }
 
+export function notifyEnabledForSession(map: Record<string, boolean>, id: string, directory?: string) {
+  const key = notifySessionKey(id, directory)
+  if (map[key] === true) return true
+  return map[id] === true
+}
+
+export function migrateNotifySessionKey(map: Record<string, boolean>, id: string, directory?: string) {
+  const key = notifySessionKey(id, directory)
+  if (key === id) return false
+  if (map[id] !== true) return false
+  map[key] = true
+  delete map[id]
+  return true
+}
+
+export function writeNotifySessionEnabled(
+  map: Record<string, boolean>,
+  id: string,
+  enabled: boolean,
+  directory?: string,
+) {
+  const key = notifySessionKey(id, directory)
+  if (enabled) {
+    map[key] = true
+    if (key !== id) delete map[id]
+    return
+  }
+  delete map[key]
+  delete map[id]
+}
+
 const DEFAULT_ALARM_CHANNELS: AlarmChannels = {
   browser: true,
   telegram: false,

--- a/app-prefixable/src/utils/notify.ts
+++ b/app-prefixable/src/utils/notify.ts
@@ -10,6 +10,12 @@ export type AlarmChannels = {
   telegram: boolean
 }
 
+export function notifySessionKey(id: string, directory?: string) {
+  const dir = directory?.trim()
+  if (!dir) return id
+  return `${dir}::${id}`
+}
+
 const DEFAULT_ALARM_CHANNELS: AlarmChannels = {
   browser: true,
   telegram: false,
@@ -59,10 +65,12 @@ export function writeNotifyMap(map: Record<string, boolean>) {
 }
 
 /** Remove a session's entry from the notification toggle map */
-export function cleanupNotifyState(id: string) {
+export function cleanupNotifyState(id: string, directory?: string) {
   const map = readNotifyMap();
-  if (!(id in map)) return;
+  const key = notifySessionKey(id, directory)
+  if (!(id in map) && !(key in map)) return;
   delete map[id];
+  delete map[key]
   writeNotifyMap(map);
 }
 

--- a/app-prefixable/tests/extended-api.test.ts
+++ b/app-prefixable/tests/extended-api.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+import { invalidateTelegramSourceIdCache, resolveTelegramSourceId } from "../src/utils/extended-api"
+
+describe("resolveTelegramSourceId", () => {
+  beforeEach(() => {
+    invalidateTelegramSourceIdCache()
+  })
+
+  afterEach(() => {
+    invalidateTelegramSourceIdCache()
+  })
+
+  test("reuses cached source mapping within TTL", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          settings: {
+            sources: [{ id: "alpha", directory: "/workspace/app", enabled: true }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    })
+
+    const first = await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+    const second = await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+
+    expect(first).toBe("alpha")
+    expect(second).toBe("alpha")
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    fetchSpy.mockRestore()
+  })
+
+  test("cache invalidation forces a refetch", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          settings: {
+            sources: [{ id: "alpha", directory: "/workspace/app", enabled: true }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    })
+
+    await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+    invalidateTelegramSourceIdCache("http://127.0.0.1:3000", "/workspace/app")
+    await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    fetchSpy.mockRestore()
+  })
+
+  test("expired cache entries are refreshed", async () => {
+    const nowSpy = spyOn(Date, "now")
+    nowSpy.mockReturnValueOnce(1_000)
+    nowSpy.mockReturnValue(35_001)
+
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          settings: {
+            sources: [{ id: "alpha", directory: "/workspace/app", enabled: true }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    })
+
+    await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+    await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    fetchSpy.mockRestore()
+    nowSpy.mockRestore()
+  })
+})

--- a/app-prefixable/tests/extended-api.test.ts
+++ b/app-prefixable/tests/extended-api.test.ts
@@ -15,6 +15,7 @@ describe("resolveTelegramSourceId", () => {
       return new Response(
         JSON.stringify({
           settings: {
+            multiSourceEnabled: true,
             sources: [{ id: "alpha", directory: "/workspace/app", enabled: true }],
           },
         }),
@@ -36,6 +37,7 @@ describe("resolveTelegramSourceId", () => {
       return new Response(
         JSON.stringify({
           settings: {
+            multiSourceEnabled: true,
             sources: [{ id: "alpha", directory: "/workspace/app", enabled: true }],
           },
         }),
@@ -60,6 +62,7 @@ describe("resolveTelegramSourceId", () => {
       return new Response(
         JSON.stringify({
           settings: {
+            multiSourceEnabled: true,
             sources: [{ id: "alpha", directory: "/workspace/app", enabled: true }],
           },
         }),
@@ -86,6 +89,7 @@ describe("resolveTelegramSourceId", () => {
       return new Response(
         JSON.stringify({
           settings: {
+            multiSourceEnabled: true,
             sources: [{ id: "beta", directory: "/workspace/app", enabled: true }],
           },
         }),
@@ -101,6 +105,7 @@ describe("resolveTelegramSourceId", () => {
       new Response(
         JSON.stringify({
           settings: {
+            multiSourceEnabled: true,
             sources: [{ id: "alpha", directory: "/workspace/app", enabled: true }],
           },
         }),
@@ -113,6 +118,42 @@ describe("resolveTelegramSourceId", () => {
     expect(second).toBe("beta")
     expect(third).toBe("beta")
     expect(fetchSpy).toHaveBeenCalledTimes(2)
+    fetchSpy.mockRestore()
+  })
+
+  test("returns default source when multi-source mode is disabled", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          settings: {
+            multiSourceEnabled: false,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    })
+
+    const sourceId = await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+
+    expect(sourceId).toBe("default")
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    fetchSpy.mockRestore()
+  })
+
+  test("returns default source when multi-source flag is missing", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          settings: {},
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    })
+
+    const sourceId = await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+
+    expect(sourceId).toBe("default")
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
     fetchSpy.mockRestore()
   })
 })

--- a/app-prefixable/tests/extended-api.test.ts
+++ b/app-prefixable/tests/extended-api.test.ts
@@ -74,4 +74,45 @@ describe("resolveTelegramSourceId", () => {
     fetchSpy.mockRestore()
     nowSpy.mockRestore()
   })
+
+  test("does not let invalidated in-flight responses overwrite fresh cache", async () => {
+    let releaseFirst: ((value: Response) => void) | undefined
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => {
+      if (!releaseFirst) {
+        return await new Promise<Response>((resolve) => {
+          releaseFirst = resolve
+        })
+      }
+      return new Response(
+        JSON.stringify({
+          settings: {
+            sources: [{ id: "beta", directory: "/workspace/app", enabled: true }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    })
+
+    const first = resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+    invalidateTelegramSourceIdCache("http://127.0.0.1:3000", "/workspace/app")
+    const second = await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+
+    releaseFirst?.(
+      new Response(
+        JSON.stringify({
+          settings: {
+            sources: [{ id: "alpha", directory: "/workspace/app", enabled: true }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    await first
+    const third = await resolveTelegramSourceId("http://127.0.0.1:3000", "/workspace/app")
+
+    expect(second).toBe("beta")
+    expect(third).toBe("beta")
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    fetchSpy.mockRestore()
+  })
 })

--- a/app-prefixable/tests/notify.test.ts
+++ b/app-prefixable/tests/notify.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import {
+  migrateNotifySessionKey,
+  notifyEnabledForSession,
+  writeNotifySessionEnabled,
+} from "../src/utils/notify"
+
+describe("notify storage compatibility", () => {
+  test("reads legacy and scoped keys", () => {
+    const map = {
+      "session-legacy": true,
+      "/workspace/project::session-scoped": true,
+    }
+    expect(notifyEnabledForSession(map, "session-legacy", "/workspace/project")).toBe(true)
+    expect(notifyEnabledForSession(map, "session-scoped", "/workspace/project")).toBe(true)
+  })
+
+  test("migrates legacy key into scoped key", () => {
+    const map = { "session-a": true }
+    expect(migrateNotifySessionKey(map, "session-a", "/workspace/project")).toBe(true)
+    expect(map["session-a"]).toBeUndefined()
+    expect(map["/workspace/project::session-a"]).toBe(true)
+  })
+
+  test("writes scoped key and clears legacy key", () => {
+    const map = { "session-a": true }
+    writeNotifySessionEnabled(map, "session-a", true, "/workspace/project")
+    expect(map["session-a"]).toBeUndefined()
+    expect(map["/workspace/project::session-a"]).toBe(true)
+
+    writeNotifySessionEnabled(map, "session-a", false, "/workspace/project")
+    expect(map["session-a"]).toBeUndefined()
+    expect(map["/workspace/project::session-a"]).toBeUndefined()
+  })
+})

--- a/app-prefixable/tests/telegram-settings.test.ts
+++ b/app-prefixable/tests/telegram-settings.test.ts
@@ -170,15 +170,15 @@ describe("telegram settings extended API", () => {
       expect.arrayContaining([
         {
           field: "sources.0.id",
-          message: "id must match [A-Za-z0-9._-]+ and must not be default",
+          message: "id must match [A-Za-z0-9._-]+",
         },
         {
           field: "sources.1.id",
-          message: "id must match [A-Za-z0-9._-]+ and must not be default",
+          message: 'id must not be "default" (case-insensitive)',
         },
         {
           field: "sources.2.id",
-          message: "id must match [A-Za-z0-9._-]+ and must not be default",
+          message: "id must be 64 characters or fewer",
         },
       ]),
     )

--- a/app-prefixable/tests/telegram-settings.test.ts
+++ b/app-prefixable/tests/telegram-settings.test.ts
@@ -138,7 +138,7 @@ describe("telegram settings extended API", () => {
     )
   })
 
-  test("PUT rejects source ids with ':' and reserved default id", async () => {
+  test("PUT rejects invalid source ids including reserved and oversized values", async () => {
     const dir = await mkdtemp(join(tmpdir(), "telegram-settings-"))
     const path = join(dir, "telegram-settings.json")
     cleanupPaths.push(dir)
@@ -157,6 +157,7 @@ describe("telegram settings extended API", () => {
             sources: [
               { id: "alpha:beta", openCodeUrl: "https://api.example.com", enabled: true },
               { id: "default", openCodeUrl: "https://api2.example.com", enabled: true },
+              { id: "a".repeat(65), openCodeUrl: "https://api3.example.com", enabled: true },
             ],
           },
         }),
@@ -173,6 +174,10 @@ describe("telegram settings extended API", () => {
         },
         {
           field: "sources.1.id",
+          message: "id must match [A-Za-z0-9._-]+ and must not be default",
+        },
+        {
+          field: "sources.2.id",
           message: "id must match [A-Za-z0-9._-]+ and must not be default",
         },
       ]),
@@ -434,6 +439,14 @@ describe("telegram settings extended API", () => {
       new Request("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=session-source&sourceId=bad:value"),
     )
     expect(badSource?.status).toBe(400)
+
+    const defaultVariant = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "GET",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=session-source&sourceId=Default"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=session-source&sourceId=Default"),
+    )
+    expect(defaultVariant?.status).toBe(400)
 
     const mismatch = await handleExtendedEndpoint(
       "/api/ext/telegram/session-alarm",

--- a/app-prefixable/tests/telegram-settings.test.ts
+++ b/app-prefixable/tests/telegram-settings.test.ts
@@ -201,7 +201,7 @@ describe("telegram settings extended API", () => {
 
     expect(set?.status).toBe(200)
     const setData = await set?.json()
-    expect(setData).toEqual({ sessionId: "session-alarm-a", enabled: true })
+    expect(setData).toEqual({ sessionId: "session-alarm-a", sourceId: "default", enabled: true })
 
     const get = await handleExtendedEndpoint(
       "/api/ext/telegram/session-alarm",
@@ -212,7 +212,7 @@ describe("telegram settings extended API", () => {
 
     expect(get?.status).toBe(200)
     const getData = await get?.json()
-    expect(getData).toEqual({ sessionId: "session-alarm-a", enabled: true })
+    expect(getData).toEqual({ sessionId: "session-alarm-a", sourceId: "default", enabled: true })
 
     const stored = JSON.parse(await Bun.file(storePath).text()) as { sessionAlarms?: Record<string, boolean> }
     expect(stored.sessionAlarms?.["session-alarm-a"]).toBe(true)
@@ -262,6 +262,99 @@ describe("telegram settings extended API", () => {
     expect(stored.notifications?.["chat:99"]).toBe(true)
     expect(stored.notifications?.["chat:100"]).toBe(true)
     expect(stored.notifications?.["chat:101"]).toBeUndefined()
+  })
+
+  test("session alarm endpoint isolates same session id across sources", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "telegram-settings-"))
+    const path = join(dir, "telegram-settings.json")
+    const storePath = join(dir, "telegram-sessions.json")
+    cleanupPaths.push(dir)
+
+    process.env.TELEGRAM_SETTINGS_PATH = path
+    process.env.TELEGRAM_SESSION_STORE_PATH = storePath
+
+    const setDefault = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "PUT",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: "shared-session", enabled: true }),
+      }),
+    )
+    expect(setDefault?.status).toBe(200)
+
+    const setOther = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "PUT",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: "shared-session", sourceId: "alpha", enabled: false }),
+      }),
+    )
+    expect(setOther?.status).toBe(200)
+
+    const getDefault = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "GET",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=shared-session"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=shared-session"),
+    )
+    expect(getDefault?.status).toBe(200)
+    expect(await getDefault?.json()).toEqual({ sessionId: "shared-session", sourceId: "default", enabled: true })
+
+    const getOther = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "GET",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=shared-session&sourceId=alpha"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=shared-session&sourceId=alpha"),
+    )
+    expect(getOther?.status).toBe(200)
+    expect(await getOther?.json()).toEqual({ sessionId: "shared-session", sourceId: "alpha", enabled: false })
+
+    const stored = JSON.parse(await Bun.file(storePath).text()) as { sessionAlarms?: Record<string, boolean> }
+    expect(stored.sessionAlarms?.["shared-session"]).toBe(true)
+    expect(stored.sessionAlarms?.["alpha::shared-session"]).toBeUndefined()
+  })
+
+  test("session alarm endpoint accepts scopedSessionId for reads and writes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "telegram-settings-"))
+    const path = join(dir, "telegram-settings.json")
+    const storePath = join(dir, "telegram-sessions.json")
+    cleanupPaths.push(dir)
+
+    process.env.TELEGRAM_SETTINGS_PATH = path
+    process.env.TELEGRAM_SESSION_STORE_PATH = storePath
+
+    const set = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "PUT",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scopedSessionId: "beta::session-scoped", enabled: true }),
+      }),
+    )
+
+    expect(set?.status).toBe(200)
+    expect(await set?.json()).toEqual({ sessionId: "session-scoped", sourceId: "beta", enabled: true })
+
+    const get = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "GET",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm?scopedSessionId=beta::session-scoped"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm?scopedSessionId=beta::session-scoped"),
+    )
+
+    expect(get?.status).toBe(200)
+    expect(await get?.json()).toEqual({ sessionId: "session-scoped", sourceId: "beta", enabled: true })
+
+    const stored = JSON.parse(await Bun.file(storePath).text()) as { sessionAlarms?: Record<string, boolean> }
+    expect(stored.sessionAlarms?.["beta::session-scoped"]).toBe(true)
   })
 
   test("session alarm endpoint validates session id and enabled payload", async () => {
@@ -333,6 +426,26 @@ describe("telegram settings extended API", () => {
       }),
     )
     expect(controlPut?.status).toBe(400)
+
+    const badSource = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "GET",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=session-source&sourceId=bad:value"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm?sessionId=session-source&sourceId=bad:value"),
+    )
+    expect(badSource?.status).toBe(400)
+
+    const mismatch = await handleExtendedEndpoint(
+      "/api/ext/telegram/session-alarm",
+      "PUT",
+      new URL("http://127.0.0.1/api/ext/telegram/session-alarm"),
+      new Request("http://127.0.0.1/api/ext/telegram/session-alarm", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: "session-x", scopedSessionId: "alpha::session-y", enabled: true }),
+      }),
+    )
+    expect(mismatch?.status).toBe(400)
   })
 
   test("session alarm endpoint reuses cached store by session store path", async () => {

--- a/shared/extended-api.ts
+++ b/shared/extended-api.ts
@@ -10,6 +10,8 @@ import * as fs from "node:fs"
 import * as nodePath from "node:path"
 import * as os from "node:os"
 import {
+  TELEGRAM_SOURCE_ID_MAX_LENGTH,
+  TELEGRAM_SOURCE_ID_PATTERN,
   readDesiredTelegramSettingsFingerprint,
   readTelegramRuntimeState,
   readTelegramSettings,
@@ -19,8 +21,6 @@ import { createTelegramSessionStore, type TelegramSessionStore } from "./telegra
 
 const MAX_TELEGRAM_SESSION_STORES = 8
 const MAX_SESSION_ALARM_SESSION_ID_LENGTH = 256
-const MAX_SESSION_ALARM_SOURCE_ID_LENGTH = 64
-const SESSION_ALARM_SOURCE_ID_PATTERN = /^[A-Za-z0-9._-]+$/
 const telegramSessionStores = new Map<string, TelegramSessionStore>()
 let telegramSessionStoreFactory = createTelegramSessionStore
 
@@ -36,10 +36,14 @@ function sessionAlarmSessionIdError(sessionId: string) {
 
 function sessionAlarmSourceIdError(sourceId: string) {
   if (!sourceId) return "sourceId parameter is required"
-  if (sourceId.length > MAX_SESSION_ALARM_SOURCE_ID_LENGTH) {
-    return `sourceId must be ${MAX_SESSION_ALARM_SOURCE_ID_LENGTH} characters or fewer`
+  if (sourceId === "default") return
+  if (sourceId.toLowerCase() === "default") {
+    return 'sourceId is reserved; use exact "default" or choose another id'
   }
-  if (!SESSION_ALARM_SOURCE_ID_PATTERN.test(sourceId)) {
+  if (sourceId.length > TELEGRAM_SOURCE_ID_MAX_LENGTH) {
+    return `sourceId must be ${TELEGRAM_SOURCE_ID_MAX_LENGTH} characters or fewer`
+  }
+  if (!TELEGRAM_SOURCE_ID_PATTERN.test(sourceId)) {
     return "sourceId must match [A-Za-z0-9._-]+"
   }
 }

--- a/shared/extended-api.ts
+++ b/shared/extended-api.ts
@@ -19,6 +19,8 @@ import { createTelegramSessionStore, type TelegramSessionStore } from "./telegra
 
 const MAX_TELEGRAM_SESSION_STORES = 8
 const MAX_SESSION_ALARM_SESSION_ID_LENGTH = 256
+const MAX_SESSION_ALARM_SOURCE_ID_LENGTH = 64
+const SESSION_ALARM_SOURCE_ID_PATTERN = /^[A-Za-z0-9._-]+$/
 const telegramSessionStores = new Map<string, TelegramSessionStore>()
 let telegramSessionStoreFactory = createTelegramSessionStore
 
@@ -29,6 +31,88 @@ function sessionAlarmSessionIdError(sessionId: string) {
   }
   if (/[\x00-\x1F\x7F]/.test(sessionId)) {
     return "sessionId contains unsupported control characters"
+  }
+}
+
+function sessionAlarmSourceIdError(sourceId: string) {
+  if (!sourceId) return "sourceId parameter is required"
+  if (sourceId.length > MAX_SESSION_ALARM_SOURCE_ID_LENGTH) {
+    return `sourceId must be ${MAX_SESSION_ALARM_SOURCE_ID_LENGTH} characters or fewer`
+  }
+  if (!SESSION_ALARM_SOURCE_ID_PATTERN.test(sourceId)) {
+    return "sourceId must match [A-Za-z0-9._-]+"
+  }
+}
+
+function sourceScopedId(sourceId: string, sessionId: string): string {
+  if (sourceId === "default") return sessionId
+  return `${sourceId}::${sessionId}`
+}
+
+type SessionAlarmRef = {
+  sourceId: string
+  sessionId: string
+  scopedSessionId: string
+}
+
+function decodeSessionAlarmRef(value: string): SessionAlarmRef | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) return
+  const parts = trimmed.split("::")
+  if (parts.length === 1) {
+    const sessionId = parts[0] || ""
+    return { sourceId: "default", sessionId, scopedSessionId: sessionId }
+  }
+  const sourceId = parts[0]?.trim() || ""
+  const sessionId = parts.slice(1).join("::").trim()
+  if (!sourceId || !sessionId) return
+  return {
+    sourceId,
+    sessionId,
+    scopedSessionId: sourceScopedId(sourceId, sessionId),
+  }
+}
+
+function sessionAlarmRefFromInput(input: {
+  sessionId: string
+  sourceId: string
+  scopedSessionId: string
+}): { ref?: SessionAlarmRef; error?: string } {
+  const scopedSessionId = input.scopedSessionId.trim()
+  if (scopedSessionId) {
+    const decoded = decodeSessionAlarmRef(scopedSessionId)
+    if (!decoded) return { error: "scopedSessionId is invalid" }
+    const sourceIdError = sessionAlarmSourceIdError(decoded.sourceId)
+    if (sourceIdError) return { error: sourceIdError }
+    const sessionIdError = sessionAlarmSessionIdError(decoded.sessionId)
+    if (sessionIdError) return { error: sessionIdError }
+
+    const sourceId = input.sourceId.trim()
+    if (sourceId && sourceId !== decoded.sourceId) {
+      return { error: "sourceId does not match scopedSessionId" }
+    }
+
+    const sessionId = input.sessionId.trim()
+    if (sessionId && sessionId !== decoded.sessionId) {
+      return { error: "sessionId does not match scopedSessionId" }
+    }
+    return { ref: decoded }
+  }
+
+  const sessionId = input.sessionId.trim()
+  const sessionIdError = sessionAlarmSessionIdError(sessionId)
+  if (sessionIdError) return { error: sessionIdError }
+
+  const sourceId = input.sourceId.trim() || "default"
+  const sourceIdError = sessionAlarmSourceIdError(sourceId)
+  if (sourceIdError) return { error: sourceIdError }
+
+  return {
+    ref: {
+      sourceId,
+      sessionId,
+      scopedSessionId: sourceScopedId(sourceId, sessionId),
+    },
   }
 }
 
@@ -637,11 +721,15 @@ export async function handleExtendedEndpoint(
   }
 
   if (path === "/api/ext/telegram/session-alarm" && method === "GET") {
-    const sessionId = (url.searchParams.get("sessionId") || "").trim()
-    const sessionIdError = sessionAlarmSessionIdError(sessionId)
-    if (sessionIdError) {
-      return Response.json({ error: sessionIdError }, { status: 400 })
+    const parsed = sessionAlarmRefFromInput({
+      sessionId: url.searchParams.get("sessionId") || "",
+      sourceId: url.searchParams.get("sourceId") || "",
+      scopedSessionId: url.searchParams.get("scopedSessionId") || "",
+    })
+    if (!parsed.ref) {
+      return Response.json({ error: parsed.error || "invalid request" }, { status: 400 })
     }
+    const ref = parsed.ref
     const settings = await readTelegramSettings().catch((error) => {
       console.error("[ExtAPI] telegram settings read error", error)
       return null
@@ -659,25 +747,28 @@ export async function handleExtendedEndpoint(
         { status: 501 },
       )
     }
-    const enabled = await store.sessionAlarmGet(sessionId).catch((error) => {
+    const enabled = await store.sessionAlarmGet(ref.scopedSessionId).catch((error) => {
       console.error("[ExtAPI] telegram session alarm read error", error)
       return undefined
     })
     if (enabled === undefined) {
       return Response.json({ error: "failed to read telegram session alarm" }, { status: 500 })
     }
-    return Response.json({ sessionId, enabled: enabled === true })
+    return Response.json({ sessionId: ref.sessionId, sourceId: ref.sourceId, enabled: enabled === true })
   }
 
   if (path === "/api/ext/telegram/session-alarm" && method === "PUT") {
     const body = await req.json().catch(() => null)
     const payload = body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : null
-    const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId.trim() : ""
+    const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : ""
+    const sourceId = typeof payload?.sourceId === "string" ? payload.sourceId : ""
+    const scopedSessionId = typeof payload?.scopedSessionId === "string" ? payload.scopedSessionId : ""
     const enabled = payload?.enabled
-    const sessionIdError = sessionAlarmSessionIdError(sessionId)
-    if (sessionIdError) {
-      return Response.json({ error: sessionIdError }, { status: 400 })
+    const parsed = sessionAlarmRefFromInput({ sessionId, sourceId, scopedSessionId })
+    if (!parsed.ref) {
+      return Response.json({ error: parsed.error || "invalid request" }, { status: 400 })
     }
+    const ref = parsed.ref
     if (typeof enabled !== "boolean") {
       return Response.json({ error: "enabled must be a boolean" }, { status: 400 })
     }
@@ -698,7 +789,7 @@ export async function handleExtendedEndpoint(
         { status: 501 },
       )
     }
-    const ok = await store.sessionAlarmSet(sessionId, enabled).then(
+    const ok = await store.sessionAlarmSet(ref.scopedSessionId, enabled).then(
       () => true,
       (error) => {
         console.error("[ExtAPI] telegram session alarm write error", error)
@@ -709,11 +800,15 @@ export async function handleExtendedEndpoint(
       return Response.json({ error: "failed to update telegram session alarm" }, { status: 500 })
     }
     if (enabled) {
-      await enableTelegramNotifyForSession(store, sessionId).catch((error) => {
-        console.error("[ExtAPI] telegram notify sync on session alarm enable failed", { sessionId, error })
+      await enableTelegramNotifyForSession(store, ref.scopedSessionId).catch((error) => {
+        console.error("[ExtAPI] telegram notify sync on session alarm enable failed", {
+          sessionId: ref.sessionId,
+          sourceId: ref.sourceId,
+          error,
+        })
       })
     }
-    return Response.json({ sessionId, enabled })
+    return Response.json({ sessionId: ref.sessionId, sourceId: ref.sourceId, enabled })
   }
 
   if (path === "/api/ext/telegram/restart" && method === "GET") {

--- a/shared/telegram-settings.ts
+++ b/shared/telegram-settings.ts
@@ -135,14 +135,24 @@ function parsePersistedLinkBase(value: unknown, fallback: string | undefined): s
   return normalizeLinkBase(trimmed, "persisted sessionLinkBase")
 }
 
-function parseSourceId(value: unknown): string | undefined {
-  if (typeof value !== "string") return
+function parseSourceId(value: unknown): { id?: string; error?: string } {
+  if (typeof value !== "string") {
+    return { error: "id must be a string" }
+  }
   const id = value.trim()
-  if (!id) return
-  if (id.length > TELEGRAM_SOURCE_ID_MAX_LENGTH) return
-  if (!TELEGRAM_SOURCE_ID_PATTERN.test(id)) return
-  if (id.toLowerCase() === "default") return
-  return id
+  if (!id) {
+    return { error: "id must not be empty" }
+  }
+  if (id.length > TELEGRAM_SOURCE_ID_MAX_LENGTH) {
+    return { error: `id must be ${TELEGRAM_SOURCE_ID_MAX_LENGTH} characters or fewer` }
+  }
+  if (!TELEGRAM_SOURCE_ID_PATTERN.test(id)) {
+    return { error: "id must match [A-Za-z0-9._-]+" }
+  }
+  if (id.toLowerCase() === "default") {
+    return { error: 'id must not be "default" (case-insensitive)' }
+  }
+  return { id }
 }
 
 function parsePersistedSources(value: unknown): TelegramSourceSetting[] | undefined {
@@ -157,7 +167,8 @@ function parsePersistedSources(value: unknown): TelegramSourceSetting[] | undefi
       enabled?: unknown
       directory?: unknown
     }
-    const id = parseSourceId(source.id)
+    const parsed = parseSourceId(source.id)
+    const id = parsed.id
     if (!id || ids.has(id)) continue
     if (typeof source.openCodeUrl !== "string" || !source.openCodeUrl.trim()) continue
     const openCodeUrl = parsePersistedUrl(source.openCodeUrl, "openCodeUrl", undefined)
@@ -758,9 +769,11 @@ function normalizePayload(input: unknown): {
           continue
         }
         const source = entry as Record<string, unknown>
-        const id = parseSourceId(source.id)
+        const parsed = parseSourceId(source.id)
+        const id = parsed.id
         if (!id) {
-          errors.push({ field: `sources.${i}.id`, message: "id must match [A-Za-z0-9._-]+ and must not be default" })
+          const message = parsed.error || "id must match [A-Za-z0-9._-]+ and must not be default"
+          errors.push({ field: `sources.${i}.id`, message })
           continue
         }
         if (ids.has(id)) {

--- a/shared/telegram-settings.ts
+++ b/shared/telegram-settings.ts
@@ -79,6 +79,9 @@ export type TelegramBridgeSettings = {
   sessionLinkBase?: string
 }
 
+export const TELEGRAM_SOURCE_ID_MAX_LENGTH = 64
+export const TELEGRAM_SOURCE_ID_PATTERN = /^[A-Za-z0-9._-]+$/
+
 function env(name: string): string {
   return process.env[name]?.trim() || ""
 }
@@ -136,7 +139,8 @@ function parseSourceId(value: unknown): string | undefined {
   if (typeof value !== "string") return
   const id = value.trim()
   if (!id) return
-  if (!/^[A-Za-z0-9._-]+$/.test(id)) return
+  if (id.length > TELEGRAM_SOURCE_ID_MAX_LENGTH) return
+  if (!TELEGRAM_SOURCE_ID_PATTERN.test(id)) return
   if (id.toLowerCase() === "default") return
   return id
 }


### PR DESCRIPTION
## Summary
- make `/api/ext/telegram/session-alarm` source-aware by accepting `sourceId` or `scopedSessionId` and normalizing alarm keys to source-scoped IDs
- update session alarm client helpers and session bell sync flow to resolve and pass source context from Telegram settings
- add coverage for cross-source alarm isolation, scoped-session API usage, and source/scoped validation paths

Closes #369