### PR TITLE
fix: harden session bootstrap against stale Workbox routes

### DIFF
--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -106,7 +106,13 @@ const server = Bun.serve<{ target: string }>({
 
           if (!response.ok) {
             console.error("[Proxy] SSE error:", response.status, response.statusText)
-            return new Response(response.body, { status: response.status })
+            return withNoStoreHeaders(
+              new Response(response.body, {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+              }),
+            )
           }
 
           // Pass through the body directly - Bun handles streaming
@@ -123,18 +129,23 @@ const server = Bun.serve<{ target: string }>({
           })
         } catch (e) {
           console.error("[Proxy] SSE connection error:", e)
-          return new Response("SSE proxy error", { status: 502 })
+          return withNoStoreHeaders(new Response("SSE proxy error", { status: 502 }))
         }
       }
 
       console.log("[Proxy] API:", req.method, strippedPath)
-      const body = req.method === "GET" || req.method === "HEAD" ? undefined : req.body
-      const response = await fetch(target.toString(), {
-        method: req.method,
-        headers,
-        body,
-      })
-      return withNoStoreHeaders(normalizeProxiedResponse(response))
+      try {
+        const body = req.method === "GET" || req.method === "HEAD" ? undefined : req.body
+        const response = await fetch(target.toString(), {
+          method: req.method,
+          headers,
+          body,
+        })
+        return withNoStoreHeaders(normalizeProxiedResponse(response))
+      } catch (e) {
+        console.error("[Proxy] API error:", e)
+        return withNoStoreHeaders(new Response("API proxy error", { status: 502 }))
+      }
     }
 
     // Frontend routes - try to serve static file

--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -36,6 +36,18 @@ const basePathWithTrailing = validatedBasePath.endsWith("/") ? validatedBasePath
 // Track WebSocket connections: client ws -> backend ws
 const wsConnections = new Map<object, WebSocket>()
 
