### PR TITLE
feat: drag-and-drop queued followup reordering

### DIFF
--- a/app-prefixable/src/components/followup-dock.tsx
+++ b/app-prefixable/src/components/followup-dock.tsx
@@ -1,6 +1,15 @@
 import { For, Show, createMemo, createSignal, createUniqueId } from "solid-js";
-import { ChevronDown } from "lucide-solid";
+import { ChevronDown, GripVertical } from "lucide-solid";
+import {
+  DragDropProvider,
+  DragDropSensors,
+  SortableProvider,
+  closestCenter,
+  createSortable,
+} from "@thisbeyond/solid-dnd";
+import type { DragEvent as SolidDragEvent } from "@thisbeyond/solid-dnd";
 import { Button } from "./ui/button";
+import { ConstrainDragXAxis } from "../utils/solid-dnd";
 
 export function FollowupDock(props: {
   items: { id: string; text: string }[];
@@ -14,8 +23,10 @@ export function FollowupDock(props: {
   onDelete: (id: string) => void;
   onMoveUp: (id: string) => void;
   onMoveDown: (id: string) => void;
+  onReorder: (from: string, to: string) => void;
 }) {
   const [collapsed, setCollapsed] = createSignal(true);
+  const [dragId, setDragId] = createSignal<string | null>(null);
   const contentId = `followup-dock-${createUniqueId()}`;
   const count = createMemo(() => props.items.length);
   const hasItems = createMemo(() => count() > 0);
@@ -27,6 +38,21 @@ export function FollowupDock(props: {
 
   function toggle() {
     setCollapsed((v) => !v);
+  }
+
+  function handleDragStart(event: SolidDragEvent) {
+    setDragId(event.draggable ? String(event.draggable.id) : null);
+  }
+
+  function handleDragEnd(event: SolidDragEvent) {
+    setDragId(null);
+    const { draggable, droppable } = event;
+    if (!draggable || !droppable) return;
+    const from = String(draggable.id);
+    const to = String(droppable.id);
+    if (from === to) return;
+    if (props.sending === from) return;
+    props.onReorder(from, to);
   }
 
   return (
@@ -88,76 +114,103 @@ export function FollowupDock(props: {
       </div>
 
       <Show when={hasItems() && !collapsed()}>
-        <div
-          id={contentId}
-          class="px-3 pb-3 pt-1 flex flex-col gap-2 max-h-44 overflow-y-auto"
-          role="region"
-          aria-label="Queued followup messages"
+        <DragDropProvider
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          collisionDetector={closestCenter}
         >
-          <For each={props.items}>
-            {(item, i) => {
-              const sending = () => props.sending === item.id;
-              const first = () => i() === 0;
-              const last = () => i() === props.items.length - 1;
-              return (
-                <div class="flex items-center gap-2 min-w-0">
-                  <span class="text-sm truncate flex-1" style={{ color: "var(--text-base)" }}>
-                    {item.text}
-                  </span>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    disabled={sending() || first()}
-                    aria-label="Move followup up"
-                    title="Move followup up"
-                    onClick={() => props.onMoveUp(item.id)}
-                  >
-                    Up
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    disabled={sending() || last()}
-                    aria-label="Move followup down"
-                    title="Move followup down"
-                    onClick={() => props.onMoveDown(item.id)}
-                  >
-                    Down
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    disabled={busy()}
-                    onClick={() => props.onSend(item.id)}
-                  >
-                    Send now
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    disabled={sending()}
-                    onClick={() => props.onEdit(item.id)}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    disabled={sending()}
-                    onClick={() => props.onDelete(item.id)}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              );
-            }}
-          </For>
-        </div>
+          <DragDropSensors />
+          <ConstrainDragXAxis />
+          <SortableProvider ids={props.items.map((item) => item.id)}>
+            <div
+              id={contentId}
+              class="px-3 pb-3 pt-1 flex flex-col gap-2 max-h-44 overflow-y-auto"
+              role="region"
+              aria-label="Queued followup messages"
+            >
+              <For each={props.items}>
+                {(item, i) => {
+                  const sortable = createSortable(item.id);
+                  const sending = () => props.sending === item.id;
+                  const first = () => i() === 0;
+                  const last = () => i() === props.items.length - 1;
+                  return (
+                    <div
+                      use:sortable={sortable}
+                      class="flex items-center gap-2 min-w-0"
+                      classList={{
+                        "opacity-40": dragId() === item.id,
+                      }}
+                    >
+                      <button
+                        type="button"
+                        class="shrink-0 flex items-center cursor-grab active:cursor-grabbing p-0 border-0 bg-transparent"
+                        aria-label="Drag to reorder followup"
+                        title="Drag to reorder followup"
+                        disabled={sending()}
+                        {...(sending() ? {} : sortable.dragActivators)}
+                      >
+                        <GripVertical class="w-4 h-4" style={{ color: "var(--icon-weak)" }} />
+                      </button>
+                      <span class="text-sm truncate flex-1" style={{ color: "var(--text-base)" }}>
+                        {item.text}
+                      </span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={sending() || first()}
+                        aria-label="Move followup up"
+                        title="Move followup up"
+                        onClick={() => props.onMoveUp(item.id)}
+                      >
+                        Up
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={sending() || last()}
+                        aria-label="Move followup down"
+                        title="Move followup down"
+                        onClick={() => props.onMoveDown(item.id)}
+                      >
+                        Down
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        disabled={busy()}
+                        onClick={() => props.onSend(item.id)}
+                      >
+                        Send now
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={sending()}
+                        onClick={() => props.onEdit(item.id)}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={sending()}
+                        onClick={() => props.onDelete(item.id)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  );
+                }}
+              </For>
+            </div>
+          </SortableProvider>
+        </DragDropProvider>
       </Show>
     </div>
   );

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -522,6 +522,20 @@ export function Session() {
     setSessionFollowups(sid, next);
   }
 
+  function reorderFollowup(from: string, to: string) {
+    const sid = sessionId();
+    if (!sid) return;
+    if (from === to) return;
+    const list = followups();
+    const fromIndex = list.findIndex((item) => item.id === from);
+    const toIndex = list.findIndex((item) => item.id === to);
+    if (fromIndex < 0 || toIndex < 0) return;
+    const next = [...list];
+    next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, list[fromIndex]);
+    setSessionFollowups(sid, next);
+  }
+
   // Double-Escape to abort: track last Escape press timestamp
   const lastEsc = { ts: 0 };
 
@@ -2799,6 +2813,7 @@ export function Session() {
                 onDelete={removeFollowup}
                 onMoveUp={(id) => moveFollowup(id, -1)}
                 onMoveDown={(id) => moveFollowup(id, 1)}
+                onReorder={reorderFollowup}
               />
             </Show>
           </div>


### PR DESCRIPTION
## Summary
- add drag-and-drop sorting in the queued followup dock using the existing Solid DnD stack
- keep Up/Down button fallback controls for keyboard and non-drag usage
- persist reordered queue state through existing followup session storage behavior

Closes #356