### PR TITLE
fix: update MCP URL guidance

### DIFF
--- a/app-prefixable/src/components/mcp-add-dialog.tsx
+++ b/app-prefixable/src/components/mcp-add-dialog.tsx
@@ -195,12 +195,12 @@ export function MCPAddDialog(props: Props) {
               type="text"
               value={url()}
               onInput={(e) => setUrl(e.currentTarget.value)}
-              placeholder="https://mcp.example.com/sse"
+              placeholder="https://mcp.example.com/mcp/"
               class="w-full px-3 py-2 rounded-md text-sm"
               style={inputStyle}
             />
             <p class="text-xs mt-1" style={{ color: "var(--text-weak)" }}>
-              The URL of the remote MCP server (SSE or HTTP endpoint)
+              The URL of the remote MCP server. OpenCode supports streamable HTTP and SSE transports.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Update the Add MCP Server placeholder to use the modern `/mcp/` endpoint shape.
- Clarify that OpenCode supports streamable HTTP and SSE transports for remote MCP servers.

## Testing
- `bunx eslint src/components/mcp-add-dialog.tsx` (passes with existing warnings in this file)
- `bun run lint` (fails on existing unrelated repo-wide lint errors)
- `bun run typecheck` (fails on existing unrelated repo-wide type errors)

Note: existing uncommitted Docker/Telegram changes are present in the worktree and are not part of this PR.