### PR TITLE
fix: autosend persisted followups

### DIFF
--- a/app-prefixable/src/context/events.tsx
+++ b/app-prefixable/src/context/events.tsx
@@ -164,9 +164,9 @@ export function EventProvider(props: ParentProps) {
         for (const [sessionID, s] of Object.entries(statuses)) {
           if (!sseSeenStatuses.has(sessionID)) setStatus(sessionID, s)
         }
+        setStatusReady(true)
       })
       .catch((err) => console.error("[Events] Failed to load statuses:", err))
-      .finally(() => setStatusReady(true))
   })
 
   onCleanup(() => {

--- a/app-prefixable/src/context/events.tsx
+++ b/app-prefixable/src/context/events.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, onCleanup, onMount, type ParentProps } from "solid-js"
+import { createContext, useContext, createSignal, onCleanup, onMount, type ParentProps } from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import type { Event, SessionStatus, QuestionRequest } from "../sdk/client"
 import { useSDK } from "./sdk"
@@ -10,6 +10,7 @@ type EventHandler = (event: Event) => void
 interface EventContextValue {
   subscribe: (handler: EventHandler) => () => void
   status: Record<string, SessionStatus>
+  statusReady: () => boolean
   pendingQuestions: Record<string, QuestionRequest | undefined>
   dismissQuestion: (sessionID: string, requestID: string) => void
 }
@@ -21,6 +22,7 @@ export function EventProvider(props: ParentProps) {
   const { authHeaders } = useServer()
   const handlers = new Set<EventHandler>()
   const [status, setStatus] = createStore<Record<string, SessionStatus>>({})
+  const [statusReady, setStatusReady] = createSignal(false)
   const [pendingQuestions, setPendingQuestions] = createStore<Record<string, QuestionRequest | undefined>>({})
 
   // Connect to SSE endpoint using fetch (supports custom headers unlike EventSource)
@@ -140,7 +142,10 @@ export function EventProvider(props: ParentProps) {
 
   onMount(() => {
     connect()
-    if (!directory) return
+    if (!directory) {
+      setStatusReady(true)
+      return
+    }
     client.question.list({ directory })
       .then((res) => {
         const questions = Array.isArray(res.data) ? res.data : []
@@ -161,6 +166,7 @@ export function EventProvider(props: ParentProps) {
         }
       })
       .catch((err) => console.error("[Events] Failed to load statuses:", err))
+      .finally(() => setStatusReady(true))
   })
 
   onCleanup(() => {
@@ -184,7 +190,7 @@ export function EventProvider(props: ParentProps) {
     }))
   }
 
-  return <EventContext.Provider value={{ subscribe, status, pendingQuestions, dismissQuestion }}>{props.children}</EventContext.Provider>
+  return <EventContext.Provider value={{ subscribe, status, statusReady, pendingQuestions, dismissQuestion }}>{props.children}</EventContext.Provider>
 }
 
 export function useEvents() {

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -489,6 +489,7 @@ export function Session() {
 
   function followupSessionAvailable(id: string) {
     const status = events.status[id]?.type;
+    if (!status && !events.statusReady()) return false;
     return status !== "busy" && status !== "retry";
   }
 

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -487,6 +487,11 @@ export function Session() {
     setError(message);
   }
 
+  function followupSessionAvailable(id: string) {
+    const status = events.status[id]?.type;
+    return status !== "busy" && status !== "retry";
+  }
+
   function toggleFollowupAutoSend() {
     const id = sessionId();
     if (!id) return;
@@ -494,8 +499,7 @@ export function Session() {
     setSessionFollowupAutoSend(id, enabled);
     clearAutoFollowupStatusError();
     if (!enabled) return;
-    const status = events.status[id]?.type;
-    if (status !== "idle") return;
+    if (!followupSessionAvailable(id)) return;
     queueAutoFollowupSend();
   }
 
@@ -805,8 +809,7 @@ export function Session() {
     if (!followupAutoSend()) return;
     if (followupAutoPending()) return;
     if (loading() || followupSending() || processing()) return;
-    const status = events.status[sid]?.type;
-    if (status !== "idle") return;
+    if (!followupSessionAvailable(sid)) return;
     const next = followups()[0];
     if (!next) return;
     if (followupAutoPaused() === next.id) return;
@@ -827,8 +830,7 @@ export function Session() {
       return;
     }
     if (loading() || followupSending() || processing()) return;
-    const status = events.status[sid]?.type;
-    if (status !== "idle") return;
+    if (!followupSessionAvailable(sid)) return;
     const next = followups()[0];
     if (!next) {
       setFollowupAutoPending(false);


### PR DESCRIPTION
## Summary
- Allow followup autosend to proceed when a session has no status entry, while still blocking explicit busy/retry states.
- Reuse the same availability check for toggling autosend and pending autosend execution.

## Verification
- bun run build
- bun test tests/session-start.test.ts
- bun run typecheck (fails on existing unrelated TypeScript errors)
- bun run lint (fails on existing unrelated lint errors)
- bun test tests/ (fails on existing API contract/local environment issues)

Closes #393