### PR TITLE
fix: sync Telegram alarms across directories and preserve latest tool states

### DIFF
--- a/app-prefixable/src/components/telegram-settings.tsx
+++ b/app-prefixable/src/components/telegram-settings.tsx
@@ -274,7 +274,7 @@ export function TelegramSettings(props: Props) {
                   <p>Config: {report().config.status === "ok" ? "loaded" : "invalid"}</p>
                   <p>Telegram API: {report().dependencies.telegramApi.status} - {report().dependencies.telegramApi.message}</p>
                   <p>OpenCode API: {report().dependencies.openCodeApi.status} - {report().dependencies.openCodeApi.message}</p>
-                  <Show when={(report().dependencies.openCodeSources || []).length > 0}>
+                  <Show when={(report().dependencies.openCodeSources || []).length > 1}>
                     <div class="space-y-1 pt-1">
                       {(report().dependencies.openCodeSources || []).map((item) => (
                         <p>Source {item.sourceId}: {item.status} - {item.message}</p>

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -58,6 +58,70 @@ function sortParts(parts: Part[]): Part[] {
   return [...withId, ...withoutId]
 }
 
+function toolEnd(part: Extract<Part, { type: "tool" }>): number {
+  const state = part.state
+  if (state.status === "completed") return state.time.end
+  if (state.status === "error") return state.time.end
+  return 0
+}
+
+function toolStart(part: Extract<Part, { type: "tool" }>): number {
+  const state = part.state
+  if (state.status === "running") return state.time.start
+  if (state.status === "completed") return state.time.start
+  if (state.status === "error") return state.time.start
+  return 0
+}
+
+function toolRank(part: Extract<Part, { type: "tool" }>): number {
+  const state = part.state
+  if (state.status === "pending") return 1
+  if (state.status === "running") return 2
+  return 3
+}
+
+function mergePart(existing: Part, synced: Part): Part {
+  if (existing.type !== "tool") return synced
+  if (synced.type !== "tool") return synced
+
+  const existingEnd = toolEnd(existing)
+  const syncedEnd = toolEnd(synced)
+  if (existingEnd > syncedEnd) return existing
+  if (syncedEnd > existingEnd) return synced
+
+  const existingStart = toolStart(existing)
+  const syncedStart = toolStart(synced)
+  if (existingStart > syncedStart) return existing
+  if (syncedStart > existingStart) return synced
+
+  const existingRank = toolRank(existing)
+  const syncedRank = toolRank(synced)
+  if (existingRank > syncedRank) return existing
+  if (syncedRank > existingRank) return synced
+
+  return synced
+}
+
+function mergeMessage(existing: MessageWithParts, synced: MessageWithParts): MessageWithParts {
+  const map = new Map(existing.parts.map((part) => [part.id, part]))
+  const merged = synced.parts.map((part) => {
+    const current = map.get(part.id)
+    if (!current) return part
+    return mergePart(current, part)
+  })
+  const ids = new Set(merged.map((part) => part.id))
+
+  for (const part of existing.parts) {
+    if (ids.has(part.id)) continue
+    merged.push(part)
+  }
+
+  return {
+    info: synced.info,
+    parts: sortParts(merged),
+  }
+}
+
 function errorText(err: unknown) {
   if (err instanceof Error && err.message.trim()) return err.message
   return "Failed to bootstrap app state from API."
@@ -405,19 +469,18 @@ export function SyncProvider(props: ParentProps) {
             setStore("message", sessionID, (existing: MessageWithParts[]) => {
               if (!existing || existing.length === 0) return synced
 
-              // Merge: use existing message if it has more recent parts
-              const merged = synced.map((s) => {
-                const e = existing.find((m) => m.info.id === s.info.id)
-                if (!e) return s
-                // Keep existing if it has more parts (SSE updates arrived)
-                return e.parts.length >= s.parts.length ? e : s
+              const map = new Map(existing.map((msg) => [msg.info.id, msg]))
+              const merged = synced.map((msg) => {
+                const current = map.get(msg.info.id)
+                if (!current) return msg
+                return mergeMessage(current, msg)
               })
+              const ids = new Set(merged.map((msg) => msg.info.id))
 
               // Add any messages from existing that aren't in synced (new SSE messages)
-              for (const e of existing) {
-                if (!merged.find((m) => m.info.id === e.info.id)) {
-                  merged.push(e)
-                }
+              for (const msg of existing) {
+                if (ids.has(msg.info.id)) continue
+                merged.push(msg)
               }
 
               return merged.sort((a, b) => cmp(a.info.id, b.info.id))

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -56,7 +56,7 @@ import {
   writeNotifyMap,
   writeNotifySessionEnabled,
 } from "../utils/notify";
-import { getSessionAlarm, resolveTelegramSourceId, setSessionAlarm } from "../utils/extended-api";
+import { getSessionAlarm, setSessionAlarm } from "../utils/extended-api";
 import { sessionQuestionRequest } from "../utils/session-tree-request";
 import { createRootSession } from "../utils/root-session";
 import {
@@ -560,29 +560,13 @@ export function Session() {
     })(),
   );
   const [notifyDenied, setNotifyDenied] = createSignal(false);
-  const [notifySourceId, setNotifySourceId] = createSignal<string | undefined>();
-  const [notifySourceReady, setNotifySourceReady] = createSignal(false);
   const notifyVersion = { value: 0 };
   const deniedTimer = { id: null as ReturnType<typeof setTimeout> | null };
   onCleanup(() => { if (deniedTimer.id !== null) clearTimeout(deniedTimer.id) });
 
-  createEffect(() => {
-    const dir = directory || base64Decode(params.dir);
-    setNotifySourceReady(false);
-    let cancelled = false;
-    onCleanup(() => { cancelled = true });
-    resolveTelegramSourceId(url, dir).then((sourceId) => {
-      if (cancelled) return;
-      setNotifySourceId(sourceId);
-      setNotifySourceReady(true);
-    });
-  });
-
   // Re-read notification state when session changes, and seed from server alarm state
   createEffect(() => {
     const id = params.id;
-    const sourceReady = notifySourceReady();
-    const sourceId = notifySourceId();
     const dir = directory || base64Decode(params.dir);
     setNotifyDenied(false);
     if (!id) {
@@ -595,13 +579,12 @@ export function Session() {
     if (migrated) writeNotifyMap(map);
     const local = notifyEnabledForSession(map, id, dir);
     setNotifyEnabled(local);
-    if (!sourceReady) return;
     // Cancellation flag for stale responses
     let cancelled = false;
     const version = notifyVersion.value;
     onCleanup(() => { cancelled = true });
     // Then fetch server-side alarm state asynchronously
-    getSessionAlarm(url, id, sourceId).then((state) => {
+    getSessionAlarm(url, id).then((state) => {
       // Skip if effect was cleaned up, session changed, or local state was updated
       if (cancelled || !state || params.id !== id) return;
       if (notifyVersion.value !== version) return;
@@ -615,20 +598,15 @@ export function Session() {
 
   /** Mirror bell toggle to server-side alarm state (fire-and-forget). */
   function syncAlarmToServer(id: string, enabled: boolean) {
-    const sourceId = notifySourceId();
-    if (sourceId) {
-      setSessionAlarm(url, id, enabled, sourceId);
-      return;
-    }
-    const dir = directory || base64Decode(params.dir);
-    resolveTelegramSourceId(url, dir).then((resolved) => {
-      if (resolved) {
-        setNotifySourceId(resolved);
-        setSessionAlarm(url, id, enabled, resolved);
-        return;
+    const dir = directory || base64Decode(params.dir)
+    console.log("[session] syncing telegram session alarm", { sessionId: id, enabled, directory: dir })
+    setSessionAlarm(url, id, enabled, undefined, dir).then((ok) => {
+      if (ok) {
+        console.log("[session] telegram session alarm synced", { sessionId: id, enabled, directory: dir })
+        return
       }
-      console.warn("[session] skip setSessionAlarm: telegram source id unresolved", { id, dir });
-    });
+      console.warn("[session] telegram session alarm sync failed", { sessionId: id, enabled, directory: dir })
+    })
   }
 
   function toggleNotify() {

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -56,7 +56,7 @@ import {
   writeNotifyMap,
   writeNotifySessionEnabled,
 } from "../utils/notify";
-import { getSessionAlarm, setSessionAlarm } from "../utils/extended-api";
+import { getSessionAlarm, resolveTelegramSourceId, setSessionAlarm } from "../utils/extended-api";
 import { sessionQuestionRequest } from "../utils/session-tree-request";
 import { createRootSession } from "../utils/root-session";
 import {
@@ -584,29 +584,33 @@ export function Session() {
     const version = notifyVersion.value;
     onCleanup(() => { cancelled = true });
     // Then fetch server-side alarm state asynchronously
-    getSessionAlarm(url, id).then((state) => {
-      // Skip if effect was cleaned up, session changed, or local state was updated
-      if (cancelled || !state || params.id !== id) return;
-      if (notifyVersion.value !== version) return;
-      setNotifyEnabled(state.enabled);
-      // Sync localStorage to match server truth
-      const map = readNotifyMap();
-      writeNotifySessionEnabled(map, id, state.enabled, dir);
-      writeNotifyMap(map);
-    });
+    resolveTelegramSourceId(url, dir)
+      .then((sourceId) => getSessionAlarm(url, id, sourceId))
+      .then((state) => {
+        // Skip if effect was cleaned up, session changed, or local state was updated
+        if (cancelled || !state || params.id !== id) return;
+        if (notifyVersion.value !== version) return;
+        setNotifyEnabled(state.enabled);
+        // Sync localStorage to match server truth
+        const map = readNotifyMap();
+        writeNotifySessionEnabled(map, id, state.enabled, dir);
+        writeNotifyMap(map);
+      });
   });
 
   /** Mirror bell toggle to server-side alarm state (fire-and-forget). */
   function syncAlarmToServer(id: string, enabled: boolean) {
     const dir = directory || base64Decode(params.dir)
     console.log("[session] syncing telegram session alarm", { sessionId: id, enabled, directory: dir })
-    setSessionAlarm(url, id, enabled, undefined, dir).then((ok) => {
-      if (ok) {
-        console.log("[session] telegram session alarm synced", { sessionId: id, enabled, directory: dir })
-        return
-      }
-      console.warn("[session] telegram session alarm sync failed", { sessionId: id, enabled, directory: dir })
-    })
+    resolveTelegramSourceId(url, dir)
+      .then((sourceId) => setSessionAlarm(url, id, enabled, sourceId, dir))
+      .then((ok) => {
+        if (ok) {
+          console.log("[session] telegram session alarm synced", { sessionId: id, enabled, directory: dir })
+          return
+        }
+        console.warn("[session] telegram session alarm sync failed", { sessionId: id, enabled, directory: dir })
+      })
   }
 
   function toggleNotify() {

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -138,7 +138,6 @@ export function Settings() {
   async function toggleTelegramAlarmChannel() {
     if (telegramAlarmSaving()) return
     const current = alarmChannels().telegram
-    if (!telegramAlarmReady() && !current) return
 
     setTelegramAlarmSaving(true)
     const target = !current
@@ -2458,7 +2457,7 @@ Add your project-specific instructions here.
                     <button
                       type="button"
                       onClick={() => void toggleTelegramAlarmChannel()}
-                      disabled={telegramAlarmSaving() || (!telegramAlarmReady() && !alarmChannels().telegram)}
+                      disabled={telegramAlarmSaving()}
                       class="relative w-10 h-5 rounded-full transition-colors disabled:opacity-50"
                       style={{
                         background: alarmChannels().telegram ? "var(--interactive-base)" : "var(--surface-inset)",

--- a/app-prefixable/src/utils/extended-api.ts
+++ b/app-prefixable/src/utils/extended-api.ts
@@ -314,12 +314,21 @@ export async function getSessionAlarm(serverUrl: string, sessionId: string, sour
 }
 
 /** Update session alarm state on the server (Telegram bridge). Returns true on success. */
-export async function setSessionAlarm(serverUrl: string, sessionId: string, enabled: boolean, sourceId?: string): Promise<boolean> {
+export async function setSessionAlarm(
+  serverUrl: string,
+  sessionId: string,
+  enabled: boolean,
+  sourceId?: string,
+  directory?: string,
+): Promise<boolean> {
   const source = sourceId?.trim()
+  const dir = directory?.trim()
+  const base = source ? { sessionId, sourceId: source, enabled } : { sessionId, enabled }
+  const body = dir ? { ...base, directory: dir } : base
   const res = await fetch(`${serverUrl}/api/ext/telegram/session-alarm`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(source ? { sessionId, sourceId: source, enabled } : { sessionId, enabled }),
+    body: JSON.stringify(body),
   }).catch(() => null)
   if (!res) {
     console.warn("[extended-api] setSessionAlarm: network error for session", sessionId)

--- a/app-prefixable/tests/telegram-bridge.test.ts
+++ b/app-prefixable/tests/telegram-bridge.test.ts
@@ -369,7 +369,7 @@ describe("telegram bridge config and cache", () => {
       expect(report.status).toBe("healthy");
       expect(report.dependencies.telegramApi.status).toBe("ok");
       expect(report.dependencies.openCodeApi.status).toBe("ok");
-      expect(report.dependencies.openCodeApi.message).toBe("OpenCode API is reachable for sources: default");
+      expect(report.dependencies.openCodeApi.message).toBe("OpenCode API is reachable");
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -558,7 +558,7 @@ describe("telegram bridge config and cache", () => {
       expect(report.status).toBe("degraded");
       expect(report.dependencies.telegramApi.status).toBe("error");
       expect(report.dependencies.openCodeApi.status).toBe("ok");
-      expect(report.dependencies.openCodeApi.message).toBe("OpenCode API is reachable for sources: default");
+      expect(report.dependencies.openCodeApi.message).toBe("OpenCode API is reachable");
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/shared/extended-api.ts
+++ b/shared/extended-api.ts
@@ -132,11 +132,7 @@ async function enableTelegramNotifyForSession(store: TelegramSessionStore, sessi
   if (!store.sessionKeys || !store.notificationSet) {
     return { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
   }
-  const mappedKeys = await store.sessionKeys(sessionId)
-  const fallbackKeys = !mappedKeys.length && store.sessionMapKeys
-    ? await store.sessionMapKeys()
-    : []
-  const keys = mappedKeys.length ? mappedKeys : fallbackKeys
+  const keys = await store.sessionKeys(sessionId)
   if (!keys.length) {
     return { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
   }
@@ -151,9 +147,9 @@ async function enableTelegramNotifyForSession(store: TelegramSessionStore, sessi
   }
   return {
     mappedChats: chats.size,
-    sessionKeys: mappedKeys.length,
-    fallbackSessionKeys: mappedKeys.length ? 0 : fallbackKeys.length,
-    usedFallback: !mappedKeys.length && fallbackKeys.length > 0,
+    sessionKeys: keys.length,
+    fallbackSessionKeys: 0,
+    usedFallback: false,
   }
 }
 

--- a/shared/extended-api.ts
+++ b/shared/extended-api.ts
@@ -129,9 +129,17 @@ function notifyChatKeyFromSessionKey(value: string) {
 }
 
 async function enableTelegramNotifyForSession(store: TelegramSessionStore, sessionId: string) {
-  if (!store.sessionKeys || !store.notificationSet) return
-  const keys = await store.sessionKeys(sessionId)
-  if (!keys.length) return
+  if (!store.sessionKeys || !store.notificationSet) {
+    return { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
+  }
+  const mappedKeys = await store.sessionKeys(sessionId)
+  const fallbackKeys = !mappedKeys.length && store.sessionMapKeys
+    ? await store.sessionMapKeys()
+    : []
+  const keys = mappedKeys.length ? mappedKeys : fallbackKeys
+  if (!keys.length) {
+    return { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
+  }
   const chats = new Set<string>()
   for (const key of keys) {
     const chatKey = notifyChatKeyFromSessionKey(key)
@@ -140,6 +148,12 @@ async function enableTelegramNotifyForSession(store: TelegramSessionStore, sessi
   }
   for (const chatKey of chats) {
     await store.notificationSet(chatKey, true)
+  }
+  return {
+    mappedChats: chats.size,
+    sessionKeys: mappedKeys.length,
+    fallbackSessionKeys: mappedKeys.length ? 0 : fallbackKeys.length,
+    usedFallback: !mappedKeys.length && fallbackKeys.length > 0,
   }
 }
 
@@ -525,6 +539,35 @@ async function queryTelegramBridgeHealth(port: number): Promise<TelegramBridgeHe
   return res.json().catch(() => undefined)
 }
 
+async function updateTelegramBridgeSessionAlarm(
+  port: number,
+  ref: { sessionId: string; sourceId: string; scopedSessionId: string },
+  enabled: boolean,
+  directory?: string,
+) {
+  const timeoutMs = 2_500
+  const payload: Record<string, unknown> = {
+    sessionId: ref.sessionId,
+    enabled,
+  }
+  if (ref.sourceId !== "default") {
+    payload.sourceId = ref.sourceId
+  }
+  if (directory?.trim()) {
+    payload.directory = directory.trim()
+  }
+  const res = await fetch(`http://127.0.0.1:${port}/session-alarm`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(timeoutMs),
+  }).catch(() => undefined)
+  if (!res?.ok) return
+  const data = await res.json().catch(() => undefined) as { enabled?: unknown } | undefined
+  if (typeof data?.enabled !== "boolean") return
+  return data
+}
+
 interface StoredPrompt {
   id: string
   title: string
@@ -767,9 +810,25 @@ export async function handleExtendedEndpoint(
     const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : ""
     const sourceId = typeof payload?.sourceId === "string" ? payload.sourceId : ""
     const scopedSessionId = typeof payload?.scopedSessionId === "string" ? payload.scopedSessionId : ""
+    const directory = typeof payload?.directory === "string" ? payload.directory : ""
     const enabled = payload?.enabled
+    console.log("[TelegramBridge] session alarm endpoint hit", {
+      sessionId,
+      sourceId,
+      scopedSessionId,
+      directory,
+      enabled,
+      payloadValid: Boolean(payload),
+    })
     const parsed = sessionAlarmRefFromInput({ sessionId, sourceId, scopedSessionId })
     if (!parsed.ref) {
+      console.warn("[TelegramBridge] session alarm request rejected", {
+        sessionId,
+        sourceId,
+        scopedSessionId,
+        enabled,
+        error: parsed.error || "invalid request",
+      })
       return Response.json({ error: parsed.error || "invalid request" }, { status: 400 })
     }
     const ref = parsed.ref
@@ -793,6 +852,12 @@ export async function handleExtendedEndpoint(
         { status: 501 },
       )
     }
+    console.log("[TelegramBridge] session alarm write requested", {
+      sessionId: ref.sessionId,
+      sourceId: ref.sourceId,
+      scopedSessionId: ref.scopedSessionId,
+      enabled,
+    })
     const ok = await store.sessionAlarmSet(ref.scopedSessionId, enabled).then(
       () => true,
       (error) => {
@@ -803,13 +868,52 @@ export async function handleExtendedEndpoint(
     if (ok === false) {
       return Response.json({ error: "failed to update telegram session alarm" }, { status: 500 })
     }
+    console.log("[TelegramBridge] session alarm write applied", {
+      sessionId: ref.sessionId,
+      sourceId: ref.sourceId,
+      scopedSessionId: ref.scopedSessionId,
+      enabled,
+    })
+    console.log(`[TelegramBridge] session alarm ${enabled ? "enabled" : "disabled"}`, {
+      sessionId: ref.sessionId,
+      sourceId: ref.sourceId,
+      scopedSessionId: ref.scopedSessionId,
+    })
+    const sourceExplicit = Boolean(sourceId.trim() || scopedSessionId.trim())
     if (enabled) {
-      await enableTelegramNotifyForSession(store, ref.scopedSessionId).catch((error) => {
+      const sync = await enableTelegramNotifyForSession(store, ref.scopedSessionId).catch((error) => {
         console.error("[ExtAPI] telegram notify sync on session alarm enable failed", {
           sessionId: ref.sessionId,
           sourceId: ref.sourceId,
           error,
         })
+        return null
+      })
+      console.log("[TelegramBridge] session alarm registered", {
+        sessionId: ref.sessionId,
+        sourceId: ref.sourceId,
+        scopedSessionId: ref.scopedSessionId,
+        sourceExplicit,
+        mappedChats: sync?.mappedChats ?? 0,
+        sessionKeys: sync?.sessionKeys ?? 0,
+        fallbackSessionKeys: sync?.fallbackSessionKeys ?? 0,
+        usedFallback: sync?.usedFallback ?? false,
+      })
+      if (!sourceExplicit && settings.settings.multiSourceEnabled) {
+        console.warn("[TelegramBridge] session alarm registered with implicit default source while multi-source is enabled", {
+          sessionId: ref.sessionId,
+          scopedSessionId: ref.scopedSessionId,
+        })
+      }
+    }
+    const bridgePort = restartProbePort(null, settings)
+    const bridge = await updateTelegramBridgeSessionAlarm(bridgePort, ref, enabled, directory)
+    if (bridge && typeof bridge.enabled === "boolean") {
+      console.log("[ExtAPI] session alarm write forwarded to bridge", {
+        sessionId: ref.sessionId,
+        sourceId: ref.sourceId,
+        scopedSessionId: ref.scopedSessionId,
+        enabled: bridge.enabled,
       })
     }
     return Response.json({ sessionId: ref.sessionId, sourceId: ref.sourceId, enabled })

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -148,6 +148,10 @@ export function allowTelegramHealthRequest(address: string | undefined): boolean
   return isLocalAddress(address)
 }
 
+function allowSessionAlarmRequest(address: string | undefined): boolean {
+  return isLocalAddress(address)
+}
+
 type TelegramCommand = {
   name: string
   text: string
@@ -240,6 +244,10 @@ function sessionAlarmSessionIdError(sessionId: string): string | undefined {
 
 function sessionAlarmSourceIdError(sourceId: string): string | undefined {
   if (!sourceId) return "sourceId is required"
+  if (sourceId === "default") return
+  if (sourceId.toLowerCase() === "default") {
+    return 'sourceId is reserved; use exact "default" or choose another id'
+  }
   if (sourceId.length > 128) return "sourceId must be 128 characters or fewer"
   if (!/^[a-zA-Z0-9._-]+$/.test(sourceId)) return "sourceId contains unsupported characters"
 }
@@ -249,6 +257,10 @@ function parseSessionAlarmRef(input: { sessionId: string; sourceId: string; scop
   if (scoped) {
     const decoded = decodeSessionRef(scoped)
     if (!decoded) return { error: "scopedSessionId is invalid" }
+    const sourceIdError = sessionAlarmSourceIdError(decoded.sourceId)
+    if (sourceIdError) return { error: sourceIdError }
+    const sessionIdError = sessionAlarmSessionIdError(decoded.sessionId)
+    if (sessionIdError) return { error: sessionIdError }
     const mismatch = input.sessionId.trim() && input.sessionId.trim() !== decoded.sessionId
     if (mismatch) return { error: "sessionId does not match scopedSessionId" }
     return { ref: { sourceId: decoded.sourceId, sessionId: decoded.sessionId, scopedSessionId: sourceScopedId(decoded.sourceId, decoded.sessionId) } }
@@ -266,11 +278,7 @@ async function enableAlarmTargets(runtime: Runtime, scopedSessionId: string): Pr
   if (!runtime.store.sessionKeys || !runtime.store.notificationSet) {
     return { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
   }
-  const mappedKeys = await runtime.store.sessionKeys(scopedSessionId)
-  const fallbackKeys = !mappedKeys.length && runtime.store.sessionMapKeys
-    ? await runtime.store.sessionMapKeys()
-    : []
-  const keys = mappedKeys.length ? mappedKeys : fallbackKeys
+  const keys = await runtime.store.sessionKeys(scopedSessionId)
   if (!keys.length) {
     return { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
   }
@@ -285,9 +293,9 @@ async function enableAlarmTargets(runtime: Runtime, scopedSessionId: string): Pr
   }
   return {
     mappedChats: chats.size,
-    sessionKeys: mappedKeys.length,
-    fallbackSessionKeys: mappedKeys.length ? 0 : fallbackKeys.length,
-    usedFallback: !mappedKeys.length && fallbackKeys.length > 0,
+    sessionKeys: keys.length,
+    fallbackSessionKeys: 0,
+    usedFallback: false,
   }
 }
 
@@ -3964,11 +3972,14 @@ export function runPollingHealthServer(runtime: Runtime): boolean {
       hostname: host,
       async fetch(req, server) {
         const url = new URL(req.url)
+        if (url.pathname === "/session-alarm" && (req.method === "GET" || req.method === "PUT")) {
+          if (!allowSessionAlarmRequest(server.requestIP(req)?.address)) {
+            return new Response("Not Found", { status: 404 })
+          }
+          return handleSessionAlarmEndpoint(runtime, req, url)
+        }
         if (!allowTelegramHealthRequest(server.requestIP(req)?.address)) {
           return new Response("Not Found", { status: 404 })
-        }
-        if (url.pathname === "/session-alarm" && (req.method === "GET" || req.method === "PUT")) {
-          return handleSessionAlarmEndpoint(runtime, req, url)
         }
         if (req.method !== "GET" || url.pathname !== "/health") {
           return new Response("Not Found", { status: 404 })
@@ -4009,7 +4020,7 @@ async function runWebhook(runtime: Runtime) {
         return Response.json(report)
       }
       if (url.pathname === "/session-alarm" && (req.method === "GET" || req.method === "PUT")) {
-        if (!allowTelegramHealthRequest(server.requestIP(req)?.address)) {
+        if (!allowSessionAlarmRequest(server.requestIP(req)?.address)) {
           return new Response("Not Found", { status: 404 })
         }
         return handleSessionAlarmEndpoint(runtime, req, url)

--- a/shared/telegram-bridge.ts
+++ b/shared/telegram-bridge.ts
@@ -58,6 +58,7 @@ type Runtime = {
   sourceById?: Map<string, SourceConfig>
   defaultSourceId?: string
   store: ReturnType<typeof createTelegramSessionStore>
+  outboundStreams?: Set<string>
 }
 
 type SourceConfig = {
@@ -117,6 +118,7 @@ type CachedSession = {
 type CachedSessionInfo = {
   exists: boolean
   title: string | null
+  directory: string | null
   expiresAt: number
 }
 
@@ -163,6 +165,13 @@ type SavedPrompt = {
 type SessionRef = {
   sourceId: string
   sessionId: string
+}
+
+type SessionAlarmResult = {
+  mappedChats: number
+  sessionKeys: number
+  fallbackSessionKeys: number
+  usedFallback: boolean
 }
 
 function defaultSource(config: BridgeConfig): SourceConfig {
@@ -223,6 +232,138 @@ function sourceScopedId(sourceId: string, sessionId: string): string {
   return `${sourceId}::${sessionId}`
 }
 
+function sessionAlarmSessionIdError(sessionId: string): string | undefined {
+  if (!sessionId) return "sessionId is required"
+  if (sessionId.length > 256) return "sessionId must be 256 characters or fewer"
+  if (/\p{C}/u.test(sessionId)) return "sessionId contains unsupported control characters"
+}
+
+function sessionAlarmSourceIdError(sourceId: string): string | undefined {
+  if (!sourceId) return "sourceId is required"
+  if (sourceId.length > 128) return "sourceId must be 128 characters or fewer"
+  if (!/^[a-zA-Z0-9._-]+$/.test(sourceId)) return "sourceId contains unsupported characters"
+}
+
+function parseSessionAlarmRef(input: { sessionId: string; sourceId: string; scopedSessionId: string }) {
+  const scoped = input.scopedSessionId.trim()
+  if (scoped) {
+    const decoded = decodeSessionRef(scoped)
+    if (!decoded) return { error: "scopedSessionId is invalid" }
+    const mismatch = input.sessionId.trim() && input.sessionId.trim() !== decoded.sessionId
+    if (mismatch) return { error: "sessionId does not match scopedSessionId" }
+    return { ref: { sourceId: decoded.sourceId, sessionId: decoded.sessionId, scopedSessionId: sourceScopedId(decoded.sourceId, decoded.sessionId) } }
+  }
+  const sessionId = input.sessionId.trim()
+  const sessionIdError = sessionAlarmSessionIdError(sessionId)
+  if (sessionIdError) return { error: sessionIdError }
+  const sourceId = input.sourceId.trim() || "default"
+  const sourceIdError = sessionAlarmSourceIdError(sourceId)
+  if (sourceIdError) return { error: sourceIdError }
+  return { ref: { sourceId, sessionId, scopedSessionId: sourceScopedId(sourceId, sessionId) } }
+}
+
+async function enableAlarmTargets(runtime: Runtime, scopedSessionId: string): Promise<SessionAlarmResult> {
+  if (!runtime.store.sessionKeys || !runtime.store.notificationSet) {
+    return { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
+  }
+  const mappedKeys = await runtime.store.sessionKeys(scopedSessionId)
+  const fallbackKeys = !mappedKeys.length && runtime.store.sessionMapKeys
+    ? await runtime.store.sessionMapKeys()
+    : []
+  const keys = mappedKeys.length ? mappedKeys : fallbackKeys
+  if (!keys.length) {
+    return { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
+  }
+  const chats = new Set<string>()
+  for (const key of keys) {
+    const parsed = parseTelegramKey(key)
+    if (!parsed) continue
+    chats.add(notificationKey(parsed.chatId))
+  }
+  for (const chatKey of chats) {
+    await runtime.store.notificationSet(chatKey, true)
+  }
+  return {
+    mappedChats: chats.size,
+    sessionKeys: mappedKeys.length,
+    fallbackSessionKeys: mappedKeys.length ? 0 : fallbackKeys.length,
+    usedFallback: !mappedKeys.length && fallbackKeys.length > 0,
+  }
+}
+
+async function handleSessionAlarmEndpoint(runtime: Runtime, req: Request, url: URL) {
+  if (url.pathname !== "/session-alarm") return
+  if (req.method === "GET") {
+    const parsed = parseSessionAlarmRef({
+      sessionId: url.searchParams.get("sessionId") || "",
+      sourceId: url.searchParams.get("sourceId") || "",
+      scopedSessionId: url.searchParams.get("scopedSessionId") || "",
+    })
+    if (!parsed.ref) {
+      return Response.json({ error: parsed.error || "invalid request" }, { status: 400 })
+    }
+    if (!runtime.store.sessionAlarmGet) {
+      return Response.json({ error: "not_implemented", message: "session alarm read not supported" }, { status: 501 })
+    }
+    const enabled = await runtime.store.sessionAlarmGet(parsed.ref.scopedSessionId).catch(() => undefined)
+    if (enabled === undefined) {
+      return Response.json({ error: "failed to read session alarm" }, { status: 500 })
+    }
+    return Response.json({
+      sessionId: parsed.ref.sessionId,
+      sourceId: parsed.ref.sourceId,
+      enabled: enabled === true,
+    })
+  }
+  if (req.method !== "PUT") {
+    return new Response("Method Not Allowed", { status: 405 })
+  }
+  const body = await req.json().catch(() => null)
+  const payload = body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : null
+  const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : ""
+  const sourceId = typeof payload?.sourceId === "string" ? payload.sourceId : ""
+  const scopedSessionId = typeof payload?.scopedSessionId === "string" ? payload.scopedSessionId : ""
+  const directory = normalizedDirectory(payload?.directory)
+  const enabled = payload?.enabled
+  console.log("[TelegramBridge] session alarm rpc hit", { sessionId, sourceId, scopedSessionId, enabled, directory })
+  const parsed = parseSessionAlarmRef({ sessionId, sourceId, scopedSessionId })
+  if (!parsed.ref) {
+    return Response.json({ error: parsed.error || "invalid request" }, { status: 400 })
+  }
+  if (typeof enabled !== "boolean") {
+    return Response.json({ error: "enabled must be a boolean" }, { status: 400 })
+  }
+  if (!runtime.store.sessionAlarmSet) {
+    return Response.json({ error: "not_implemented", message: "session alarm update not supported" }, { status: 501 })
+  }
+  const ref = parsed.ref
+  const ok = await runtime.store.sessionAlarmSet(ref.scopedSessionId, enabled).then(
+    () => true,
+    () => false,
+  )
+  if (!ok) {
+    return Response.json({ error: "failed to update session alarm" }, { status: 500 })
+  }
+  if (enabled && directory) {
+    ensureOutboundNotifications(runtime, ref.sourceId, directory)
+  }
+  console.log(`[TelegramBridge] session alarm ${enabled ? "enabled" : "disabled"} (bridge rpc)`, {
+    sessionId: ref.sessionId,
+    sourceId: ref.sourceId,
+    scopedSessionId: ref.scopedSessionId,
+  })
+  const sync = enabled ? await enableAlarmTargets(runtime, ref.scopedSessionId) : { mappedChats: 0, sessionKeys: 0, fallbackSessionKeys: 0, usedFallback: false }
+  return Response.json({
+    sessionId: ref.sessionId,
+    sourceId: ref.sourceId,
+    enabled,
+    mappedChats: sync.mappedChats,
+    sessionKeys: sync.sessionKeys,
+    fallbackSessionKeys: sync.fallbackSessionKeys,
+    usedFallback: sync.usedFallback,
+  })
+}
+
 function sourceLabel(sourceId: string): string {
   if (sourceId === "default") return "default"
   return sourceId
@@ -253,11 +394,59 @@ function sourceForSessionRef(runtime: Runtime, ref: SessionRef): BridgeConfig | 
   return sourceConfig(runtime, ref.sourceId)
 }
 
+function normalizedDirectory(value: unknown): string | undefined {
+  if (typeof value !== "string") return
+  const directory = value.trim()
+  if (!directory) return
+  if (directory.length > 4096) return
+  return directory
+}
+
+function outboundStreamKey(sourceId: string, directory?: string): string {
+  if (!directory) return `${sourceId}::root`
+  return `${sourceId}::${directory}`
+}
+
+function logPreview(value: unknown, max = 220): string | undefined {
+  if (typeof value !== "string") return
+  const text = value.replace(/\s+/g, " ").trim()
+  if (!text) return
+  if (text.length <= max) return text
+  return `${text.slice(0, Math.max(1, max - 3))}...`
+}
+
+function logInboundUpdate(update: TelegramUpdate) {
+  const message = update.message
+  const text = logPreview(message?.text)
+  if (message?.chat?.id && text) {
+    console.log("[TelegramBridge] inbound message", {
+      updateId: update.update_id,
+      chatId: message.chat.id,
+      userId: message.from?.id,
+      text,
+    })
+    return
+  }
+
+  const callback = update.callback_query
+  const data = logPreview(callback?.data)
+  if (callback?.message?.chat?.id && callback?.id && data) {
+    console.log("[TelegramBridge] inbound callback", {
+      updateId: update.update_id,
+      callbackId: callback.id,
+      chatId: callback.message.chat.id,
+      userId: callback.from?.id,
+      data,
+    })
+  }
+}
+
 const sessions = new Map<string, CachedSession>()
 const creatingSessions = new Map<string, Promise<string>>()
 const chatQueues = new Map<string, Promise<void>>()
 const eventNotifications = new Map<string, number>()
 const statusBySession = new Map<string, string>()
+const alarmStateBySession = new Map<string, boolean>()
 const fallbackNotifications = new Map<string, boolean>()
 const fallbackPending = new Map<string, TelegramPendingItem[]>()
 const pendingQuestions = new Map<string, TelegramPendingQuestion[]>()
@@ -277,6 +466,19 @@ const pendingTextMax = 240
 const sessionHistoryMax = 60
 const sessionTitleLookupBatchSize = 6
 const switchPageSize = 10
+
+function logAlarmState(ref: SessionRef, enabled: boolean) {
+  const scopedSessionId = sourceScopedId(ref.sourceId, ref.sessionId)
+  const prev = alarmStateBySession.get(scopedSessionId)
+  if (prev === enabled) return
+  alarmStateBySession.set(scopedSessionId, enabled)
+  console.log("[TelegramBridge] session alarm state", {
+    sessionId: ref.sessionId,
+    sourceId: ref.sourceId,
+    scopedSessionId,
+    enabled,
+  })
+}
 const recentDefaultCount = 5
 const recentMaxCount = 12
 const recentPartTextMax = 500
@@ -678,6 +880,7 @@ async function pendingTargets(runtime: Runtime, ref: SessionRef): Promise<string
   const alarmEnabled = runtime.store.sessionAlarmGet
     ? await runtime.store.sessionAlarmGet(scoped)
     : true
+  logAlarmState(ref, alarmEnabled)
   if (!alarmEnabled) return []
 
   const targets = new Set<string>()
@@ -697,6 +900,7 @@ async function eventTargets(runtime: Runtime, ref: SessionRef): Promise<string[]
   const alarmEnabled = runtime.store.sessionAlarmGet
     ? await runtime.store.sessionAlarmGet(scoped)
     : true
+  logAlarmState(ref, alarmEnabled)
   if (!alarmEnabled) return []
 
   const mapped = await sessionTargets(runtime, ref)
@@ -1088,7 +1292,11 @@ function questionMarkup(question: TelegramPendingQuestion): { inline_keyboard: A
   }
 }
 
-function parsePendingQuestion(properties: Record<string, unknown>, sourceId = "default"): TelegramPendingQuestion | undefined {
+function parsePendingQuestion(
+  properties: Record<string, unknown>,
+  sourceId = "default",
+  streamDirectory?: string,
+): TelegramPendingQuestion | undefined {
   const requestId = typeof properties.id === "string" ? properties.id.trim() : ""
   const sessionId = typeof properties.sessionID === "string" ? properties.sessionID.trim() : ""
   const rows = Array.isArray(properties.questions) ? properties.questions : []
@@ -1127,6 +1335,7 @@ function parsePendingQuestion(properties: Record<string, unknown>, sourceId = "d
     callbackId: callbackQuestionId(requestId),
     sessionId,
     sourceId,
+    directory: streamDirectory,
     createdAt: now,
     expiresAt: now + pendingQuestionTtlMs,
     questions: parsed,
@@ -1448,6 +1657,13 @@ export function setRetryDelayForTest(next?: (ms: number) => Promise<void>) {
 
 async function telegramRequest(config: BridgeConfig, method: string, body: Record<string, unknown>, timeoutMs = 10_000) {
   const run = async () => {
+    if (method === "sendMessage") {
+      console.log("[TelegramBridge] outbound message", {
+        chatId: typeof body.chat_id === "number" ? body.chat_id : undefined,
+        text: logPreview(body.text),
+        hasMarkup: Boolean(body.reply_markup),
+      })
+    }
     const url = `https://api.telegram.org/bot${config.token}/${method}`
     const res = await fetch(url, {
       method: "POST",
@@ -1633,7 +1849,12 @@ function cacheSessionInfo(config: BridgeConfig, sessionId: string, info: Session
   const expiresAt = now + config.sessionCacheTtlMs
   const key = sourceScopedId(sourceId, sessionId)
   sessionInfo.delete(key)
-  sessionInfo.set(key, { exists: info.exists, title: info.title || null, expiresAt })
+  sessionInfo.set(key, {
+    exists: info.exists,
+    title: info.title || null,
+    directory: info.directory || null,
+    expiresAt,
+  })
   pruneExpiredSessionInfo(now)
   for (const key of sessionInfo.keys()) {
     if (sessionInfo.size <= config.sessionCacheMax * 2) return
@@ -1652,6 +1873,7 @@ function cachedSessionLookup(sessionId: string, sourceId = "default"): SessionLo
   return {
     exists: cached.exists,
     title: cached.title || undefined,
+    directory: cached.directory || undefined,
   }
 }
 
@@ -1711,6 +1933,7 @@ function normalizeSessionLookupId(sessionId: string): string | undefined {
 type SessionLookup = {
   exists: boolean
   title?: string
+  directory?: string
 }
 
 type SessionStatusSnapshot = {
@@ -1815,15 +2038,17 @@ async function statusText(runtime: Runtime, ref: SessionRef): Promise<string> {
   const scoped = sourceForSessionRef(runtime, ref)
   if (!scoped) return sourceUnavailableText(ref.sourceId)
   const scopedSessionId = sourceScopedId(ref.sourceId, ref.sessionId)
+  const configuredProject = scoped.directory?.trim()
   const [title, snapshot] = await Promise.all([
     safeSessionTitle(scoped, ref.sessionId, ref.sourceId),
     readSessionStatusSnapshot(scoped),
   ])
+  const cached = cachedSessionLookup(ref.sessionId, ref.sourceId)
   const subsessions = await readSubsessionSummary(scoped, ref.sessionId, ref.sourceId, snapshot)
   const status = normalizeStatusType(statusBySession.get(scopedSessionId))
     || normalizeStatusType(snapshot.bySession.get(ref.sessionId))
     || (snapshot.reachable ? "idle" : "unknown")
-  const project = scoped.directory?.trim() || "unknown"
+  const project = configuredProject || cached?.directory?.trim() || "unknown"
   return [
     `Session: ${formatSessionDisplay(ref.sessionId, title, ref.sourceId)}`,
     `Project: ${project} (source: ${sourceLabel(ref.sourceId)})`,
@@ -1852,19 +2077,22 @@ async function readSessionInfo(config: BridgeConfig, sessionId: string): Promise
   return {
     exists: true,
     title: trimSessionTitle(payload.title),
+    directory: sessionDirectoryFromPayload(payload),
   }
 }
 
-async function sessionTitle(config: BridgeConfig, sessionId: string, sourceId = "default"): Promise<string | undefined> {
+async function sessionLookup(config: BridgeConfig, sessionId: string, sourceId = "default"): Promise<SessionLookup> {
   const id = normalizeSessionLookupId(sessionId)
-  if (!id) return
+  if (!id) return { exists: false }
   const cached = cachedSessionLookup(id, sourceId)
-  if (cached) {
-    if (!cached.exists) return
-    return cached.title
-  }
+  if (cached) return cached
   const loaded = await readSessionInfo(config, id)
   cacheSessionInfo(config, id, loaded, sourceId)
+  return loaded
+}
+
+async function sessionTitle(config: BridgeConfig, sessionId: string, sourceId = "default"): Promise<string | undefined> {
+  const loaded = await sessionLookup(config, sessionId, sourceId)
   if (!loaded.exists) return
   return loaded.title
 }
@@ -2056,12 +2284,7 @@ async function recentText(
 }
 
 async function sessionExists(config: BridgeConfig, sessionId: string, sourceId = "default"): Promise<boolean> {
-  const id = normalizeSessionLookupId(sessionId)
-  if (!id) return false
-  const cached = cachedSessionLookup(id, sourceId)
-  if (cached) return cached.exists
-  const loaded = await readSessionInfo(config, id)
-  cacheSessionInfo(config, id, loaded, sourceId)
+  const loaded = await sessionLookup(config, sessionId, sourceId)
   return loaded.exists
 }
 
@@ -2655,6 +2878,12 @@ async function sendQuestionReply(
     if (config.directory) {
       url.searchParams.set("directory", config.directory)
     }
+    console.log("[TelegramBridge] question reply request", {
+      requestId,
+      directory: config.directory || "",
+      answers: answers.length,
+      url: `${url.origin}${url.pathname}${url.search}`,
+    })
     const res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -2665,6 +2894,10 @@ async function sendQuestionReply(
       const body = await res.text().catch(() => "")
       throw new Error(`OpenCode question reply failed (${res.status}): ${body.slice(0, 300)}`)
     }
+    console.log("[TelegramBridge] question reply applied", {
+      requestId,
+      directory: config.directory || "",
+    })
   }
 
   return retry("opencode:question.reply", run, 2, 400, (error) => {
@@ -2787,11 +3020,16 @@ export async function readTelegramBridgeHealth(runtime: Runtime): Promise<Bridge
   const errorSources = sourceChecks.filter((item) => item.status !== "ok").map((item) => item.sourceId)
   const hasSources = sourceChecks.length > 0
   const allHealthy = hasSources && errorSources.length === 0
+  const multiSource = sourceChecks.length > 1
   const healthyList = okSources.join(", ")
   const failingList = errorSources.join(", ")
   const healthySuffix = okSources.length > 0 ? `; healthy sources: ${healthyList}` : ""
   const openCodeApi = !hasSources
     ? { status: "error" as const, message: "No OpenCode sources configured" }
+    : !multiSource && allHealthy
+    ? { status: "ok" as const, message: "OpenCode API is reachable" }
+    : !multiSource
+    ? { status: "error" as const, message: "OpenCode API check failed" }
     : allHealthy
     ? { status: "ok" as const, message: `OpenCode API is reachable for sources: ${healthyList}` }
     : { status: "error" as const, message: `OpenCode API check failed for sources: ${failingList}${healthySuffix}` }
@@ -2983,6 +3221,13 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
     }
 
     const pending = match.pending
+    console.log("[TelegramBridge] callback matched pending question", {
+      callbackId,
+      requestId: pending.requestId,
+      sessionId: pending.sessionId,
+      sourceId: pending.sourceId || "default",
+      directory: pending.directory || "",
+    })
     const index = pendingQuestionIndex(pending)
     if (parsed.questionIndex !== index) {
       await answerCallback(runtime.config, callbackId, "That step has already been answered.")
@@ -3033,7 +3278,10 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
       await sendTelegramMessage(runtime.config, chatId, sourceUnavailableText(pendingSource))
       return
     }
-    await sendQuestionReply(replyConfig, pending.requestId, answers)
+    const questionConfig = pending.directory
+      ? { ...replyConfig, directory: pending.directory }
+      : replyConfig
+    await sendQuestionReply(questionConfig, pending.requestId, answers)
       .then(async () => {
         await deletePendingQuestionByKey(runtime, match.itemKey, pending.requestId)
         const remaining = await readPendingQuestionsByKey(runtime, match.itemKey)
@@ -3064,6 +3312,7 @@ export async function handleCallbackUpdate(runtime: Runtime, update: TelegramUpd
 }
 
 export async function handleTelegramUpdate(runtime: Runtime, update: TelegramUpdate) {
+  logInboundUpdate(update)
   if (update.callback_query) {
     await handleCallbackUpdate(runtime, update)
     return
@@ -3489,7 +3738,7 @@ async function notifyQuestion(runtime: Runtime, sessionId: string, sourceId: str
   }
 }
 
-async function handleOutboundBlocks(runtime: Runtime, blocks: string[], sourceId: string) {
+async function handleOutboundBlocks(runtime: Runtime, blocks: string[], sourceId: string, streamDirectory?: string) {
   for (const block of blocks) {
     const lines = block.split("\n")
     const dataLines = lines
@@ -3501,11 +3750,16 @@ async function handleOutboundBlocks(runtime: Runtime, blocks: string[], sourceId
       .then(() => parseEvent(raw))
       .catch(() => undefined)
     if (!event) continue
-    await handleBridgeEvent(runtime, event, sourceId)
+    await handleBridgeEvent(runtime, event, sourceId, streamDirectory)
   }
 }
 
-export async function consumeOutboundEventStream(runtime: Runtime, body: ReadableStream<Uint8Array>, sourceId = "default") {
+export async function consumeOutboundEventStream(
+  runtime: Runtime,
+  body: ReadableStream<Uint8Array>,
+  sourceId = "default",
+  streamDirectory?: string,
+) {
   const reader = body.getReader()
   const decoder = new TextDecoder()
   const parser = createOutboundSSEParser()
@@ -3513,19 +3767,24 @@ export async function consumeOutboundEventStream(runtime: Runtime, body: Readabl
     const step = await reader.read()
     if (step.done) break
     const blocks = parser.push(decoder.decode(step.value, { stream: true }))
-    await handleOutboundBlocks(runtime, blocks, sourceId)
+    await handleOutboundBlocks(runtime, blocks, sourceId, streamDirectory)
   }
 
   const finalText = decoder.decode()
   if (finalText) {
-    await handleOutboundBlocks(runtime, parser.push(finalText), sourceId)
+    await handleOutboundBlocks(runtime, parser.push(finalText), sourceId, streamDirectory)
   }
 
   const tailBlocks = parser.flush()
-  await handleOutboundBlocks(runtime, tailBlocks, sourceId)
+  await handleOutboundBlocks(runtime, tailBlocks, sourceId, streamDirectory)
 }
 
-export async function handleBridgeEvent(runtime: Runtime, event: { type: string; properties: Record<string, unknown> }, sourceId = "default") {
+export async function handleBridgeEvent(
+  runtime: Runtime,
+  event: { type: string; properties: Record<string, unknown> },
+  sourceId = "default",
+  streamDirectory?: string,
+) {
   const sessionId = typeof event.properties.sessionID === "string" ? event.properties.sessionID : ""
   if (event.type === "session.deleted") {
     const info = event.properties.info && typeof event.properties.info === "object"
@@ -3555,7 +3814,7 @@ export async function handleBridgeEvent(runtime: Runtime, event: { type: string;
   }
   if (!sessionId) return
   if (event.type === "question.asked") {
-    const pending = parsePendingQuestion(event.properties, sourceId)
+    const pending = parsePendingQuestion(event.properties, sourceId, streamDirectory)
     if (!pending) {
       const requestId = typeof event.properties.id === "string" ? event.properties.id.trim() : ""
       const notifyKind = requestId ? `question:${sourceId}:${requestId}` : undefined
@@ -3605,15 +3864,21 @@ export async function handleBridgeEvent(runtime: Runtime, event: { type: string;
 }
 
 async function runOutboundNotifications(runtime: Runtime, source: SourceConfig) {
+  return runOutboundNotificationsForDirectory(runtime, source, source.directory)
+}
+
+async function runOutboundNotificationsForDirectory(runtime: Runtime, source: SourceConfig, directory?: string) {
   const config = sourceConfig(runtime, source.id)
   if (!config) {
     console.warn(`[TelegramBridge] skipping outbound notifications for source=${source.id}: source config unavailable`)
     return
   }
+  const streamScope = directory ? `directory=${directory}` : "default-directory"
+  console.log(`[TelegramBridge] outbound stream source=${source.id} scope=${streamScope} openCodeUrl=${config.openCodeUrl}`)
   while (true) {
     const url = opencodeUrl(config, "/event")
-    if (config.directory) {
-      url.searchParams.set("directory", config.directory)
+    if (directory) {
+      url.searchParams.set("directory", directory)
     }
 
     try {
@@ -3625,7 +3890,7 @@ async function runOutboundNotifications(runtime: Runtime, source: SourceConfig) 
         throw new Error(`OpenCode event stream failed (${response.status})`)
       }
 
-      await consumeOutboundEventStream(runtime, response.body, source.id)
+      await consumeOutboundEventStream(runtime, response.body, source.id, directory)
     } catch (error) {
       if (isTimeoutError(error)) {
         console.log(`[TelegramBridge] outbound event stream timed out for source=${source.id}, reconnecting`)
@@ -3636,6 +3901,17 @@ async function runOutboundNotifications(runtime: Runtime, source: SourceConfig) 
       await sleep(1500)
     }
   }
+}
+
+function ensureOutboundNotifications(runtime: Runtime, sourceId: string, directory?: string) {
+  const source = runtime.sources?.find((item) => item.id === sourceId)
+  if (!source) return
+  const key = outboundStreamKey(sourceId, directory)
+  const streams = runtime.outboundStreams || new Set<string>()
+  runtime.outboundStreams = streams
+  if (streams.has(key)) return
+  streams.add(key)
+  void runOutboundNotificationsForDirectory(runtime, source, directory)
 }
 
 async function runPolling(runtime: Runtime) {
@@ -3686,8 +3962,14 @@ export function runPollingHealthServer(runtime: Runtime): boolean {
     Bun.serve({
       port: config.port,
       hostname: host,
-      async fetch(req) {
+      async fetch(req, server) {
         const url = new URL(req.url)
+        if (!allowTelegramHealthRequest(server.requestIP(req)?.address)) {
+          return new Response("Not Found", { status: 404 })
+        }
+        if (url.pathname === "/session-alarm" && (req.method === "GET" || req.method === "PUT")) {
+          return handleSessionAlarmEndpoint(runtime, req, url)
+        }
         if (req.method !== "GET" || url.pathname !== "/health") {
           return new Response("Not Found", { status: 404 })
         }
@@ -3725,6 +4007,12 @@ async function runWebhook(runtime: Runtime) {
         }
         const report = await readTelegramBridgeHealth(runtime)
         return Response.json(report)
+      }
+      if (url.pathname === "/session-alarm" && (req.method === "GET" || req.method === "PUT")) {
+        if (!allowTelegramHealthRequest(server.requestIP(req)?.address)) {
+          return new Response("Not Found", { status: 404 })
+        }
+        return handleSessionAlarmEndpoint(runtime, req, url)
       }
       if (req.method !== "POST" || url.pathname !== config.webhookPath) {
         return new Response("Not Found", { status: 404 })
@@ -3777,13 +4065,16 @@ export async function startTelegramBridge() {
     console.log(`[TelegramBridge] OpenCode directory: ${config.directory}`)
   }
   registerTelegramCommandsWithoutBlocking(config)
+  for (const source of runtime.sources) {
+    ensureOutboundNotifications(runtime, source.id, source.directory)
+  }
   if (config.mode === "polling") {
     runPollingHealthServer(runtime)
-    await Promise.all([runPolling(runtime), ...runtime.sources.map((source) => runOutboundNotifications(runtime, source))])
+    await runPolling(runtime)
     return
   }
 
-  await Promise.all([runWebhook(runtime), ...runtime.sources.map((source) => runOutboundNotifications(runtime, source))])
+  await runWebhook(runtime)
 }
 
 export function resetSessionCacheForTest() {
@@ -3794,6 +4085,7 @@ export function resetSessionCacheForTest() {
   chatQueues.clear()
   eventNotifications.clear()
   statusBySession.clear()
+  alarmStateBySession.clear()
   fallbackNotifications.clear()
   fallbackPending.clear()
   pendingQuestions.clear()

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -11,6 +11,8 @@ type StoreShape = {
   pending: Record<string, TelegramPendingQuestion[]>
 }
 
+const REFRESH_STAT_INTERVAL_MS = 250
+
 type TelegramPendingItem = {
   id: string
   kind: "question" | "permission" | "task-finished"
@@ -462,6 +464,7 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
 
   let writes = Promise.resolve()
   let ops = Promise.resolve()
+  let lastRefreshCheckMs = 0
 
   function flush() {
     const payload: StoreShape = {
@@ -477,6 +480,9 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
       () => writeStore(path, payload),
       () => writeStore(path, payload),
     )
+    writes = writes.then(() => stat(path).then((file) => {
+      loadedMtimeMs = file.mtimeMs
+    }).catch(() => undefined))
     return writes
   }
 
@@ -486,18 +492,23 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
     return step
   }
 
-  async function refreshFromDisk() {
-    await ready
-    const file = await stat(path).catch(() => undefined)
-    if (!file) return
-    if (file.mtimeMs <= loadedMtimeMs) return
-    const data = await readStore(path).catch((error) => {
-      console.warn("[TelegramBridge] session store refresh failed", { path, error })
-      return
+  function refreshFromDisk() {
+    return run(async () => {
+      await ready
+      const now = Date.now()
+      if (now - lastRefreshCheckMs < REFRESH_STAT_INTERVAL_MS) return
+      lastRefreshCheckMs = now
+      const file = await stat(path).catch(() => undefined)
+      if (!file) return
+      if (file.mtimeMs <= loadedMtimeMs) return
+      const data = await readStore(path).catch((error) => {
+        console.warn("[TelegramBridge] session store refresh failed", { path, error })
+        return
+      })
+      if (!data) return
+      applyData(data)
+      loadedMtimeMs = file.mtimeMs
     })
-    if (!data) return
-    applyData(data)
-    loadedMtimeMs = file.mtimeMs
   }
 
   function sameList(a: string[] | undefined, b: string[]): boolean {

--- a/shared/telegram-session-store.ts
+++ b/shared/telegram-session-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, rename, rm } from "node:fs/promises"
+import { mkdir, readdir, rename, rm, stat } from "node:fs/promises"
 import { basename, dirname, join } from "node:path"
 
 type StoreShape = {
@@ -35,6 +35,7 @@ export type TelegramPendingQuestion = {
   callbackId: string
   sessionId: string
   sourceId?: string
+  directory?: string
   createdAt: number
   expiresAt: number
   questions: TelegramPendingQuestionEntry[]
@@ -140,6 +141,7 @@ function parsePendingQuestion(value: unknown): TelegramPendingQuestion | undefin
     callbackId: pendingId,
     sessionId,
     sourceId: typeof row.sourceId === "string" && row.sourceId.trim() ? row.sourceId.trim() : undefined,
+    directory: typeof row.directory === "string" && row.directory.trim() ? row.directory.trim() : undefined,
     createdAt,
     expiresAt,
     questions,
@@ -362,6 +364,7 @@ export type TelegramSessionStore = {
   set: (key: string, sessionId: string) => Promise<void>
   delete: (key: string) => Promise<void>
   sessionKeys?: (sessionId: string) => Promise<string[]>
+  sessionMapKeys?: () => Promise<string[]>
   historyGet?: (key: string) => Promise<string[]>
   historySet?: (key: string, ids: string[]) => Promise<void>
   notificationGet?: (key: string) => Promise<boolean>
@@ -388,6 +391,7 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
   const sessionAlarms = new Map<string, boolean>()
   const inbox = new Map<string, TelegramPendingItem[]>()
   const pending = new Map<string, TelegramPendingQuestion[]>()
+  let loadedMtimeMs = 0
 
   function indexAdd(sessionId: string, key: string) {
     const set = sessionIndex.get(sessionId)
@@ -414,27 +418,43 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
       indexAdd(next, key)
     }
   }
+  function applyData(data: StoreShape) {
+    sessions.clear()
+    sessionIndex.clear()
+    history.clear()
+    notifications.clear()
+    sessionAlarms.clear()
+    inbox.clear()
+    pending.clear()
+    for (const [key, value] of Object.entries(data.sessions)) {
+      sessions.set(key, value)
+      indexAdd(value, key)
+    }
+    for (const [key, value] of Object.entries(data.history)) {
+      history.set(key, value)
+    }
+    for (const [key, value] of Object.entries(data.notifications)) {
+      notifications.set(key, value)
+    }
+    for (const [key, value] of Object.entries(data.sessionAlarms)) {
+      sessionAlarms.set(key, value)
+    }
+    for (const [key, value] of Object.entries(data.inbox)) {
+      inbox.set(key, value)
+    }
+    for (const [key, value] of Object.entries(data.pending)) {
+      pending.set(key, value)
+    }
+  }
+
   const ready = readStore(path)
     .then((data) => {
-      for (const [key, value] of Object.entries(data.sessions)) {
-        sessions.set(key, value)
-        indexAdd(value, key)
-      }
-      for (const [key, value] of Object.entries(data.history)) {
-        history.set(key, value)
-      }
-      for (const [key, value] of Object.entries(data.notifications)) {
-        notifications.set(key, value)
-      }
-      for (const [key, value] of Object.entries(data.sessionAlarms)) {
-        sessionAlarms.set(key, value)
-      }
-      for (const [key, value] of Object.entries(data.inbox)) {
-        inbox.set(key, value)
-      }
-      for (const [key, value] of Object.entries(data.pending)) {
-        pending.set(key, value)
-      }
+      applyData(data)
+      return stat(path).then((file) => {
+        loadedMtimeMs = file.mtimeMs
+      }).catch(() => {
+        loadedMtimeMs = 0
+      })
     })
     .catch((error) => {
       console.warn("[TelegramBridge] session store load failed, starting empty", { path, error })
@@ -466,6 +486,20 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
     return step
   }
 
+  async function refreshFromDisk() {
+    await ready
+    const file = await stat(path).catch(() => undefined)
+    if (!file) return
+    if (file.mtimeMs <= loadedMtimeMs) return
+    const data = await readStore(path).catch((error) => {
+      console.warn("[TelegramBridge] session store refresh failed", { path, error })
+      return
+    })
+    if (!data) return
+    applyData(data)
+    loadedMtimeMs = file.mtimeMs
+  }
+
   function sameList(a: string[] | undefined, b: string[]): boolean {
     if (!a) return b.length === 0
     if (a.length !== b.length) return false
@@ -476,14 +510,14 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
   }
 
   async function inboxGet(key: string) {
-    await ready
+    await refreshFromDisk()
     const rows = inbox.get(key)
     if (!rows) return []
     return [...rows]
   }
 
   async function inboxSet(key: string, items: TelegramPendingItem[]) {
-    await ready
+    await refreshFromDisk()
     await run(async () => {
       const prev = inbox.get(key) || []
       if (items.length) inbox.set(key, [...items])
@@ -501,11 +535,11 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
 
   return {
     async get(key: string) {
-      await ready
+      await refreshFromDisk()
       return sessions.get(key)
     },
     async set(key: string, sessionId: string) {
-      await ready
+      await refreshFromDisk()
       await run(async () => {
         const prev = sessions.get(key)
         if (prev === sessionId) return
@@ -524,7 +558,7 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
       })
     },
     async delete(key: string) {
-      await ready
+      await refreshFromDisk()
       await run(async () => {
         const prev = sessions.get(key)
         if (prev === undefined) return
@@ -538,17 +572,21 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
       })
     },
     async sessionKeys(sessionId: string) {
-      await ready
+      await refreshFromDisk()
       const keys = sessionIndex.get(sessionId)
       if (!keys) return []
       return Array.from(keys)
     },
+    async sessionMapKeys() {
+      await refreshFromDisk()
+      return Array.from(sessions.keys())
+    },
     async historyGet(key: string) {
-      await ready
+      await refreshFromDisk()
       return [...(history.get(key) || [])]
     },
     async historySet(key: string, ids: string[]) {
-      await ready
+      await refreshFromDisk()
       await run(async () => {
         const next = parseHistoryList(ids)
         const prev = history.get(key)
@@ -566,11 +604,11 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
       })
     },
     async notificationGet(key: string) {
-      await ready
+      await refreshFromDisk()
       return notifications.get(key) === true
     },
     async notificationSet(key: string, enabled: boolean) {
-      await ready
+      await refreshFromDisk()
       await run(async () => {
         const prev = notifications.get(key)
         if (enabled) notifications.set(key, true)
@@ -586,15 +624,15 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
       })
     },
     async notificationKeys() {
-      await ready
+      await refreshFromDisk()
       return Array.from(notifications.keys())
     },
     async sessionAlarmGet(sessionId: string) {
-      await ready
+      await refreshFromDisk()
       return sessionAlarms.get(sessionId) === true
     },
     async sessionAlarmSet(sessionId: string, enabled: boolean) {
-      await ready
+      await refreshFromDisk()
       await run(async () => {
         const prev = sessionAlarms.get(sessionId)
         if ((prev === true && enabled) || (prev === undefined && !enabled)) return
@@ -615,13 +653,13 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
     pendingGet: inboxGet,
     pendingSet: inboxSet,
     async questionList(key: string) {
-      await ready
+      await refreshFromDisk()
       const rows = pending.get(key)
       if (!rows) return []
       return [...rows]
     },
     async questionUpsert(key: string, question: TelegramPendingQuestion) {
-      await ready
+      await refreshFromDisk()
       await run(async () => {
         const prev = pending.get(key) || []
         const filtered = prev.filter((item) => item.requestId !== question.requestId)
@@ -640,7 +678,7 @@ export function createTelegramSessionStore(path: string): TelegramSessionStore {
       })
     },
     async questionDelete(key: string, requestId: string) {
-      await ready
+      await refreshFromDisk()
       await run(async () => {
         const prev = pending.get(key) || []
         if (!prev.length) return


### PR DESCRIPTION
## Summary
- make session alarm writes directory-aware end-to-end (web UI -> extended API -> Telegram bridge) so toggles from other project directories are forwarded and tracked correctly
- improve Telegram bridge observability and health reporting, including explicit alarm toggle logs, bridge `/session-alarm` handling, and clearer single-source health messaging
- harden frontend session bootstrap merge logic so older sync payloads do not overwrite newer SSE tool-part states (avoids stuck/pending regressions)

## Validation
- updated Telegram bridge tests for health message expectations
- verified local branch contains two focused commits with clean working tree