### PR TITLE
fix: reduce settings SSE noise and restore typecheck

### DIFF
--- a/app-prefixable/src/app.tsx
+++ b/app-prefixable/src/app.tsx
@@ -1,5 +1,5 @@
 import { Router, Route, Navigate, useParams } from "@solidjs/router"
-import { createSignal, onMount, onCleanup, For } from "solid-js"
+import { createSignal, onMount, onCleanup, For, type Accessor } from "solid-js"
 import { BasePathProvider, useBasePath } from "./context/base-path"
 import { ServerProvider, useServer } from "./context/server"
 import { BrandingProvider } from "./context/branding"
@@ -33,7 +33,7 @@ function getLastSessionHref(encodedDir: string): string {
 
 function DirectoryIndex() {
   const params = useParams<{ dir: string }>()
-  return <Navigate href={getLastSessionHref(params.dir)} replace />
+  return <Navigate href={getLastSessionHref(params.dir)} />
 }
 
 function SessionIndex() {
@@ -41,7 +41,7 @@ function SessionIndex() {
   const href = getLastSessionHref(params.dir)
   if (href === "session") return <Session />
   const id = href.replace(/^session\//, "")
-  return <Navigate href={id} replace />
+  return <Navigate href={id} />
 }
 
 function AppRoutes() {
@@ -71,16 +71,21 @@ function AppRoutes() {
  * Reads the active directory from window.location (outside Router context).
  * Re-evaluates on popstate and on history.pushState/history.replaceState navigation.
  */
-function useActiveDirectory() {
+function useRouteState() {
   const [dir, setDir] = createSignal<string | undefined>(
     typeof window === "undefined" ? undefined : deriveDirectoryFromPathname(),
   )
+  const [pathname, setPathname] = createSignal(
+    typeof window === "undefined" ? "" : window.location.pathname,
+  )
 
   onMount(() => {
-    // Ensure correct value once mounted (covers SSR hydration)
-    setDir(deriveDirectoryFromPathname())
+    function update() {
+      setDir(deriveDirectoryFromPathname())
+      setPathname(window.location.pathname)
+    }
 
-    function update() { setDir(deriveDirectoryFromPathname()) }
+    update()
 
     // Patch pushState/replaceState to detect SolidJS Router navigations
     // instead of polling with setInterval
@@ -97,7 +102,10 @@ function useActiveDirectory() {
     })
   })
 
-  return dir
+  return {
+    activeDirectory: dir,
+    pathname,
+  }
 }
 
 function useProjectsList() {
@@ -129,7 +137,11 @@ function useProjectsList() {
   return projects
 }
 
-function AppWithServer(props: { projects: () => Project[]; activeDirectory: () => string | undefined }) {
+function AppWithServer(props: {
+  projects: () => Project[]
+  activeDirectory: Accessor<string | undefined>
+  pathname: Accessor<string>
+}) {
   const { serverUrl, activeServerKey } = useServer()
 
   // Key by server config to force full remount when switching or editing servers
@@ -141,7 +153,11 @@ function AppWithServer(props: { projects: () => Project[]; activeDirectory: () =
             <BrandingProvider>
               <RecentProjectsProvider>
                 <SavedPromptsProvider directory={props.activeDirectory}>
-                  <GlobalEventsProvider projects={props.projects} activeDirectory={props.activeDirectory}>
+                  <GlobalEventsProvider
+                    projects={props.projects}
+                    activeDirectory={props.activeDirectory}
+                    pathname={props.pathname}
+                  >
                     <CommandProvider>
                       <AppRoutes />
                     </CommandProvider>
@@ -158,11 +174,15 @@ function AppWithServer(props: { projects: () => Project[]; activeDirectory: () =
 
 export function App() {
   const projects = useProjectsList()
-  const activeDirectory = useActiveDirectory()
+  const route = useRouteState()
 
   return (
     <ServerProvider>
-      <AppWithServer projects={projects} activeDirectory={activeDirectory} />
+      <AppWithServer
+        projects={projects}
+        activeDirectory={route.activeDirectory}
+        pathname={route.pathname}
+      />
     </ServerProvider>
   )
 }

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -44,6 +44,7 @@ const GlobalEventsContext = createContext<GlobalEventsContextValue>()
 export function GlobalEventsProvider(props: ParentProps & {
   projects: () => { worktree: string }[]
   activeDirectory: () => string | undefined
+  pathname: () => string
 }) {
   const { authHeaders, serverUrl, activeServer } = useServer()
 
@@ -458,11 +459,18 @@ export function GlobalEventsProvider(props: ParentProps & {
   // Active project is excluded — it has its own EventProvider.
   // Remote servers are skipped — local projects don't exist on remote servers.
   createEffect(on(
-    () => ({ dirs: props.projects().map((p) => p.worktree), active: props.activeDirectory(), isRemote: !activeServer().isDefault }),
+    () => ({
+      dirs: props.projects().map((p) => p.worktree),
+      active: props.activeDirectory(),
+      isRemote: !activeServer().isDefault,
+      isSettings: props.pathname().endsWith("/settings"),
+    }),
     (current) => {
       // When a remote server is active, disconnect all global event connections
       // since local projects don't exist on the remote server.
-      if (current.isRemote) {
+      // Also suspend these background connections on settings routes to avoid
+      // opening one SSE stream per saved project while the user edits settings.
+      if (current.isRemote || current.isSettings) {
         for (const dir of [...connections.keys()]) {
           disconnectDirectory(dir)
         }

--- a/app-prefixable/src/context/server.tsx
+++ b/app-prefixable/src/context/server.tsx
@@ -75,7 +75,7 @@ function loadServers(): ServerConfig[] {
         const parsed: ServerConfig[] = raw
           .filter(isValidServerEntry)
           .map((s) => {
-            const obj = s as Record<string, unknown>
+            const obj = s as unknown as Record<string, unknown>
             // Prefer credentials from sessionStorage; fall back to authMethod stub
             if (creds[obj.id as string]) {
               return { ...s, auth: normalizeAuth({ auth: creds[obj.id as string] } as unknown as Record<string, unknown>) }

--- a/app-prefixable/src/context/theme.tsx
+++ b/app-prefixable/src/context/theme.tsx
@@ -40,6 +40,10 @@ export function ThemeProvider(props: ParentProps) {
   const query = typeof window !== "undefined" && typeof window.matchMedia === "function"
     ? window.matchMedia("(prefers-color-scheme: dark)")
     : undefined
+  const legacyQuery = query as (MediaQueryList & {
+    addListener?: (listener: (event: MediaQueryListEvent) => void) => void
+    removeListener?: (listener: (event: MediaQueryListEvent) => void) => void
+  }) | undefined
 
   const [systemDark, setSystemDark] = createSignal(query?.matches ?? false)
 
@@ -48,9 +52,9 @@ export function ThemeProvider(props: ParentProps) {
     if ("addEventListener" in query) {
       query.addEventListener("change", handler)
       onCleanup(() => query.removeEventListener("change", handler))
-    } else if ("addListener" in query) {
-      query.addListener(handler)
-      onCleanup(() => query.removeListener(handler))
+    } else if (legacyQuery?.addListener && legacyQuery.removeListener) {
+      legacyQuery.addListener(handler)
+      onCleanup(() => legacyQuery.removeListener?.(handler))
     }
   }
 

--- a/app-prefixable/src/entry.tsx
+++ b/app-prefixable/src/entry.tsx
@@ -11,8 +11,10 @@ if (!root) {
   throw new Error("Root element not found")
 }
 
+const mount = root
+
 // Clear the loading text first
-root.innerHTML = ""
+mount.innerHTML = ""
 
 async function start() {
   const cleanup = await preventLegacyServiceWorkerCaching().catch((e) => {
@@ -27,17 +29,17 @@ async function start() {
   }
 
   console.log("[OpenCode] Rendering...")
-  render(() => <App />, root)
+  render(() => <App />, mount)
   console.log("[OpenCode] Rendered successfully")
-  console.log("[OpenCode] Root innerHTML:", root.innerHTML.slice(0, 200))
+  console.log("[OpenCode] Root innerHTML:", mount.innerHTML.slice(0, 200))
 }
 
 start().catch((e) => {
   console.error("[OpenCode] Render error:", e)
-  root.innerHTML = ""
+  mount.innerHTML = ""
   const message = document.createElement("div")
   message.style.color = "red"
   message.style.padding = "20px"
   message.textContent = `Error: ${e instanceof Error && e.message.trim() ? e.message : String(e)}`
-  root.appendChild(message)
+  mount.appendChild(message)
 })

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -878,14 +878,16 @@ export function Layout(props: ParentProps) {
   const [now, setNow] = createSignal(new Date());
 
   onMount(() => {
-    const timer = { id: 0 as ReturnType<typeof setTimeout> };
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const schedule = () => {
       const next = new Date();
       next.setHours(24, 0, 0, 0);
-      timer.id = setTimeout(() => { setNow(new Date()); schedule(); }, next.getTime() - Date.now());
+      timer = setTimeout(() => { setNow(new Date()); schedule(); }, next.getTime() - Date.now());
     };
     schedule();
-    onCleanup(() => clearTimeout(timer.id));
+    onCleanup(() => {
+      if (timer) clearTimeout(timer);
+    });
   });
 
   const pinnedSessions = createMemo(() => {

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -115,7 +115,11 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
       body: req.method !== "GET" && req.method !== "HEAD" ? req.body : undefined,
     })
 
-    const corsHeaders = corsOrigin ? { "Access-Control-Allow-Origin": corsOrigin, Vary: "Origin" } : {}
+    const corsHeaders = new Headers()
+    if (corsOrigin) {
+      corsHeaders.set("Access-Control-Allow-Origin", corsOrigin)
+      corsHeaders.set("Vary", "Origin")
+    }
 
     if (isSSE) {
       if (!response.ok) {
@@ -123,15 +127,15 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
         return new Response(response.body, { status: response.status, headers: corsHeaders })
       }
 
+      const headers = new Headers(corsHeaders)
+      headers.set("Content-Type", "text/event-stream")
+      headers.set("Cache-Control", "no-cache")
+      headers.set("Connection", "keep-alive")
+      headers.set("X-Accel-Buffering", "no")
+
       return new Response(response.body, {
         status: response.status,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          "Connection": "keep-alive",
-          "X-Accel-Buffering": "no",
-        },
+        headers,
       })
     }
 


### PR DESCRIPTION
## Summary
- pause background per-project SSE connections while viewing settings pages to avoid a large pile of pending `/event` requests
- reuse the existing top-level route tracking instead of patching browser history a second time in `GlobalEventsProvider`
- clean up TypeScript issues in routing, theme listeners, entry mounting, layout timer handling, and proxy SSE headers so `bun run typecheck` passes again

## Testing
- bun run typecheck