### PR TITLE
feat: add collapsible provider groups to model picker

### DIFF
--- a/app-prefixable/src/components/picker-dialog.tsx
+++ b/app-prefixable/src/components/picker-dialog.tsx
@@ -92,6 +92,13 @@ export function PickerDialog(props: Props) {
     return visibleSections().flatMap((section) => section.rows.map((row) => row.item))
   })
 
+  const activeDescendant = createMemo(() => {
+    if (visibleItems().length === 0) return
+    return `picker-option-${activeIndex()}`
+  })
+
+  const showCollapseHint = createMemo(() => visibleSections().some((section) => section.canCollapse))
+
   const keyboardSectionKey = createMemo(() => {
     if (!props.collapsibleGroups || filter().trim()) return
 
@@ -260,7 +267,7 @@ export function PickerDialog(props: Props) {
                 role="combobox"
                 aria-controls="picker-listbox"
                 aria-expanded="true"
-                aria-activedescendant={`picker-option-${activeIndex()}`}
+                aria-activedescendant={activeDescendant()}
                 placeholder={props.placeholder || "Filter..."}
                 value={filter()}
                 onInput={(e) => setFilter(e.currentTarget.value)}
@@ -272,7 +279,7 @@ export function PickerDialog(props: Props) {
             </div>
             <div class="mt-1.5 text-[10px]" style={{ color: "var(--text-weak)" }}>
               <span class="opacity-70">Arrow keys to navigate</span>
-              <Show when={props.collapsibleGroups}>
+              <Show when={showCollapseHint()}>
                 <span class="mx-1.5">-</span>
                 <span class="opacity-70">Left/right to collapse or expand groups</span>
               </Show>

--- a/app-prefixable/src/components/picker-dialog.tsx
+++ b/app-prefixable/src/components/picker-dialog.tsx
@@ -402,11 +402,11 @@ export function PickerDialog(props: Props) {
                           </div>
                         }
                       >
-                        <button
-                          type="button"
-                          class="w-full px-4 pt-3 pb-1 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide transition-colors"
+                        <div
+                          role="presentation"
+                          class="w-full px-4 pt-3 pb-1 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide transition-colors select-none cursor-pointer"
                           style={{ color: "var(--text-weak)", opacity: 0.9 }}
-                          aria-expanded={!section.isCollapsed}
+                          onMouseDown={(e) => e.preventDefault()}
                           onClick={() => toggleSection(section.key)}
                         >
                           <Show when={section.isCollapsed} fallback={<ChevronDown class="w-3 h-3 shrink-0" />}>
@@ -416,7 +416,7 @@ export function PickerDialog(props: Props) {
                           <span class="ml-auto text-[10px] tracking-normal normal-case opacity-70">
                             {section.isCollapsed ? "Collapsed" : "Expanded"}
                           </span>
-                        </button>
+                        </div>
                       </Show>
                     </Show>
 

--- a/app-prefixable/src/components/picker-dialog.tsx
+++ b/app-prefixable/src/components/picker-dialog.tsx
@@ -1,6 +1,6 @@
 import { createSignal, createEffect, createMemo, Show, onMount, onCleanup, For, Index } from "solid-js"
 import { Portal } from "solid-js/web"
-import { X, Search } from "lucide-solid"
+import { X, Search, ChevronDown, ChevronRight } from "lucide-solid"
 import { createBackdropDismiss } from "../utils/backdrop"
 
 interface PickerItem {
@@ -19,11 +19,13 @@ interface Props {
   emptyMessage?: string
   placeholder?: string
   initialFilter?: string
+  collapsibleGroups?: boolean
 }
 
 export function PickerDialog(props: Props) {
   const [filter, setFilter] = createSignal(props.initialFilter ?? "")
   const [activeIndex, setActiveIndex] = createSignal(0)
+  const [collapsed, setCollapsed] = createSignal(new Set<string>())
   let inputRef: HTMLInputElement | undefined
   let listRef: HTMLDivElement | undefined
   let closeButtonRef: HTMLButtonElement | undefined
@@ -43,29 +45,69 @@ export function PickerDialog(props: Props) {
   const isGrouped = createMemo(() => props.items.some((item) => !!item.groupKey?.trim()))
 
   const sections = createMemo(() => {
-    const map = new Map<string, { key: string; label?: string; rows: { item: PickerItem; index: number }[] }>()
+    const map = new Map<string, { key: string; label?: string; rows: PickerItem[] }>()
 
-    filtered().forEach((item, index) => {
+    filtered().forEach((item) => {
       const key = item.groupKey?.trim() || item.id
       const section = map.get(key)
       if (section) {
-        section.rows.push({ item, index })
+        section.rows.push(item)
         return
       }
 
       map.set(key, {
         key,
         label: item.group?.trim() || undefined,
-        rows: [{ item, index }],
+        rows: [item],
       })
     })
 
     return Array.from(map.values())
   })
 
+  const visibleSections = createMemo(() => {
+    const canCollapse = !!props.collapsibleGroups && !filter().trim()
+    let index = 0
+
+    return sections().map((section) => {
+      const isCollapsed = canCollapse && !!section.label && collapsed().has(section.key)
+      const rows = isCollapsed
+        ? []
+        : section.rows.map((item) => ({ item, index: index++ }))
+
+      return {
+        key: section.key,
+        label: section.label,
+        rows,
+        canCollapse: !!props.collapsibleGroups && !!section.label,
+        isCollapsed,
+      }
+    })
+  })
+
+  const visibleItems = createMemo(() => {
+    if (!isGrouped()) return filtered()
+    return visibleSections().flatMap((section) => section.rows.map((row) => row.item))
+  })
+
   createEffect(() => {
     filter()
     setActiveIndex(0)
+  })
+
+  createEffect(() => {
+    const keys = new Set(sections().map((section) => section.key))
+    setCollapsed((prev) => new Set(Array.from(prev).filter((key) => keys.has(key))))
+  })
+
+  createEffect(() => {
+    const count = visibleItems().length
+    const idx = activeIndex()
+    if (count === 0) {
+      if (idx !== 0) setActiveIndex(0)
+      return
+    }
+    if (idx >= count) setActiveIndex(count - 1)
   })
 
   createEffect(() => {
@@ -79,7 +121,7 @@ export function PickerDialog(props: Props) {
     inputRef?.focus()
 
     const handler = (e: KeyboardEvent) => {
-      const items = filtered()
+      const items = visibleItems()
       if (e.key === "Escape") {
         e.preventDefault()
         e.stopPropagation()
@@ -111,6 +153,16 @@ export function PickerDialog(props: Props) {
   })
 
   const backdrop = createBackdropDismiss(() => props.onClose())
+
+  function toggleSection(key: string) {
+    if (!props.collapsibleGroups || filter().trim()) return
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
 
   return (
     <Portal>
@@ -247,18 +299,39 @@ export function PickerDialog(props: Props) {
                 </Index>
               }
             >
-              <For each={sections()}>
+              <For each={visibleSections()}>
                 {(section) => (
                   <div role={section.label ? "group" : "presentation"} aria-label={section.label || undefined}>
                     <Show when={section.label}>
-                      <div
-                        role="presentation"
-                        aria-hidden="true"
-                        class="px-4 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-wide"
-                        style={{ color: "var(--text-weak)", opacity: 0.9 }}
+                      <Show
+                        when={section.canCollapse}
+                        fallback={
+                          <div
+                            role="presentation"
+                            aria-hidden="true"
+                            class="px-4 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-wide"
+                            style={{ color: "var(--text-weak)", opacity: 0.9 }}
+                          >
+                            {section.label}
+                          </div>
+                        }
                       >
-                        {section.label}
-                      </div>
+                        <button
+                          type="button"
+                          class="w-full px-4 pt-3 pb-1 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide transition-colors"
+                          style={{ color: "var(--text-weak)", opacity: 0.9 }}
+                          aria-expanded={!section.isCollapsed}
+                          onClick={() => toggleSection(section.key)}
+                        >
+                          <Show when={section.isCollapsed} fallback={<ChevronDown class="w-3 h-3 shrink-0" />}>
+                            <ChevronRight class="w-3 h-3 shrink-0" />
+                          </Show>
+                          <span>{section.label}</span>
+                          <span class="ml-auto text-[10px] tracking-normal normal-case opacity-70">
+                            {section.isCollapsed ? "Collapsed" : "Expanded"}
+                          </span>
+                        </button>
+                      </Show>
                     </Show>
 
                     <Index each={section.rows}>

--- a/app-prefixable/src/components/picker-dialog.tsx
+++ b/app-prefixable/src/components/picker-dialog.tsx
@@ -65,6 +65,8 @@ export function PickerDialog(props: Props) {
     return Array.from(map.values())
   })
 
+  const sectionKeys = createMemo(() => new Set(props.items.map((item) => item.groupKey?.trim() || item.id)))
+
   const visibleSections = createMemo(() => {
     const canCollapse = !!props.collapsibleGroups && !filter().trim()
     let index = 0
@@ -79,7 +81,7 @@ export function PickerDialog(props: Props) {
         key: section.key,
         label: section.label,
         rows,
-        canCollapse: !!props.collapsibleGroups && !!section.label,
+        canCollapse: canCollapse && !!section.label,
         isCollapsed,
       }
     })
@@ -112,7 +114,7 @@ export function PickerDialog(props: Props) {
   })
 
   createEffect(() => {
-    const keys = new Set(sections().map((section) => section.key))
+    const keys = sectionKeys()
     setCollapsed((prev) => new Set(Array.from(prev).filter((key) => keys.has(key))))
   })
 
@@ -159,6 +161,7 @@ export function PickerDialog(props: Props) {
         e.preventDefault()
         setActiveIndex((i) => (i - 1 + items.length) % items.length)
       } else if (e.key === "Enter" && items.length > 0) {
+        if (!isSelectableEnterTarget(e.target)) return
         e.preventDefault()
         const item = items[activeIndex()]
         if (item) {
@@ -192,6 +195,12 @@ export function PickerDialog(props: Props) {
   function toggleSection(key: string) {
     if (!props.collapsibleGroups || filter().trim()) return
     setSectionCollapsed(key, !collapsed().has(key))
+  }
+
+  function isSelectableEnterTarget(target: EventTarget | null) {
+    if (!(target instanceof Element)) return true
+    if (target.closest('[role="option"]')) return true
+    return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement
   }
 
   return (

--- a/app-prefixable/src/components/picker-dialog.tsx
+++ b/app-prefixable/src/components/picker-dialog.tsx
@@ -26,6 +26,7 @@ export function PickerDialog(props: Props) {
   const [filter, setFilter] = createSignal(props.initialFilter ?? "")
   const [activeIndex, setActiveIndex] = createSignal(0)
   const [collapsed, setCollapsed] = createSignal(new Set<string>())
+  const [keyboardSection, setKeyboardSection] = createSignal<string>()
   let inputRef: HTMLInputElement | undefined
   let listRef: HTMLDivElement | undefined
   let closeButtonRef: HTMLButtonElement | undefined
@@ -102,6 +103,9 @@ export function PickerDialog(props: Props) {
   const keyboardSectionKey = createMemo(() => {
     if (!props.collapsibleGroups || filter().trim()) return
 
+    const key = keyboardSection()
+    if (key && visibleSections().some((section) => section.key === key && section.canCollapse)) return key
+
     const idx = activeIndex()
     const active = visibleSections().find((section) => section.rows.some((row) => row.index === idx))
     if (active?.canCollapse) return active.key
@@ -123,6 +127,17 @@ export function PickerDialog(props: Props) {
   createEffect(() => {
     const keys = sectionKeys()
     setCollapsed((prev) => new Set(Array.from(prev).filter((key) => keys.has(key))))
+  })
+
+  createEffect(() => {
+    const key = keyboardSection()
+    if (!key) return
+    if (filter().trim()) {
+      setKeyboardSection()
+      return
+    }
+    if (visibleSections().some((section) => section.key === key && section.canCollapse)) return
+    setKeyboardSection()
   })
 
   createEffect(() => {
@@ -156,19 +171,32 @@ export function PickerDialog(props: Props) {
         if (!key || keyboardSectionCollapsed()) return
         e.preventDefault()
         setSectionCollapsed(key, true)
+        setKeyboardSection(key)
       } else if (e.key === "ArrowRight") {
         const key = keyboardSectionKey()
         if (!key || !keyboardSectionCollapsed()) return
         e.preventDefault()
         setSectionCollapsed(key, false)
+        setKeyboardSection()
+        setSectionActiveIndex(key)
       } else if (e.key === "ArrowDown" && items.length > 0) {
         e.preventDefault()
+        setKeyboardSection()
         setActiveIndex((i) => (i + 1) % items.length)
       } else if (e.key === "ArrowUp" && items.length > 0) {
         e.preventDefault()
+        setKeyboardSection()
         setActiveIndex((i) => (i - 1 + items.length) % items.length)
       } else if (e.key === "Enter" && items.length > 0) {
         if (!isSelectableEnterTarget(e.target)) return
+        const key = keyboardSectionKey()
+        if (key && keyboardSectionCollapsed()) {
+          e.preventDefault()
+          setSectionCollapsed(key, false)
+          setKeyboardSection()
+          setSectionActiveIndex(key)
+          return
+        }
         e.preventDefault()
         const item = items[activeIndex()]
         if (item) {
@@ -202,6 +230,11 @@ export function PickerDialog(props: Props) {
   function toggleSection(key: string) {
     if (!props.collapsibleGroups || filter().trim()) return
     setSectionCollapsed(key, !collapsed().has(key))
+  }
+
+  function setSectionActiveIndex(key: string) {
+    const row = visibleSections().find((section) => section.key === key)?.rows[0]
+    if (row) setActiveIndex(row.index)
   }
 
   function isSelectableEnterTarget(target: EventTarget | null) {
@@ -321,7 +354,10 @@ export function PickerDialog(props: Props) {
                           props.onSelect(item())
                           props.onClose()
                         }}
-                        onMouseEnter={() => setActiveIndex(idx)}
+                        onMouseEnter={() => {
+                          setKeyboardSection()
+                          setActiveIndex(idx)
+                        }}
                         class="w-full px-4 py-2.5 text-left flex flex-col gap-0.5 transition-colors"
                         style={{
                           background: isActive()
@@ -398,7 +434,10 @@ export function PickerDialog(props: Props) {
                               props.onSelect(row().item)
                               props.onClose()
                             }}
-                            onMouseEnter={() => setActiveIndex(row().index)}
+                            onMouseEnter={() => {
+                              setKeyboardSection()
+                              setActiveIndex(row().index)
+                            }}
                             class="w-full px-4 py-2.5 text-left flex flex-col gap-0.5 transition-colors"
                             style={{
                               background: isActive()

--- a/app-prefixable/src/components/picker-dialog.tsx
+++ b/app-prefixable/src/components/picker-dialog.tsx
@@ -90,6 +90,22 @@ export function PickerDialog(props: Props) {
     return visibleSections().flatMap((section) => section.rows.map((row) => row.item))
   })
 
+  const keyboardSectionKey = createMemo(() => {
+    if (!props.collapsibleGroups || filter().trim()) return
+
+    const idx = activeIndex()
+    const active = visibleSections().find((section) => section.rows.some((row) => row.index === idx))
+    if (active?.canCollapse) return active.key
+
+    return visibleSections().find((section) => section.canCollapse)?.key
+  })
+
+  const keyboardSectionCollapsed = createMemo(() => {
+    const key = keyboardSectionKey()
+    if (!key) return false
+    return !!visibleSections().find((section) => section.key === key)?.isCollapsed
+  })
+
   createEffect(() => {
     filter()
     setActiveIndex(0)
@@ -126,6 +142,16 @@ export function PickerDialog(props: Props) {
         e.preventDefault()
         e.stopPropagation()
         props.onClose()
+      } else if (e.key === "ArrowLeft") {
+        const key = keyboardSectionKey()
+        if (!key || keyboardSectionCollapsed()) return
+        e.preventDefault()
+        setSectionCollapsed(key, true)
+      } else if (e.key === "ArrowRight") {
+        const key = keyboardSectionKey()
+        if (!key || !keyboardSectionCollapsed()) return
+        e.preventDefault()
+        setSectionCollapsed(key, false)
       } else if (e.key === "ArrowDown" && items.length > 0) {
         e.preventDefault()
         setActiveIndex((i) => (i + 1) % items.length)
@@ -154,14 +180,18 @@ export function PickerDialog(props: Props) {
 
   const backdrop = createBackdropDismiss(() => props.onClose())
 
-  function toggleSection(key: string) {
-    if (!props.collapsibleGroups || filter().trim()) return
+  function setSectionCollapsed(key: string, value: boolean) {
     setCollapsed((prev) => {
       const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
+      if (value) next.add(key)
+      if (!value) next.delete(key)
       return next
     })
+  }
+
+  function toggleSection(key: string) {
+    if (!props.collapsibleGroups || filter().trim()) return
+    setSectionCollapsed(key, !collapsed().has(key))
   }
 
   return (
@@ -233,6 +263,10 @@ export function PickerDialog(props: Props) {
             </div>
             <div class="mt-1.5 text-[10px]" style={{ color: "var(--text-weak)" }}>
               <span class="opacity-70">Arrow keys to navigate</span>
+              <Show when={props.collapsibleGroups}>
+                <span class="mx-1.5">-</span>
+                <span class="opacity-70">Left/right to collapse or expand groups</span>
+              </Show>
               <span class="mx-1.5">-</span>
               <span class="opacity-70">Enter to select</span>
               <span class="mx-1.5">-</span>

--- a/app-prefixable/src/components/picker-dialog.tsx
+++ b/app-prefixable/src/components/picker-dialog.tsx
@@ -25,14 +25,17 @@ interface Props {
 export function PickerDialog(props: Props) {
   const [filter, setFilter] = createSignal(props.initialFilter ?? "")
   const [activeIndex, setActiveIndex] = createSignal(0)
+  const [activeId, setActiveId] = createSignal<string>()
   const [collapsed, setCollapsed] = createSignal(new Set<string>())
   const [keyboardSection, setKeyboardSection] = createSignal<string>()
   let inputRef: HTMLInputElement | undefined
   let listRef: HTMLDivElement | undefined
   let closeButtonRef: HTMLButtonElement | undefined
 
+  const query = createMemo(() => filter().trim().toLowerCase())
+
   const filtered = createMemo(() => {
-    const q = filter().toLowerCase()
+    const q = query()
     if (!q) return props.items
     return props.items.filter(
       (item) =>
@@ -69,7 +72,7 @@ export function PickerDialog(props: Props) {
   const sectionKeys = createMemo(() => new Set(props.items.map((item) => item.groupKey?.trim() || item.id)))
 
   const visibleSections = createMemo(() => {
-    const canCollapse = !!props.collapsibleGroups && !filter().trim()
+    const canCollapse = !!props.collapsibleGroups && !query()
     let index = 0
 
     return sections().map((section) => {
@@ -101,7 +104,7 @@ export function PickerDialog(props: Props) {
   const showCollapseHint = createMemo(() => visibleSections().some((section) => section.canCollapse))
 
   const keyboardSectionKey = createMemo(() => {
-    if (!props.collapsibleGroups || filter().trim()) return
+    if (!props.collapsibleGroups || query()) return
 
     const key = keyboardSection()
     if (key && visibleSections().some((section) => section.key === key && section.canCollapse)) return key
@@ -120,8 +123,9 @@ export function PickerDialog(props: Props) {
   })
 
   createEffect(() => {
-    filter()
+    query()
     setActiveIndex(0)
+    setActiveId()
   })
 
   createEffect(() => {
@@ -132,7 +136,7 @@ export function PickerDialog(props: Props) {
   createEffect(() => {
     const key = keyboardSection()
     if (!key) return
-    if (filter().trim()) {
+    if (query()) {
       setKeyboardSection()
       return
     }
@@ -148,6 +152,19 @@ export function PickerDialog(props: Props) {
       return
     }
     if (idx >= count) setActiveIndex(count - 1)
+  })
+
+  createEffect(() => {
+    if (activeId()) return
+    const item = visibleItems()[activeIndex()] || visibleItems()[0]
+    if (item) setActiveId(item.id)
+  })
+
+  createEffect(() => {
+    const id = activeId()
+    if (!id) return
+    const idx = visibleItems().findIndex((item) => item.id === id)
+    if (idx >= 0 && idx !== activeIndex()) setActiveIndex(idx)
   })
 
   createEffect(() => {
@@ -182,11 +199,11 @@ export function PickerDialog(props: Props) {
       } else if (e.key === "ArrowDown" && items.length > 0) {
         e.preventDefault()
         setKeyboardSection()
-        setActiveIndex((i) => (i + 1) % items.length)
+        setActive((activeIndex() + 1) % items.length)
       } else if (e.key === "ArrowUp" && items.length > 0) {
         e.preventDefault()
         setKeyboardSection()
-        setActiveIndex((i) => (i - 1 + items.length) % items.length)
+        setActive((activeIndex() - 1 + items.length) % items.length)
       } else if (e.key === "Enter" && items.length > 0) {
         if (!isSelectableEnterTarget(e.target)) return
         const key = keyboardSectionKey()
@@ -228,13 +245,25 @@ export function PickerDialog(props: Props) {
   }
 
   function toggleSection(key: string) {
-    if (!props.collapsibleGroups || filter().trim()) return
-    setSectionCollapsed(key, !collapsed().has(key))
+    if (!props.collapsibleGroups || query()) return
+    const item = visibleItems()[activeIndex()]
+    if (item) setActiveId(item.id)
+    const next = !collapsed().has(key)
+    const activeKey = item?.groupKey?.trim() || item?.id
+    if (next && activeKey === key) setKeyboardSection(key)
+    if (!next && keyboardSection() === key) setKeyboardSection()
+    setSectionCollapsed(key, next)
   }
 
   function setSectionActiveIndex(key: string) {
     const row = visibleSections().find((section) => section.key === key)?.rows[0]
-    if (row) setActiveIndex(row.index)
+    if (row) setActive(row.index)
+  }
+
+  function setActive(index: number) {
+    const item = visibleItems()[index]
+    if (item) setActiveId(item.id)
+    setActiveIndex(index)
   }
 
   function isSelectableEnterTarget(target: EventTarget | null) {
@@ -356,7 +385,7 @@ export function PickerDialog(props: Props) {
                         }}
                         onMouseEnter={() => {
                           setKeyboardSection()
-                          setActiveIndex(idx)
+                          setActive(idx)
                         }}
                         class="w-full px-4 py-2.5 text-left flex flex-col gap-0.5 transition-colors"
                         style={{
@@ -436,7 +465,7 @@ export function PickerDialog(props: Props) {
                             }}
                             onMouseEnter={() => {
                               setKeyboardSection()
-                              setActiveIndex(row().index)
+                              setActive(row().index)
                             }}
                             class="w-full px-4 py-2.5 text-left flex flex-col gap-0.5 transition-colors"
                             style={{

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -2854,6 +2854,7 @@ export function Session() {
             title="Select Model"
             placeholder="Filter models..."
             emptyMessage="No models found. Connect a provider in settings."
+            collapsibleGroups
             items={providers.providers
               .filter((p) => providers.connected.includes(p.id))
               .flatMap((p) =>


### PR DESCRIPTION
## Summary
- add optional collapsible grouped rendering to `PickerDialog` while keeping grouped pickers opt-in
- enable provider collapse/expand only in the session model picker and keep keyboard navigation scoped to visible rows
- auto-expand matching grouped results while filtering so hidden models remain discoverable

Closes #387