### PR TITLE
fix: simplify markdown code block copy button

### DIFF
--- a/app-prefixable/src/components/markdown.tsx
+++ b/app-prefixable/src/components/markdown.tsx
@@ -38,7 +38,7 @@ renderer.code = ({ text, lang }) => {
   const code = escapeHtml(text)
   const className = lang ? ` class="language-${escapeHtml(lang)}"` : ""
 
-  return `<div class="markdown-code-block"><button class="markdown-copy-button" type="button" data-state="idle" aria-label="Copy code"><span class="markdown-copy-icon" aria-hidden="true">&#x29C9;</span><span class="markdown-copy-label" aria-hidden="true">Copy</span><span class="markdown-copy-live" aria-live="polite" aria-atomic="true">Copy</span></button><pre><code${className}>${code}</code></pre></div>`
+  return `<div class="markdown-code-block"><button class="markdown-copy-button" type="button" data-state="idle" aria-label="Copy code"><span class="markdown-copy-icon markdown-copy-icon-copy" aria-hidden="true"></span><span class="markdown-copy-icon markdown-copy-icon-check" aria-hidden="true"></span><span class="markdown-copy-label" aria-hidden="true">Copy</span><span class="markdown-copy-live" aria-live="polite" aria-atomic="true">Copy</span></button><pre><code${className}>${code}</code></pre></div>`
 }
 
 function copyLabel(state: "idle" | "copied" | "failed") {

--- a/app-prefixable/src/components/message-turn.tsx
+++ b/app-prefixable/src/components/message-turn.tsx
@@ -804,7 +804,7 @@ export function MessageTurn(props: {
               e.stopPropagation()
               copy()
             }}
-            class="copy-turn-button shrink-0 p-1.5 rounded transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+            class="shrink-0 p-1.5 rounded transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
             classList={{ "opacity-100": focused() || copied() }}
             style={{
               background: "var(--surface-inset)",

--- a/app-prefixable/src/components/message-turn.tsx
+++ b/app-prefixable/src/components/message-turn.tsx
@@ -804,7 +804,7 @@ export function MessageTurn(props: {
               e.stopPropagation()
               copy()
             }}
-            class="shrink-0 p-1.5 rounded transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+            class="copy-turn-button shrink-0 p-1.5 rounded transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
             classList={{ "opacity-100": focused() || copied() }}
             style={{
               background: "var(--surface-inset)",

--- a/app-prefixable/src/index.css
+++ b/app-prefixable/src/index.css
@@ -451,31 +451,45 @@
   }
 
   .markdown-code-block pre {
-    @apply mb-0 pt-10;
+    @apply mb-0 pt-8;
   }
 
   .markdown-copy-button {
-    @apply absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md border p-0 transition-colors;
-    border-color: var(--border-strong);
-    background: color-mix(in srgb, var(--surface-base) 88%, transparent);
+    @apply absolute right-3 top-3 inline-flex items-center gap-1 rounded p-1.5 transition-colors;
     color: var(--icon-base);
-    backdrop-filter: blur(2px);
+    background: transparent;
   }
 
   .markdown-copy-button:hover {
-    background: var(--surface-base);
+    background: var(--surface-inset);
     color: var(--icon-strong);
   }
 
   .markdown-copy-button:focus-visible {
+    background: var(--surface-inset);
     color: var(--icon-strong);
   }
 
   .markdown-copy-icon {
-    @apply flex h-3.5 w-3.5 items-center justify-center;
-    font-size: 0.95rem;
-    line-height: 1;
-    font-weight: 600;
+    @apply block h-4 w-4;
+    background: currentColor;
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    -webkit-mask-position: center;
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+  }
+
+  .markdown-copy-icon-copy {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='14' height='14' x='8' y='8' rx='2' ry='2'/%3E%3Cpath d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'/%3E%3C/svg%3E");
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='14' height='14' x='8' y='8' rx='2' ry='2'/%3E%3Cpath d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'/%3E%3C/svg%3E");
+  }
+
+  .markdown-copy-icon-check {
+    @apply hidden;
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
   }
 
   .markdown-copy-label {
@@ -496,8 +510,6 @@
     white-space: nowrap;
   }
 
-  .markdown-copy-button:hover .markdown-copy-label,
-  .markdown-copy-button:focus-visible .markdown-copy-label,
   .markdown-copy-button[data-state="copied"] .markdown-copy-label,
   .markdown-copy-button[data-state="failed"] .markdown-copy-label {
     opacity: 1;
@@ -505,8 +517,16 @@
   }
 
   .markdown-copy-button[data-state="copied"] {
-    border-color: color-mix(in srgb, var(--icon-success-base) 40%, var(--border-strong));
+    background: var(--surface-inset);
     color: var(--icon-success-base);
+  }
+
+  .markdown-copy-button[data-state="copied"] .markdown-copy-icon-copy {
+    @apply hidden;
+  }
+
+  .markdown-copy-button[data-state="copied"] .markdown-copy-icon-check {
+    @apply block;
   }
 
   .markdown-copy-button[data-state="copied"] .markdown-copy-label {
@@ -515,7 +535,7 @@
   }
 
   .markdown-copy-button[data-state="failed"] {
-    border-color: color-mix(in srgb, var(--interactive-critical) 40%, var(--border-strong));
+    background: var(--surface-inset);
     color: var(--interactive-critical);
   }
 

--- a/app-prefixable/src/index.css
+++ b/app-prefixable/src/index.css
@@ -451,13 +451,21 @@
   }
 
   .markdown-code-block pre {
-    @apply mb-0 pt-10;
+    @apply mb-0 pt-9;
   }
 
   .markdown-copy-button {
-    @apply absolute right-3 top-3 inline-flex items-center gap-1 rounded p-1.5 transition-colors;
+    @apply absolute right-3 top-2 inline-flex items-center gap-1 rounded p-1.5 transition-[opacity,color,background-color];
     color: var(--icon-base);
     background: transparent;
+    opacity: 0;
+  }
+
+  .markdown-code-block:hover .markdown-copy-button,
+  .markdown-code-block:focus-within .markdown-copy-button,
+  .markdown-copy-button[data-state="copied"],
+  .markdown-copy-button[data-state="failed"] {
+    opacity: 1;
   }
 
   .markdown-copy-button:hover {
@@ -482,14 +490,14 @@
   }
 
   .markdown-copy-icon-copy {
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='14' height='14' x='8' y='8' rx='2' ry='2'/%3E%3Cpath d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'/%3E%3C/svg%3E");
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='14' height='14' x='8' y='8' rx='2' ry='2'/%3E%3Cpath d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27black%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Crect%20width%3D%2714%27%20height%3D%2714%27%20x%3D%278%27%20y%3D%278%27%20rx%3D%272%27%20ry%3D%272%27%2F%3E%3Cpath%20d%3D%27M4%2016c-1.1%200-2-.9-2-2V4c0-1.1.9-2%202-2h10c1.1%200%202%20.9%202%202%27%2F%3E%3C%2Fsvg%3E");
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27black%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Crect%20width%3D%2714%27%20height%3D%2714%27%20x%3D%278%27%20y%3D%278%27%20rx%3D%272%27%20ry%3D%272%27%2F%3E%3Cpath%20d%3D%27M4%2016c-1.1%200-2-.9-2-2V4c0-1.1.9-2%202-2h10c1.1%200%202%20.9%202%202%27%2F%3E%3C%2Fsvg%3E");
   }
 
   .markdown-copy-icon-check {
     @apply hidden;
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27black%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20d%3D%27M20%206%209%2017l-5-5%27%2F%3E%3C%2Fsvg%3E");
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27black%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20d%3D%27M20%206%209%2017l-5-5%27%2F%3E%3C%2Fsvg%3E");
   }
 
   .markdown-copy-label {

--- a/app-prefixable/src/index.css
+++ b/app-prefixable/src/index.css
@@ -107,12 +107,6 @@
 }
 
 @layer components {
-  @media (hover: none), (pointer: coarse) {
-    .markdown-copy-button {
-      opacity: 1;
-    }
-  }
-
   /* ============================================
      BUTTONS
      ============================================ */
@@ -464,14 +458,21 @@
     @apply absolute right-3 top-2 inline-flex items-center gap-1 rounded p-1.5 transition-[opacity,color,background-color];
     color: var(--icon-base);
     background: transparent;
-    opacity: 0;
   }
 
-  .markdown-code-block:hover .markdown-copy-button,
-  .markdown-code-block:focus-within .markdown-copy-button,
-  .markdown-copy-button[data-state="copied"],
-  .markdown-copy-button[data-state="failed"] {
-    opacity: 1;
+  @media (hover: hover) and (pointer: fine) {
+    .markdown-copy-button {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .markdown-code-block:hover .markdown-copy-button,
+    .markdown-code-block:focus-within .markdown-copy-button,
+    .markdown-copy-button[data-state="copied"],
+    .markdown-copy-button[data-state="failed"] {
+      opacity: 1;
+      pointer-events: auto;
+    }
   }
 
   .markdown-copy-button:hover {

--- a/app-prefixable/src/index.css
+++ b/app-prefixable/src/index.css
@@ -451,7 +451,7 @@
   }
 
   .markdown-code-block pre {
-    @apply mb-0 pt-8;
+    @apply mb-0 pt-10;
   }
 
   .markdown-copy-button {

--- a/app-prefixable/src/index.css
+++ b/app-prefixable/src/index.css
@@ -107,6 +107,12 @@
 }
 
 @layer components {
+  @media (hover: none), (pointer: coarse) {
+    .copy-turn-button {
+      opacity: 1;
+    }
+  }
+
   /* ============================================
      BUTTONS
      ============================================ */

--- a/app-prefixable/src/index.css
+++ b/app-prefixable/src/index.css
@@ -108,7 +108,7 @@
 
 @layer components {
   @media (hover: none), (pointer: coarse) {
-    .copy-turn-button {
+    .markdown-copy-button {
       opacity: 1;
     }
   }


### PR DESCRIPTION
Closes #388

## Summary
- simplify the markdown code block copy affordance to match the lighter chat history style
- replace the unicode glyph with SVG-based copy and check icons while preserving copied and failed states
- reduce code block top padding to fit the smaller control