### PR TITLE
feat: add provider reconfigure and disconnect actions

### DIFF
--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -123,6 +123,7 @@ interface ProviderContextValue {
   }
   refetch: () => void
   connectProvider: (providerID: string, apiKey: string) => Promise<boolean>
+  disconnectProvider: (providerID: string) => Promise<boolean>
   startOAuth: (providerID: string, methodIndex: number) => Promise<OAuthAuthorization | undefined>
   completeOAuth: (providerID: string, methodIndex: number, code?: string) => Promise<boolean>
 }
@@ -447,6 +448,18 @@ export function ProviderProvider(props: ParentProps) {
     }
   }
 
+  async function disconnectProvider(providerID: string): Promise<boolean> {
+    try {
+      await client.auth.remove({ providerID })
+      await client.instance.dispose()
+      await refetchProviders()
+      return true
+    } catch (e) {
+      console.error("Failed to disconnect provider:", e)
+      return false
+    }
+  }
+
   async function startOAuth(providerID: string, methodIndex: number): Promise<OAuthAuthorization | undefined> {
     try {
       const res = await client.provider.oauth.authorize({
@@ -526,6 +539,7 @@ export function ProviderProvider(props: ParentProps) {
     },
     refetch,
     connectProvider,
+    disconnectProvider,
     startOAuth,
     completeOAuth,
   }

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -463,8 +463,12 @@ export function ProviderProvider(props: ParentProps) {
           delete state[sessionID]
         }
       }))