+function withNoStoreHeaders(response: Response) {
+  const headers = new Headers(response.headers)
+  headers.set("Cache-Control", "no-store")
+  headers.set("Pragma", "no-cache")
+  headers.set("Expires", "0")
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
 const server = Bun.serve<{ target: string }>({
   port: PORT,
   idleTimeout: 0, // Disable timeout for SSE connections
@@ -76,7 +88,7 @@ const server = Bun.serve<{ target: string }>({
 
     // Extended API endpoints (handled locally, not proxied)
     const extResponse = await handleExtendedEndpoint(strippedPath, req.method, url, req)
-    if (extResponse) return extResponse
+    if (extResponse) return withNoStoreHeaders(extResponse)
 
     // API requests go directly to the backend
     if (isApiPath(strippedPath)) {
@@ -102,7 +114,9 @@ const server = Bun.serve<{ target: string }>({
             status: response.status,
             headers: {
               "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
+              "Cache-Control": "no-store",
+              Pragma: "no-cache",
+              Expires: "0",
               Connection: "keep-alive",
               "X-Accel-Buffering": "no",
             },
@@ -120,7 +134,7 @@ const server = Bun.serve<{ target: string }>({
         headers,
         body,
       })
-      return normalizeProxiedResponse(response)
+      return withNoStoreHeaders(normalizeProxiedResponse(response))
     }
 
     // Frontend routes - try to serve static file

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -60,7 +60,7 @@ function sortParts(parts: Part[]): Part[] {
 
 function errorText(err: unknown) {
   if (err instanceof Error && err.message.trim()) return err.message
-  return "Failed to bootstrap sessions from API."
+  return "Failed to bootstrap app state from API."
 }
 
 function binarySearch<T>(arr: T[], id: string, getId: (item: T) => string): { found: boolean; index: number } {

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -24,6 +24,7 @@ type ProviderData = {
 
 type SyncStore = {
   ready: boolean
+  error: string | null
   session: Session[]
   archivedSession: Session[]
   message: Record<string, MessageWithParts[]>
@@ -34,6 +35,7 @@ type SyncStore = {
 interface SyncContextValue {
   data: SyncStore
   ready: boolean
+  bootstrapError: string | null
   sessions: () => Session[]
   archivedSessions: () => Session[]
   messages: (sessionID: string) => MessageWithParts[]
@@ -56,6 +58,11 @@ function sortParts(parts: Part[]): Part[] {
   return [...withId, ...withoutId]
 }
 
+function errorText(err: unknown) {
+  if (err instanceof Error && err.message.trim()) return err.message
+  return "Failed to bootstrap sessions from API."
+}
+
 function binarySearch<T>(arr: T[], id: string, getId: (item: T) => string): { found: boolean; index: number } {
   let low = 0
   let high = arr.length - 1
@@ -75,6 +82,7 @@ export function SyncProvider(props: ParentProps) {
 
   const [store, setStore] = createStore<SyncStore>({
     ready: false,
+    error: null,
     session: [],
     archivedSession: [],
     message: {},
@@ -320,6 +328,7 @@ export function SyncProvider(props: ParentProps) {
   }
 
   async function bootstrap() {
+    setStore("error", null)
     try {
       const [sessionsRes, providersRes] = await Promise.all([client.session.list(), client.provider.list()])
 
@@ -341,6 +350,7 @@ export function SyncProvider(props: ParentProps) {
       console.log("[Sync] Bootstrap complete, sessions:", store.session.length)
     } catch (err) {
       console.error("[Sync] Bootstrap failed:", err)
+      setStore("error", errorText(err))
     }
   }
 
@@ -451,6 +461,9 @@ export function SyncProvider(props: ParentProps) {
     },
     get ready() {
       return store.ready
+    },
+    get bootstrapError() {
+      return store.error
     },
     sessions: () => store.session,
     archivedSessions: () => store.archivedSession,

--- a/app-prefixable/src/entry.tsx
+++ b/app-prefixable/src/entry.tsx
@@ -1,6 +1,7 @@
 /* @refresh reload */
 import { render } from "solid-js/web"
 import { App } from "./app"
+import { preventLegacyServiceWorkerCaching } from "./utils/legacy-service-worker"
 
 console.log("[OpenCode] Starting app...")
 
@@ -13,12 +14,22 @@ if (!root) {
 // Clear the loading text first
 root.innerHTML = ""
 
-try {
+async function start() {
+  const cleanup = await preventLegacyServiceWorkerCaching()
+  if (cleanup.registrations > 0 || cleanup.caches > 0) {
+    console.log(
+      "[OpenCode] Cleared legacy service worker state:",
+      `${cleanup.unregistered}/${cleanup.registrations} registrations, ${cleanup.caches} caches`,
+    )
+  }
+
   console.log("[OpenCode] Rendering...")
   render(() => <App />, root)
   console.log("[OpenCode] Rendered successfully")
   console.log("[OpenCode] Root innerHTML:", root.innerHTML.slice(0, 200))
-} catch (e) {
+}
+
+start().catch((e) => {
   console.error("[OpenCode] Render error:", e)
   root.innerHTML = `<div style="color: red; padding: 20px;">Error: ${e}</div>`
-}
+})

--- a/app-prefixable/src/entry.tsx
+++ b/app-prefixable/src/entry.tsx
@@ -34,5 +34,10 @@ async function start() {
 
 start().catch((e) => {
   console.error("[OpenCode] Render error:", e)
-  root.innerHTML = `<div style="color: red; padding: 20px;">Error: ${e}</div>`
+  root.innerHTML = ""
+  const message = document.createElement("div")
+  message.style.color = "red"
+  message.style.padding = "20px"
+  message.textContent = `Error: ${e instanceof Error && e.message.trim() ? e.message : String(e)}`
+  root.appendChild(message)
 })

--- a/app-prefixable/src/entry.tsx
+++ b/app-prefixable/src/entry.tsx
@@ -15,8 +15,11 @@ if (!root) {
 root.innerHTML = ""
 
 async function start() {
-  const cleanup = await preventLegacyServiceWorkerCaching()
-  if (cleanup.registrations > 0 || cleanup.caches > 0) {
+  const cleanup = await preventLegacyServiceWorkerCaching().catch((e) => {
+    console.warn("[OpenCode] Legacy service worker cleanup failed:", e)
+    return null
+  })
+  if (cleanup && (cleanup.registrations > 0 || cleanup.caches > 0)) {
     console.log(
       "[OpenCode] Cleared legacy service worker state:",
       `${cleanup.unregistered}/${cleanup.registrations} registrations, ${cleanup.caches} caches`,

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1183,12 +1183,11 @@ export function Layout(props: ParentProps) {
     }
   }
 
-  const sessionError = createMemo(() => sessionLoadError() ?? sync.bootstrapError);
+  const sessionError = createMemo(() => sessionLoadError());
 
   function retrySessionBootstrap() {
     setLoading(true);
     void loadSessions();
-    void sync.refresh();
   }
 
   function handleSearchInput(query: string) {

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -269,6 +269,7 @@ export function Layout(props: ParentProps) {
 
   const [sessions, setSessions] = createSignal<Session[]>([]);
   const [loading, setLoading] = createSignal(true);
+  const [sessionLoadError, setSessionLoadError] = createSignal<string | null>(null);
   const [projects, setProjects] = createSignal<Project[]>([]);
   const [sidebarExpanded, setSidebarExpanded] = createSignal(true);
   const [showArchived, setShowArchived] = createSignal(false);
@@ -1149,6 +1150,11 @@ export function Layout(props: ParentProps) {
     });
   }
 
+  function errorText(err: unknown) {
+    if (err instanceof Error && err.message.trim()) return err.message;
+    return "Session bootstrap failed. Check API connectivity and retry.";
+  }
+
   async function loadSessions() {
     try {
       const res = await client.session.list({ roots: true });
@@ -1159,15 +1165,26 @@ export function Layout(props: ParentProps) {
             s && typeof s === "object" && typeof s.id === "string",
         );
         setSessions(valid);
+        setSessionLoadError(null);
       } else {
         setSessions([]);
+        setSessionLoadError(null);
       }
     } catch (e) {
       console.error("Failed to load sessions:", e);
       setSessions([]);
+      setSessionLoadError(errorText(e));
     } finally {
       setLoading(false);
     }
+  }
+
+  const sessionError = createMemo(() => sessionLoadError() ?? sync.bootstrapError);
+
+  function retrySessionBootstrap() {
+    setLoading(true);
+    void loadSessions();
+    void sync.refresh();
   }
 
   function handleSearchInput(query: string) {
@@ -2490,19 +2507,45 @@ export function Layout(props: ParentProps) {
             {/* Normal Session List */}
             <Show when={!loading() && !searchQuery().trim()}>
               <Show
-                when={
-                  projectSessions().length > 0 || archivedSessions().length > 0
-                }
+                when={!sessionError()}
                 fallback={
                   <div
-                    class="py-6 text-center"
-                    style={{ color: "var(--text-weak)" }}
+                    class="mx-1 my-3 rounded-md border p-3"
+                    style={{
+                      color: "var(--text-base)",
+                      background: "var(--surface-inset)",
+                      "border-color": "var(--border-base)",
+                    }}
                   >
-                    <p class="text-sm">No sessions yet</p>
-                    <p class="text-xs mt-1">Click "New Session" to start</p>
+                    <div class="flex items-start gap-2">
+                      <AlertTriangle class="w-4 h-4 mt-0.5 shrink-0" style={{ color: "var(--text-critical-base)" }} />
+                      <div class="min-w-0">
+                        <p class="text-sm font-medium">Could not load sessions</p>
+                        <p class="text-xs mt-1" style={{ color: "var(--text-weak)" }}>{sessionError()}</p>
+                        <div class="mt-3">
+                          <Button size="sm" variant="secondary" onClick={retrySessionBootstrap}>
+                            Retry
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 }
               >
+                <Show
+                  when={
+                    projectSessions().length > 0 || archivedSessions().length > 0
+                  }
+                  fallback={
+                    <div
+                      class="py-6 text-center"
+                      style={{ color: "var(--text-weak)" }}
+                    >
+                      <p class="text-sm">No sessions yet</p>
+                      <p class="text-xs mt-1">Click "New Session" to start</p>
+                    </div>
+                  }
+                >
                 {/* Pinned Sessions (drag-and-drop reorderable) */}
                 <Show when={pinnedSessions().length > 0}>
                   <div class="pb-2">

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -2511,6 +2511,8 @@ export function Layout(props: ParentProps) {
                 fallback={
                   <div
                     class="mx-1 my-3 rounded-md border p-3"
+                    role="alert"
+                    aria-live="polite"
                     style={{
                       color: "var(--text-base)",
                       background: "var(--surface-inset)",
@@ -2800,6 +2802,7 @@ export function Layout(props: ParentProps) {
                         )}
                       </For>
                     </div>
+                  </Show>
                   </Show>
                 </Show>
               </Show>

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -2514,7 +2514,7 @@ export function Layout(props: ParentProps) {
                 fallback={
                   <div
                     class="mx-1 my-3 rounded-md border p-3"
-                    role="alert"
+                    role="status"
                     aria-live="polite"
                     style={{
                       color: "var(--text-base)",

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -868,6 +868,10 @@ export function Layout(props: ParentProps) {
       .sort((a, b) => (b.time?.archived || 0) - (a.time?.archived || 0)),
   );
 
+  const hasSessions = createMemo(
+    () => projectSessions().length > 0 || archivedSessions().length > 0,
+  );
+
   const [now, setNow] = createSignal(new Date());
 
   onMount(() => {
@@ -2507,7 +2511,7 @@ export function Layout(props: ParentProps) {
             {/* Normal Session List */}
             <Show when={!loading() && !searchQuery().trim()}>
               <Show
-                when={!sessionError()}
+                when={!sessionError() || hasSessions()}
                 fallback={
                   <div
                     class="mx-1 my-3 rounded-md border p-3"
@@ -2535,9 +2539,7 @@ export function Layout(props: ParentProps) {
                 }
               >
                 <Show
-                  when={
-                    projectSessions().length > 0 || archivedSessions().length > 0
-                  }
+                  when={hasSessions()}
                   fallback={
                     <div
                       class="py-6 text-center"

--- a/app-prefixable/src/utils/legacy-service-worker.ts
+++ b/app-prefixable/src/utils/legacy-service-worker.ts
@@ -1,29 +1,32 @@
 const LEGACY_CACHE_PATTERN = /(workbox|opencode-(precache|runtime))/i
 
-export async function preventLegacyServiceWorkerCaching() {
-  if (typeof window === "undefined") {
-    return { registrations: 0, unregistered: 0, caches: 0 }
-  }
-  if (!("serviceWorker" in navigator)) {
-    return { registrations: 0, unregistered: 0, caches: 0 }
-  }
+type CleanupResult = {
+  registrations: number
+  unregistered: number
+  caches: number
+}
 
-  const url = window.location.href
+const EMPTY_RESULT: CleanupResult = { registrations: 0, unregistered: 0, caches: 0 }
+
+export async function preventLegacyServiceWorkerCaching() {
+  if (typeof window === "undefined") return EMPTY_RESULT
+  if (typeof navigator === "undefined") return EMPTY_RESULT
+  if (!("serviceWorker" in navigator)) return EMPTY_RESULT
+
+  const appScope = new URL(".", window.location.href).href
   const regs = await navigator.serviceWorker.getRegistrations().catch(() => [] as ServiceWorkerRegistration[])
-  const scoped = regs.filter((item) => url.startsWith(item.scope))
+  const scoped = regs.filter((item) => item.scope.startsWith(appScope))
   const results = await Promise.allSettled(scoped.map((item) => item.unregister()))
   const unregistered = results.reduce((count, item) => {
     if (item.status === "fulfilled" && item.value) return count + 1
     return count
   }, 0)
 
-  if (!("caches" in window)) {
-    return { registrations: scoped.length, unregistered, caches: 0 }
-  }
+  if (!("caches" in window)) return { registrations: scoped.length, unregistered, caches: 0 }
 
-  const keys = await caches.keys().catch(() => [] as string[])
+  const keys = await window.caches.keys().catch(() => [] as string[])
   const stale = keys.filter((key) => LEGACY_CACHE_PATTERN.test(key))
-  await Promise.allSettled(stale.map((key) => caches.delete(key)))
+  await Promise.allSettled(stale.map((key) => window.caches.delete(key)))
 
   return { registrations: scoped.length, unregistered, caches: stale.length }
 }

--- a/app-prefixable/src/utils/legacy-service-worker.ts
+++ b/app-prefixable/src/utils/legacy-service-worker.ts
@@ -1,4 +1,5 @@
 const LEGACY_CACHE_PATTERN = /(workbox|opencode-(precache|runtime))/i
+const LEGACY_SCRIPT_PATTERN = /(workbox|opencode)/i
 
 type CleanupResult = {
   registrations: number
@@ -14,19 +15,31 @@ export async function preventLegacyServiceWorkerCaching() {
   if (!("serviceWorker" in navigator)) return EMPTY_RESULT
 
   const appScope = new URL(".", window.location.href).href
+  const origin = new URL(window.location.href).origin
+
+  const keys = "caches" in window ? await window.caches.keys().catch(() => [] as string[]) : []
+  const stale = keys.filter((key) => LEGACY_CACHE_PATTERN.test(key))
+  const hasLegacyCaches = stale.length > 0
+
   const regs = await navigator.serviceWorker.getRegistrations().catch(() => [] as ServiceWorkerRegistration[])
-  const scoped = regs.filter((item) => item.scope.startsWith(appScope))
-  const results = await Promise.allSettled(scoped.map((item) => item.unregister()))
+  const scoped = regs.filter((item) => appScope.startsWith(item.scope))
+  const targets = scoped.filter((item) => {
+    const worker = item.active ?? item.waiting ?? item.installing
+    const scriptUrl = worker?.scriptURL
+    const isLegacyScript = typeof scriptUrl === "string" && LEGACY_SCRIPT_PATTERN.test(scriptUrl)
+    if (isLegacyScript) return true
+    if (!hasLegacyCaches) return false
+    const regOrigin = new URL(item.scope).origin
+    if (regOrigin !== origin) return false
+    return item.scope === appScope || appScope.startsWith(item.scope)
+  })
+  const results = await Promise.allSettled(targets.map((item) => item.unregister()))
   const unregistered = results.reduce((count, item) => {
     if (item.status === "fulfilled" && item.value) return count + 1
     return count
   }, 0)
 
-  if (!("caches" in window)) return { registrations: scoped.length, unregistered, caches: 0 }
-
-  const keys = await window.caches.keys().catch(() => [] as string[])
-  const stale = keys.filter((key) => LEGACY_CACHE_PATTERN.test(key))
   await Promise.allSettled(stale.map((key) => window.caches.delete(key)))
 
-  return { registrations: scoped.length, unregistered, caches: stale.length }
+  return { registrations: targets.length, unregistered, caches: stale.length }
 }

--- a/app-prefixable/src/utils/legacy-service-worker.ts
+++ b/app-prefixable/src/utils/legacy-service-worker.ts
@@ -1,0 +1,29 @@
+const LEGACY_CACHE_PATTERN = /(workbox|opencode-(precache|runtime))/i
+
+export async function preventLegacyServiceWorkerCaching() {
+  if (typeof window === "undefined") {
+    return { registrations: 0, unregistered: 0, caches: 0 }
+  }
+  if (!("serviceWorker" in navigator)) {
+    return { registrations: 0, unregistered: 0, caches: 0 }
+  }
+
+  const url = window.location.href
+  const regs = await navigator.serviceWorker.getRegistrations().catch(() => [] as ServiceWorkerRegistration[])
+  const scoped = regs.filter((item) => url.startsWith(item.scope))
+  const results = await Promise.allSettled(scoped.map((item) => item.unregister()))
+  const unregistered = results.reduce((count, item) => {
+    if (item.status === "fulfilled" && item.value) return count + 1
+    return count
+  }, 0)
+
+  if (!("caches" in window)) {
+    return { registrations: scoped.length, unregistered, caches: 0 }
+  }
+
+  const keys = await caches.keys().catch(() => [] as string[])
+  const stale = keys.filter((key) => LEGACY_CACHE_PATTERN.test(key))
+  await Promise.allSettled(stale.map((key) => caches.delete(key)))
+
+  return { registrations: scoped.length, unregistered, caches: stale.length }
+}

--- a/app-prefixable/src/utils/legacy-service-worker.ts
+++ b/app-prefixable/src/utils/legacy-service-worker.ts
@@ -15,23 +15,16 @@ export async function preventLegacyServiceWorkerCaching() {
   if (!("serviceWorker" in navigator)) return EMPTY_RESULT
 
   const appScope = new URL(".", window.location.href).href
-  const origin = new URL(window.location.href).origin
 
   const keys = "caches" in window ? await window.caches.keys().catch(() => [] as string[]) : []
   const stale = keys.filter((key) => LEGACY_CACHE_PATTERN.test(key))
-  const hasLegacyCaches = stale.length > 0
 
   const regs = await navigator.serviceWorker.getRegistrations().catch(() => [] as ServiceWorkerRegistration[])
   const scoped = regs.filter((item) => appScope.startsWith(item.scope))
   const targets = scoped.filter((item) => {
     const worker = item.active ?? item.waiting ?? item.installing
     const scriptUrl = worker?.scriptURL
-    const isLegacyScript = typeof scriptUrl === "string" && LEGACY_SCRIPT_PATTERN.test(scriptUrl)
-    if (isLegacyScript) return true
-    if (!hasLegacyCaches) return false
-    const regOrigin = new URL(item.scope).origin
-    if (regOrigin !== origin) return false
-    return item.scope === appScope || appScope.startsWith(item.scope)
+    return typeof scriptUrl === "string" && LEGACY_SCRIPT_PATTERN.test(scriptUrl)
   })
   const results = await Promise.allSettled(targets.map((item) => item.unregister()))
   const unregistered = results.reduce((count, item) => {

--- a/app-prefixable/tests/legacy-service-worker.test.ts
+++ b/app-prefixable/tests/legacy-service-worker.test.ts
@@ -109,4 +109,30 @@ describe("preventLegacyServiceWorkerCaching", () => {
     expect(otherUnregisters).toBe(0)
     expect(deleted).toEqual(["workbox-runtime-v1", "opencode-precache-v2"])
   })
+
+  test("clears legacy caches from window when global caches is unavailable", async () => {
+    const deleted: string[] = []
+
+    const cacheStorage = {
+      keys: async () => ["misc-cache", "opencode-runtime-v3"],
+      delete: async (key: string) => {
+        deleted.push(key)
+        return true
+      },
+    } as unknown as CacheStorage
+
+    globals.window = {
+      location: { href: "https://example.test/notebook/ns/a/session" },
+      caches: cacheStorage,
+    } as unknown as Window & typeof globalThis
+    globals.navigator = {
+      serviceWorker: { getRegistrations: async () => [] },
+    } as Navigator
+    delete globals.caches
+
+    const res = await preventLegacyServiceWorkerCaching()
+
+    expect(res).toEqual({ registrations: 0, unregistered: 0, caches: 1 })
+    expect(deleted).toEqual(["opencode-runtime-v3"])
+  })
 })

--- a/app-prefixable/tests/legacy-service-worker.test.ts
+++ b/app-prefixable/tests/legacy-service-worker.test.ts
@@ -50,7 +50,7 @@ describe("preventLegacyServiceWorkerCaching", () => {
     expect(res).toEqual({ registrations: 0, unregistered: 0, caches: 0 })
   })
 
-  test("unregisters workers that control app scope when legacy caches exist", async () => {
+  test("keeps non-legacy workers registered when only legacy caches exist", async () => {
     let currentUnregisters = 0
     let broadUnregisters = 0
     let otherUnregisters = 0
@@ -106,11 +106,58 @@ describe("preventLegacyServiceWorkerCaching", () => {
 
     const res = await preventLegacyServiceWorkerCaching()
 
-    expect(res).toEqual({ registrations: 2, unregistered: 2, caches: 2 })
-    expect(currentUnregisters).toBe(1)
-    expect(broadUnregisters).toBe(1)
+    expect(res).toEqual({ registrations: 0, unregistered: 0, caches: 2 })
+    expect(currentUnregisters).toBe(0)
+    expect(broadUnregisters).toBe(0)
     expect(otherUnregisters).toBe(0)
     expect(deleted).toEqual(["workbox-runtime-v1", "opencode-precache-v2"])
+  })
+
+  test("unregisters legacy workers even when legacy caches do not exist", async () => {
+    let appLegacyUnregisters = 0
+    let broadNonLegacyUnregisters = 0
+
+    const appLegacy = {
+      scope: "https://example.test/notebook/ns/a/",
+      active: { scriptURL: "https://example.test/assets/opencode-sw.js" },
+      unregister: async () => {
+        appLegacyUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
+    const broadNonLegacy = {
+      scope: "https://example.test/",
+      active: { scriptURL: "https://example.test/sw.js" },
+      unregister: async () => {
+        broadNonLegacyUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
+    const navigator = {
+      serviceWorker: {
+        getRegistrations: async () => [appLegacy, broadNonLegacy],
+      },
+    } as Navigator
+
+    const cacheStorage = {
+      keys: async () => ["misc-cache"],
+      delete: async () => true,
+    } as unknown as CacheStorage
+
+    globals.window = {
+      location: { href: "https://example.test/notebook/ns/a/session" },
+      caches: cacheStorage,
+    } as unknown as Window & typeof globalThis
+    globals.navigator = navigator
+    globals.caches = cacheStorage
+
+    const res = await preventLegacyServiceWorkerCaching()
+
+    expect(res).toEqual({ registrations: 1, unregistered: 1, caches: 0 })
+    expect(appLegacyUnregisters).toBe(1)
+    expect(broadNonLegacyUnregisters).toBe(0)
   })
 
   test("keeps non-legacy workers when there are no legacy caches", async () => {

--- a/app-prefixable/tests/legacy-service-worker.test.ts
+++ b/app-prefixable/tests/legacy-service-worker.test.ts
@@ -39,8 +39,20 @@ describe("preventLegacyServiceWorkerCaching", () => {
     expect(res).toEqual({ registrations: 0, unregistered: 0, caches: 0 })
   })
 
+  test("skips cleanup when navigator is missing", async () => {
+    globals.window = {
+      location: { href: "https://example.test/notebook/ns/a/session" },
+    } as unknown as Window & typeof globalThis
+    delete globals.navigator
+
+    const res = await preventLegacyServiceWorkerCaching()
+
+    expect(res).toEqual({ registrations: 0, unregistered: 0, caches: 0 })
+  })
+
   test("unregisters scoped workers and clears legacy workbox caches", async () => {
     let currentUnregisters = 0
+    let broadUnregisters = 0
     let otherUnregisters = 0
     const deleted: string[] = []
 
@@ -60,9 +72,17 @@ describe("preventLegacyServiceWorkerCaching", () => {
       },
     } as ServiceWorkerRegistration
 
+    const broad = {
+      scope: "https://example.test/",
+      unregister: async () => {
+        broadUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
     const navigator = {
       serviceWorker: {
-        getRegistrations: async () => [current, other],
+        getRegistrations: async () => [current, broad, other],
       },
     } as Navigator
 
@@ -85,6 +105,7 @@ describe("preventLegacyServiceWorkerCaching", () => {
 
     expect(res).toEqual({ registrations: 1, unregistered: 1, caches: 2 })
     expect(currentUnregisters).toBe(1)
+    expect(broadUnregisters).toBe(0)
     expect(otherUnregisters).toBe(0)
     expect(deleted).toEqual(["workbox-runtime-v1", "opencode-precache-v2"])
   })

--- a/app-prefixable/tests/legacy-service-worker.test.ts
+++ b/app-prefixable/tests/legacy-service-worker.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { preventLegacyServiceWorkerCaching } from "../src/utils/legacy-service-worker"
+
+const globals = globalThis as {
+  window?: Window & typeof globalThis
+  navigator?: Navigator
+  caches?: CacheStorage
+}
+
+const originalWindow = globals.window
+const originalNavigator = globals.navigator
+const originalCaches = globals.caches
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    delete globals.window
+  } else {
+    globals.window = originalWindow
+  }
+  if (originalNavigator === undefined) {
+    delete globals.navigator
+  } else {
+    globals.navigator = originalNavigator
+  }
+  if (originalCaches === undefined) {
+    delete globals.caches
+  } else {
+    globals.caches = originalCaches
+  }
+})
+
+describe("preventLegacyServiceWorkerCaching", () => {
+  test("skips cleanup when service workers are unavailable", async () => {
+    delete globals.window
+    delete globals.navigator
+
+    const res = await preventLegacyServiceWorkerCaching()
+
+    expect(res).toEqual({ registrations: 0, unregistered: 0, caches: 0 })
+  })
+
+  test("unregisters scoped workers and clears legacy workbox caches", async () => {
+    let currentUnregisters = 0
+    let otherUnregisters = 0
+    const deleted: string[] = []
+
+    const current = {
+      scope: "https://example.test/notebook/ns/a/",
+      unregister: async () => {
+        currentUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
+    const other = {
+      scope: "https://example.test/notebook/ns/other/",
+      unregister: async () => {
+        otherUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
+    const navigator = {
+      serviceWorker: {
+        getRegistrations: async () => [current, other],
+      },
+    } as Navigator
+
+    const cacheStorage = {
+      keys: async () => ["workbox-runtime-v1", "misc-cache", "opencode-precache-v2"],
+      delete: async (key: string) => {
+        deleted.push(key)
+        return true
+      },
+    } as unknown as CacheStorage
+
+    globals.window = {
+      location: { href: "https://example.test/notebook/ns/a/session" },
+      caches: cacheStorage,
+    } as unknown as Window & typeof globalThis
+    globals.navigator = navigator
+    globals.caches = cacheStorage
+
+    const res = await preventLegacyServiceWorkerCaching()
+
+    expect(res).toEqual({ registrations: 1, unregistered: 1, caches: 2 })
+    expect(currentUnregisters).toBe(1)
+    expect(otherUnregisters).toBe(0)
+    expect(deleted).toEqual(["workbox-runtime-v1", "opencode-precache-v2"])
+  })
+})

--- a/app-prefixable/tests/legacy-service-worker.test.ts
+++ b/app-prefixable/tests/legacy-service-worker.test.ts
@@ -50,7 +50,7 @@ describe("preventLegacyServiceWorkerCaching", () => {
     expect(res).toEqual({ registrations: 0, unregistered: 0, caches: 0 })
   })
 
-  test("unregisters scoped workers and clears legacy workbox caches", async () => {
+  test("unregisters workers that control app scope when legacy caches exist", async () => {
     let currentUnregisters = 0
     let broadUnregisters = 0
     let otherUnregisters = 0
@@ -58,6 +58,7 @@ describe("preventLegacyServiceWorkerCaching", () => {
 
     const current = {
       scope: "https://example.test/notebook/ns/a/",
+      active: { scriptURL: "https://example.test/sw.js" },
       unregister: async () => {
         currentUnregisters += 1
         return true
@@ -66,6 +67,7 @@ describe("preventLegacyServiceWorkerCaching", () => {
 
     const other = {
       scope: "https://example.test/notebook/ns/other/",
+      active: { scriptURL: "https://example.test/sw.js" },
       unregister: async () => {
         otherUnregisters += 1
         return true
@@ -74,6 +76,7 @@ describe("preventLegacyServiceWorkerCaching", () => {
 
     const broad = {
       scope: "https://example.test/",
+      active: { scriptURL: "https://example.test/sw.js" },
       unregister: async () => {
         broadUnregisters += 1
         return true
@@ -103,11 +106,105 @@ describe("preventLegacyServiceWorkerCaching", () => {
 
     const res = await preventLegacyServiceWorkerCaching()
 
-    expect(res).toEqual({ registrations: 1, unregistered: 1, caches: 2 })
+    expect(res).toEqual({ registrations: 2, unregistered: 2, caches: 2 })
     expect(currentUnregisters).toBe(1)
-    expect(broadUnregisters).toBe(0)
+    expect(broadUnregisters).toBe(1)
     expect(otherUnregisters).toBe(0)
     expect(deleted).toEqual(["workbox-runtime-v1", "opencode-precache-v2"])
+  })
+
+  test("keeps non-legacy workers when there are no legacy caches", async () => {
+    let currentUnregisters = 0
+    let broadUnregisters = 0
+
+    const current = {
+      scope: "https://example.test/notebook/ns/a/",
+      active: { scriptURL: "https://example.test/sw.js" },
+      unregister: async () => {
+        currentUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
+    const broad = {
+      scope: "https://example.test/",
+      active: { scriptURL: "https://example.test/sw.js" },
+      unregister: async () => {
+        broadUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
+    const navigator = {
+      serviceWorker: {
+        getRegistrations: async () => [current, broad],
+      },
+    } as Navigator
+
+    const cacheStorage = {
+      keys: async () => ["misc-cache"],
+      delete: async () => true,
+    } as unknown as CacheStorage
+
+    globals.window = {
+      location: { href: "https://example.test/notebook/ns/a/session" },
+      caches: cacheStorage,
+    } as unknown as Window & typeof globalThis
+    globals.navigator = navigator
+    globals.caches = cacheStorage
+
+    const res = await preventLegacyServiceWorkerCaching()
+
+    expect(res).toEqual({ registrations: 0, unregistered: 0, caches: 0 })
+    expect(currentUnregisters).toBe(0)
+    expect(broadUnregisters).toBe(0)
+  })
+
+  test("unregisters legacy script workers that control app scope", async () => {
+    let broadUnregisters = 0
+    let nonLegacyUnregisters = 0
+
+    const broadLegacy = {
+      scope: "https://example.test/",
+      active: { scriptURL: "https://example.test/assets/workbox-sw.js" },
+      unregister: async () => {
+        broadUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
+    const appNonLegacy = {
+      scope: "https://example.test/notebook/ns/a/",
+      active: { scriptURL: "https://example.test/sw.js" },
+      unregister: async () => {
+        nonLegacyUnregisters += 1
+        return true
+      },
+    } as ServiceWorkerRegistration
+
+    const navigator = {
+      serviceWorker: {
+        getRegistrations: async () => [broadLegacy, appNonLegacy],
+      },
+    } as Navigator
+
+    const cacheStorage = {
+      keys: async () => ["misc-cache"],
+      delete: async () => true,
+    } as unknown as CacheStorage
+
+    globals.window = {
+      location: { href: "https://example.test/notebook/ns/a/session" },
+      caches: cacheStorage,
+    } as unknown as Window & typeof globalThis
+    globals.navigator = navigator
+    globals.caches = cacheStorage
+
+    const res = await preventLegacyServiceWorkerCaching()
+
+    expect(res).toEqual({ registrations: 1, unregistered: 1, caches: 0 })
+    expect(broadUnregisters).toBe(1)
+    expect(nonLegacyUnregisters).toBe(0)
   })
 
   test("clears legacy caches from window when global caches is unavailable", async () => {

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -75,6 +75,18 @@ let lastActivity = Date.now()
 // Store for backend WebSocket connections (keyed by client WebSocket)
 const backendConnections = new WeakMap<object, WebSocket>()
 
+function withNoStoreHeaders(response: Response) {
+  const headers = new Headers(response.headers)
+  headers.set("Cache-Control", "no-store")
+  headers.set("Pragma", "no-cache")
+  headers.set("Expires", "0")
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
 const server = Bun.serve<{ path: string; search: string }>({
   port: PORT,
   hostname: "0.0.0.0",
@@ -142,7 +154,7 @@ const server = Bun.serve<{ path: string; search: string }>({
 
     // Extended API endpoints (handled locally, not proxied)
     const extResponse = await handleExtendedEndpoint(path, req.method, url, req)
-    if (extResponse) return extResponse
+    if (extResponse) return withNoStoreHeaders(extResponse)
 
     // Check if this is an API request (after stripping prefix)
     if (isApiPath(path)) {
@@ -167,7 +179,9 @@ const server = Bun.serve<{ path: string; search: string }>({
             status: response.status,
             headers: {
               "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
+              "Cache-Control": "no-store",
+              Pragma: "no-cache",
+              Expires: "0",
               Connection: "keep-alive",
               "X-Accel-Buffering": "no",
             },
@@ -187,7 +201,7 @@ const server = Bun.serve<{ path: string; search: string }>({
           headers,
           body,
         })
-        return normalizeProxiedResponse(response)
+        return withNoStoreHeaders(normalizeProxiedResponse(response))
       } catch (e) {
         console.error("[Proxy] API error:", e)
         return new Response("API proxy error", { status: 502 })

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -172,7 +172,13 @@ const server = Bun.serve<{ path: string; search: string }>({
 
           if (!response.ok) {
             console.error("[Proxy] SSE error:", response.status, response.statusText)
-            return new Response(response.body, { status: response.status })
+            return withNoStoreHeaders(
+              new Response(response.body, {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+              }),
+            )
           }
 
           return new Response(response.body, {
@@ -188,7 +194,7 @@ const server = Bun.serve<{ path: string; search: string }>({
           })
         } catch (e) {
           console.error("[Proxy] SSE connection error:", e)
-          return new Response("SSE proxy error", { status: 502 })
+          return withNoStoreHeaders(new Response("SSE proxy error", { status: 502 }))
         }
       }
 
@@ -204,7 +210,7 @@ const server = Bun.serve<{ path: string; search: string }>({
         return withNoStoreHeaders(normalizeProxiedResponse(response))
       } catch (e) {
         console.error("[Proxy] API error:", e)
-        return new Response("API proxy error", { status: 502 })
+        return withNoStoreHeaders(new Response("API proxy error", { status: 502 }))
       }
     }
 


### PR DESCRIPTION
## Summary
- unregisters legacy in-scope service workers on app startup and clears legacy Workbox/OpenCode runtime caches
- marks proxied API and SSE responses as no-store in both dev and production servers to avoid stale cache reuse
- surfaces actionable session bootstrap errors in the sidebar with a retry action and adds regression coverage for service-worker cleanup

Closes #363