-      await client.instance.dispose()
-      await refetchProviders()
+      try {
+        await client.instance.dispose()
+        await refetchProviders()
+      } catch (e) {
+        console.error("Failed to refresh providers after disconnect:", e)
+      }
       return true
     } catch (e) {
       console.error("Failed to disconnect provider:", e)

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -451,6 +451,18 @@ export function ProviderProvider(props: ParentProps) {
   async function disconnectProvider(providerID: string): Promise<boolean> {
     try {
       await client.auth.remove({ providerID })
+      setStore("modelsByAgent", produce((state) => {
+        for (const [agent, model] of Object.entries(state)) {
+          if (model.providerID !== providerID) continue
+          delete state[agent]
+        }
+      }))
+      setStore("sessionModels", produce((state) => {
+        for (const [sessionID, model] of Object.entries(state)) {
+          if (model.providerID !== providerID) continue
+          delete state[sessionID]
+        }
+      }))
       await client.instance.dispose()
       await refetchProviders()
       return true

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -232,6 +232,8 @@ export function Settings() {
     return providers.connected.includes(id)
   })
 
+  const providerActionBusy = createMemo(() => !!providerDeleting() || connecting() || !!oauthPending())
+
   // Popular providers shown first
   const popularProviders = ["opencode", "anthropic", "github-copilot", "openai", "google", "openrouter"]
 
@@ -600,7 +602,7 @@ Add your project-specific instructions here.
   }
 
   function startProviderEdit(providerID: string) {
-    if (providerDeleting()) return
+    if (providerActionBusy()) return
     setError(null)
     setSuccess(null)
     setOauthPending(null)
@@ -1110,11 +1112,11 @@ Add your project-specific instructions here.
                               <button
                                 type="button"
                                 onClick={() => startProviderEdit(providerID)}
-                                disabled={!!providerDeleting()}
+                                disabled={providerActionBusy()}
                                 class="p-1.5 rounded transition-colors"
                                 style={{
                                   color: "var(--text-weak)",
-                                  ...(providerDeleting() ? { opacity: "0.6", cursor: "not-allowed" } : {}),
+                                  ...(providerActionBusy() ? { opacity: "0.6", cursor: "not-allowed" } : {}),
                                 }}
                                 title={`Reconfigure ${getProviderDisplayName(providerID)}`}
                                 aria-label={`Reconfigure ${getProviderDisplayName(providerID)}`}
@@ -1123,12 +1125,12 @@ Add your project-specific instructions here.
                               </button>
                               <button
                                 type="button"
-                                disabled={!!providerDeleting()}
+                                disabled={providerActionBusy()}
                                 onClick={() => setProviderToDelete(providerID)}
                                 class="p-1.5 rounded transition-colors"
                                 style={{
                                   color: "var(--interactive-critical)",
-                                  ...(providerDeleting() ? { opacity: "0.6", cursor: "not-allowed" } : {}),
+                                  ...(providerActionBusy() ? { opacity: "0.6", cursor: "not-allowed" } : {}),
                                 }}
                                 title={`Disconnect ${getProviderDisplayName(providerID)}`}
                                 aria-label={`Disconnect ${getProviderDisplayName(providerID)}`}
@@ -2718,13 +2720,13 @@ Add your project-specific instructions here.
         title="Disconnect Provider"
         message={`Are you sure you want to disconnect ${providerToDelete() ? getProviderDisplayName(providerToDelete()!) : "this provider"}?`}
         confirmLabel={providerDeleting() ? "Disconnecting..." : "Disconnect"}
-        confirmDisabled={!!providerDeleting()}
-        cancelDisabled={!!providerDeleting()}
+        confirmDisabled={providerActionBusy()}
+        cancelDisabled={providerActionBusy()}
         variant="danger"
         error={providerDeleteError()}
         onConfirm={confirmProviderDelete}
         onCancel={() => {
-          if (providerDeleting()) return
+          if (providerActionBusy()) return
           setProviderToDelete(null)
           setProviderDeleteError(null)
         }}

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -52,6 +52,8 @@ export function Settings() {
   const [mcpDeleting, setMcpDeleting] = createSignal<string | null>(null)
   const [mcpToDelete, setMcpToDelete] = createSignal<string | null>(null)
   const [providerToDelete, setProviderToDelete] = createSignal<string | null>(null)
+  const [providerDeleting, setProviderDeleting] = createSignal<string | null>(null)
+  const [providerDeleteError, setProviderDeleteError] = createSignal<string | null>(null)
 
   // Saved prompts
   const savedPrompts = useSavedPrompts()
@@ -222,6 +224,12 @@ export function Settings() {
     const id = selectedProvider()
     if (!id) return null
     return getProviderDisplayName(id)
+  })
+
+  const selectedProviderConnected = createMemo(() => {
+    const id = selectedProvider()
+    if (!id) return false
+    return providers.connected.includes(id)
   })
 
   // Popular providers shown first
@@ -592,6 +600,7 @@ Add your project-specific instructions here.
   }
 
   function startProviderEdit(providerID: string) {
+    if (providerDeleting()) return
     setError(null)
     setSuccess(null)
     setOauthPending(null)
@@ -604,12 +613,15 @@ Add your project-specific instructions here.
 
   async function confirmProviderDelete() {
     const providerID = providerToDelete()
-    if (!providerID) return
-    setProviderToDelete(null)
+    if (!providerID || providerDeleting()) return
+    setProviderDeleting(providerID)
+    setProviderDeleteError(null)
     setError(null)
     setSuccess(null)
     const ok = await providers.disconnectProvider(providerID)
+    setProviderDeleting(null)
     if (ok) {
+      setProviderToDelete(null)
       if (selectedProvider() === providerID) {
         setSelectedProvider(null)
         setApiKey("")
@@ -620,7 +632,7 @@ Add your project-specific instructions here.
       setSuccess(`Disconnected ${getProviderDisplayName(providerID)}.`)
       return
     }
-    setError(`Failed to disconnect ${getProviderDisplayName(providerID)}. Please try again.`)
+    setProviderDeleteError(`Failed to disconnect ${getProviderDisplayName(providerID)}. Please try again.`)
   }
 
   async function handleOAuthStart(providerID: string, methodIndex: number) {
@@ -1098,8 +1110,12 @@ Add your project-specific instructions here.
                               <button
                                 type="button"
                                 onClick={() => startProviderEdit(providerID)}
+                                disabled={!!providerDeleting()}
                                 class="p-1.5 rounded transition-colors"
-                                style={{ color: "var(--text-weak)" }}
+                                style={{
+                                  color: "var(--text-weak)",
+                                  ...(providerDeleting() ? { opacity: "0.6", cursor: "not-allowed" } : {}),
+                                }}
                                 title={`Reconfigure ${getProviderDisplayName(providerID)}`}
                                 aria-label={`Reconfigure ${getProviderDisplayName(providerID)}`}
                               >
@@ -1107,9 +1123,13 @@ Add your project-specific instructions here.
                               </button>
                               <button
                                 type="button"
+                                disabled={!!providerDeleting()}
                                 onClick={() => setProviderToDelete(providerID)}
                                 class="p-1.5 rounded transition-colors"
-                                style={{ color: "var(--interactive-critical)" }}
+                                style={{
+                                  color: "var(--interactive-critical)",
+                                  ...(providerDeleting() ? { opacity: "0.6", cursor: "not-allowed" } : {}),
+                                }}
                                 title={`Disconnect ${getProviderDisplayName(providerID)}`}
                                 aria-label={`Disconnect ${getProviderDisplayName(providerID)}`}
                               >
@@ -1283,7 +1303,7 @@ Add your project-specific instructions here.
                     {/* Search and Provider Selection */}
                     <Show when={!oauthPending()}>
                       <div>
-                        <Show when={selectedProvider() && providers.connected.includes(selectedProvider()!)}>
+                        <Show when={selectedProvider() && selectedProviderConnected()}>
                           <div
                             class="mb-3 p-3 rounded-md text-sm"
                             style={{
@@ -1298,7 +1318,7 @@ Add your project-specific instructions here.
 
                         {/* Search input */}
                         <Show
-                          when={!selectedProvider() || !providers.connected.includes(selectedProvider()!)}
+                          when={!selectedProvider() || !selectedProviderConnected()}
                           fallback={
                             <button
                               type="button"
@@ -1404,7 +1424,7 @@ Add your project-specific instructions here.
                     <Show when={selectedProvider() && !oauthPending()}>
                       <div class="space-y-3">
                         <label class="block text-sm font-medium" style={{ color: "var(--text-base)" }}>
-                          {providers.connected.includes(selectedProvider()!) ? "Update" : "Connect"} {getProviderDisplayName(selectedProvider()!)}
+                          {selectedProviderConnected() ? "Update" : "Connect"} {getProviderDisplayName(selectedProvider()!)}
                         </label>
 
                         {/* Show auth method buttons */}
@@ -1434,9 +1454,9 @@ Add your project-specific instructions here.
                                   color: "white",
                                 }}
                               >
-                                <Show when={connecting()} fallback={providers.connected.includes(selectedProvider()!) ? "Update API Key" : "Connect with API Key"}>
+                                <Show when={connecting()} fallback={selectedProviderConnected() ? "Update API Key" : "Connect with API Key"}>
                                   <Spinner class="w-4 h-4" />
-                                  Connecting...
+                                  {selectedProviderConnected() ? "Updating..." : "Connecting..."}
                                 </Show>
                               </button>
                             </div>
@@ -1478,9 +1498,9 @@ Add your project-specific instructions here.
                                           color: "white",
                                         }}
                                       >
-                                        <Show when={connecting()} fallback={providers.connected.includes(selectedProvider()!) ? "Update" : "Connect"}>
+                                        <Show when={connecting()} fallback={selectedProviderConnected() ? "Update" : "Connect"}>
                                           <Spinner class="w-4 h-4" />
-                                          Connecting...
+                                          {selectedProviderConnected() ? "Updating..." : "Connecting..."}
                                         </Show>
                                       </button>
                                     </div>
@@ -2697,10 +2717,17 @@ Add your project-specific instructions here.
         open={!!providerToDelete()}
         title="Disconnect Provider"
         message={`Are you sure you want to disconnect ${providerToDelete() ? getProviderDisplayName(providerToDelete()!) : "this provider"}?`}
-        confirmLabel="Disconnect"
+        confirmLabel={providerDeleting() ? "Disconnecting..." : "Disconnect"}
+        confirmDisabled={!!providerDeleting()}
+        cancelDisabled={!!providerDeleting()}
         variant="danger"
+        error={providerDeleteError()}
         onConfirm={confirmProviderDelete}
-        onCancel={() => setProviderToDelete(null)}
+        onCancel={() => {
+          if (providerDeleting()) return
+          setProviderToDelete(null)
+          setProviderDeleteError(null)
+        }}
       />
 
       {/* Prompt Add/Edit Dialog */}

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -193,6 +193,7 @@ export function Settings() {
   const [oauthPending, setOauthPending] = createSignal<{
     providerID: string
     providerName: string
+    updating: boolean
     methodIndex: number
     method: "auto" | "code"
     instructions: string
@@ -640,6 +641,7 @@ Add your project-specific instructions here.
   async function handleOAuthStart(providerID: string, methodIndex: number) {
     setError(null)
     setSuccess(null)
+    const updating = providers.connected.includes(providerID)
 
     const result = await providers.startOAuth(providerID, methodIndex)
 
@@ -655,6 +657,7 @@ Add your project-specific instructions here.
         setOauthPending({
           providerID,
           providerName,
+          updating,
           methodIndex,
           method: "code",
           instructions: result.instructions,
@@ -667,6 +670,7 @@ Add your project-specific instructions here.
         setOauthPending({
           providerID,
           providerName,
+          updating,
           methodIndex,
           method: "auto",
           instructions: result.instructions,
@@ -685,7 +689,7 @@ Add your project-specific instructions here.
         setConnecting(false)
 
         if (ok) {
-          setSuccess(`Connected to ${providerName}!`)
+          setSuccess(`${updating ? "Updated" : "Connected to"} ${providerName}!`)
           setOauthPending(null)
           setSelectedProvider(null)
           setProviderSearch("")
@@ -712,7 +716,7 @@ Add your project-specific instructions here.
     setConnecting(false)
 
     if (ok) {
-      setSuccess(`Connected to ${pending.providerName}!`)
+      setSuccess(`${pending.updating ? "Updated" : "Connected to"} ${pending.providerName}!`)
       setOauthPending(null)
       setOauthCode("")
       setSelectedProvider(null)
@@ -1324,9 +1328,13 @@ Add your project-specific instructions here.
                           fallback={
                             <button
                               type="button"
+                              disabled={providerActionBusy()}
                               onClick={() => setSelectedProvider(null)}
                               class="text-sm"
-                              style={{ color: "var(--text-weak)" }}
+                              style={{
+                                color: "var(--text-weak)",
+                                ...(providerActionBusy() ? { opacity: "0.6", cursor: "not-allowed" } : {}),
+                              }}
                             >
                               Choose a different provider
                             </button>

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -51,6 +51,7 @@ export function Settings() {
   const [mcpLoading, setMcpLoading] = createSignal<string | null>(null)
   const [mcpDeleting, setMcpDeleting] = createSignal<string | null>(null)
   const [mcpToDelete, setMcpToDelete] = createSignal<string | null>(null)
+  const [providerToDelete, setProviderToDelete] = createSignal<string | null>(null)
 
   // Saved prompts
   const savedPrompts = useSavedPrompts()
@@ -215,6 +216,12 @@ export function Settings() {
     const id = selectedProvider()
     if (!id) return []
     return providers.authMethods[id] || []
+  })
+
+  const selectedProviderName = createMemo(() => {
+    const id = selectedProvider()
+    if (!id) return null
+    return getProviderDisplayName(id)
   })
 
   // Popular providers shown first
@@ -564,6 +571,7 @@ Add your project-specific instructions here.
     const key = apiKey().trim()
 
     if (!providerID || !key) return
+    const wasConnected = providers.connected.includes(providerID)
 
     setConnecting(true)
     setError(null)
@@ -574,12 +582,45 @@ Add your project-specific instructions here.
     setConnecting(false)
 
     if (ok) {
-      setSuccess(`Connected to ${providerID}!`)
+      setSuccess(`${wasConnected ? "Updated" : "Connected to"} ${getProviderDisplayName(providerID)}!`)
       setApiKey("")
       setSelectedProvider(null)
+      setProviderSearch("")
     } else {
       setError("Failed to connect. Please check your API key.")
     }
+  }
+
+  function startProviderEdit(providerID: string) {
+    setError(null)
+    setSuccess(null)
+    setOauthPending(null)
+    setOauthCode("")
+    setCodeCopied(false)
+    setApiKey("")
+    setProviderSearch("")
+    setSelectedProvider(providerID)
+  }
+
+  async function confirmProviderDelete() {
+    const providerID = providerToDelete()
+    if (!providerID) return
+    setProviderToDelete(null)
+    setError(null)
+    setSuccess(null)
+    const ok = await providers.disconnectProvider(providerID)
+    if (ok) {
+      if (selectedProvider() === providerID) {
+        setSelectedProvider(null)
+        setApiKey("")
+        setOauthPending(null)
+        setOauthCode("")
+        setCodeCopied(false)
+      }
+      setSuccess(`Disconnected ${getProviderDisplayName(providerID)}.`)
+      return
+    }
+    setError(`Failed to disconnect ${getProviderDisplayName(providerID)}. Please try again.`)
   }
 
   async function handleOAuthStart(providerID: string, methodIndex: number) {
@@ -1039,7 +1080,7 @@ Add your project-specific instructions here.
                       <For each={providers.connected}>
                         {(providerID) => (
                           <div
-                            class="flex items-center justify-between p-3 rounded-md"
+                            class="flex items-center justify-between gap-3 p-3 rounded-md"
                             style={{ background: "var(--surface-inset)" }}
                           >
                             <div class="flex items-center gap-3">
@@ -1050,9 +1091,31 @@ Add your project-specific instructions here.
                                 {getProviderDisplayName(providerID)}
                               </span>
                             </div>
-                            <span class="text-xs" style={{ color: "var(--text-weak)" }}>
-                              Connected
-                            </span>
+                            <div class="flex items-center gap-2">
+                              <span class="text-xs" style={{ color: "var(--text-weak)" }}>
+                                Connected
+                              </span>
+                              <button
+                                type="button"
+                                onClick={() => startProviderEdit(providerID)}
+                                class="p-1.5 rounded transition-colors"
+                                style={{ color: "var(--text-weak)" }}
+                                title={`Reconfigure ${getProviderDisplayName(providerID)}`}
+                                aria-label={`Reconfigure ${getProviderDisplayName(providerID)}`}
+                              >
+                                <Pencil class="w-4 h-4" />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setProviderToDelete(providerID)}
+                                class="p-1.5 rounded transition-colors"
+                                style={{ color: "var(--interactive-critical)" }}
+                                title={`Disconnect ${getProviderDisplayName(providerID)}`}
+                                aria-label={`Disconnect ${getProviderDisplayName(providerID)}`}
+                              >
+                                <Trash2 class="w-4 h-4" />
+                              </button>
+                            </div>
                           </div>
                         )}
                       </For>
@@ -1220,92 +1283,119 @@ Add your project-specific instructions here.
                     {/* Search and Provider Selection */}
                     <Show when={!oauthPending()}>
                       <div>
-                        {/* Search input */}
-                        <div class="relative mb-3">
-                          <Search
-                            class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
-                            style={{ color: "var(--text-weak)" }}
-                          />
-                          <input
-                            type="text"
-                            value={providerSearch()}
-                            onInput={(e) => setProviderSearch(e.currentTarget.value)}
-                            placeholder="Search providers..."
-                            class="w-full pl-9 pr-8 py-2 rounded-md text-sm"
+                        <Show when={selectedProvider() && providers.connected.includes(selectedProvider()!)}>
+                          <div
+                            class="mb-3 p-3 rounded-md text-sm"
                             style={{
-                              background: "var(--background-base)",
+                              background: "var(--surface-inset)",
                               border: "1px solid var(--border-base)",
                               color: "var(--text-base)",
                             }}
-                          />
-                          <Show when={providerSearch()}>
-                            <button
-                              type="button"
-                              onClick={() => setProviderSearch("")}
-                              class="absolute right-2 top-1/2 -translate-y-1/2 p-1"
-                              style={{ color: "var(--text-weak)" }}
-                            >
-                              <X class="w-4 h-4" />
-                            </button>
-                          </Show>
-                        </div>
-
-                        {/* Provider grid - max height with scroll */}
-                        <div class="grid grid-cols-2 gap-2 max-h-64 overflow-y-auto">
-                          <For each={filteredProviders()}>
-                            {(provider) => (
-                              <button
-                                type="button"
-                                onClick={() => setSelectedProvider(provider.id)}
-                                class="p-3 rounded-md text-left transition-colors"
-                                style={{
-                                  border:
-                                    selectedProvider() === provider.id
-                                      ? "1px solid var(--interactive-base)"
-                                      : "1px solid var(--border-base)",
-                                  background:
-                                    selectedProvider() === provider.id ? "var(--surface-inset)" : "transparent",
-                                }}
-                              >
-                                <div class="flex items-center gap-2">
-                                  <span class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
-                                    {provider.name}
-                                  </span>
-                                  <Show when={provider.id === "opencode"}>
-                                    <span
-                                      class="text-xs px-1.5 py-0.5 rounded"
-                                      style={{
-                                        background: "var(--interactive-base)",
-                                        color: "white",
-                                      }}
-                                    >
-                                      Recommended
-                                    </span>
-                                  </Show>
-                                </div>
-                                <div class="text-xs" style={{ color: "var(--text-weak)" }}>
-                                  {Object.keys(provider.models).length} models
-                                </div>
-                              </button>
-                            )}
-                          </For>
-                        </div>
-
-                        <Show when={filteredProviders().length === 0 && providerSearch()}>
-                          <p class="text-sm text-center py-4" style={{ color: "var(--text-weak)" }}>
-                            No providers found matching "{providerSearch()}"
-                          </p>
+                          >
+                            Reconfiguring {selectedProviderName()}
+                          </div>
                         </Show>
 
+                        {/* Search input */}
                         <Show
-                          when={
-                            providers.providers.filter((p) => !providers.connected.includes(p.id)).length === 0 &&
-                            !providerSearch()
+                          when={!selectedProvider() || !providers.connected.includes(selectedProvider()!)}
+                          fallback={
+                            <button
+                              type="button"
+                              onClick={() => setSelectedProvider(null)}
+                              class="text-sm"
+                              style={{ color: "var(--text-weak)" }}
+                            >
+                              Choose a different provider
+                            </button>
                           }
                         >
-                          <p class="text-sm" style={{ color: "var(--text-weak)" }}>
-                            All available providers are connected!
-                          </p>
+                          <div class="relative mb-3">
+                            <Search
+                              class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
+                              style={{ color: "var(--text-weak)" }}
+                            />
+                            <input
+                              type="text"
+                              value={providerSearch()}
+                              onInput={(e) => setProviderSearch(e.currentTarget.value)}
+                              placeholder="Search providers..."
+                              class="w-full pl-9 pr-8 py-2 rounded-md text-sm"
+                              style={{
+                                background: "var(--background-base)",
+                                border: "1px solid var(--border-base)",
+                                color: "var(--text-base)",
+                              }}
+                            />
+                            <Show when={providerSearch()}>
+                              <button
+                                type="button"
+                                onClick={() => setProviderSearch("")}
+                                class="absolute right-2 top-1/2 -translate-y-1/2 p-1"
+                                style={{ color: "var(--text-weak)" }}
+                              >
+                                <X class="w-4 h-4" />
+                              </button>
+                            </Show>
+                          </div>
+
+                          {/* Provider grid - max height with scroll */}
+                          <div class="grid grid-cols-2 gap-2 max-h-64 overflow-y-auto">
+                            <For each={filteredProviders()}>
+                              {(provider) => (
+                                <button
+                                  type="button"
+                                  onClick={() => setSelectedProvider(provider.id)}
+                                  class="p-3 rounded-md text-left transition-colors"
+                                  style={{
+                                    border:
+                                      selectedProvider() === provider.id
+                                        ? "1px solid var(--interactive-base)"
+                                        : "1px solid var(--border-base)",
+                                    background:
+                                      selectedProvider() === provider.id ? "var(--surface-inset)" : "transparent",
+                                  }}
+                                >
+                                  <div class="flex items-center gap-2">
+                                    <span class="text-sm font-medium" style={{ color: "var(--text-strong)" }}>
+                                      {provider.name}
+                                    </span>
+                                    <Show when={provider.id === "opencode"}>
+                                      <span
+                                        class="text-xs px-1.5 py-0.5 rounded"
+                                        style={{
+                                          background: "var(--interactive-base)",
+                                          color: "white",
+                                        }}
+                                      >
+                                        Recommended
+                                      </span>
+                                    </Show>
+                                  </div>
+                                  <div class="text-xs" style={{ color: "var(--text-weak)" }}>
+                                    {Object.keys(provider.models).length} models
+                                  </div>
+                                </button>
+                              )}
+                            </For>
+                          </div>
+
+                          <Show when={filteredProviders().length === 0 && providerSearch()}>
+                            <p class="text-sm text-center py-4" style={{ color: "var(--text-weak)" }}>
+                              No providers found matching "{providerSearch()}"
+                            </p>
+                          </Show>
+
+                          <Show
+                            when={
+                              providers.providers.filter((p) => !providers.connected.includes(p.id)).length === 0 &&
+                              !providerSearch()
+                            }
+                          >
+                            <p class="text-sm" style={{ color: "var(--text-weak)" }}>
+                              All available providers are connected!
+                            </p>
+                          </Show>
                         </Show>
                       </div>
                     </Show>
@@ -1314,7 +1404,7 @@ Add your project-specific instructions here.
                     <Show when={selectedProvider() && !oauthPending()}>
                       <div class="space-y-3">
                         <label class="block text-sm font-medium" style={{ color: "var(--text-base)" }}>
-                          Connect {getProviderDisplayName(selectedProvider()!)}
+                          {providers.connected.includes(selectedProvider()!) ? "Update" : "Connect"} {getProviderDisplayName(selectedProvider()!)}
                         </label>
 
                         {/* Show auth method buttons */}
@@ -1344,7 +1434,7 @@ Add your project-specific instructions here.
                                   color: "white",
                                 }}
                               >
-                                <Show when={connecting()} fallback="Connect with API Key">
+                                <Show when={connecting()} fallback={providers.connected.includes(selectedProvider()!) ? "Update API Key" : "Connect with API Key"}>
                                   <Spinner class="w-4 h-4" />
                                   Connecting...
                                 </Show>
@@ -1388,7 +1478,7 @@ Add your project-specific instructions here.
                                           color: "white",
                                         }}
                                       >
-                                        <Show when={connecting()} fallback="Connect">
+                                        <Show when={connecting()} fallback={providers.connected.includes(selectedProvider()!) ? "Update" : "Connect"}>
                                           <Spinner class="w-4 h-4" />
                                           Connecting...
                                         </Show>
@@ -2601,6 +2691,16 @@ Add your project-specific instructions here.
         variant="danger"
         onConfirm={confirmMcpDelete}
         onCancel={() => setMcpToDelete(null)}
+      />
+
+      <ConfirmDialog
+        open={!!providerToDelete()}
+        title="Disconnect Provider"
+        message={`Are you sure you want to disconnect ${providerToDelete() ? getProviderDisplayName(providerToDelete()!) : "this provider"}?`}
+        confirmLabel="Disconnect"
+        variant="danger"
+        onConfirm={confirmProviderDelete}
+        onCancel={() => setProviderToDelete(null)}
       />
 
       {/* Prompt Add/Edit Dialog */}


### PR DESCRIPTION
## Summary
- add edit and disconnect actions to connected provider entries in Settings
- reuse the existing provider auth flow for API key reconfiguration and keep OAuth flows intact
- confirm before disconnecting and refresh provider state after credential removal

Closes #391