### PR TITLE
fix: resolve JSX runtime in telegram-guide test

### DIFF
--- a/app-prefixable/src/components/telegram-setup-guide-constants.ts
+++ b/app-prefixable/src/components/telegram-setup-guide-constants.ts
@@ -1,0 +1,23 @@
+type ChecklistItem = {
+  id: string
+  label: string
+}
+
+export const TELEGRAM_READINESS_CHECKS = Object.freeze([
+  Object.freeze({ id: "token", label: "Bot token is set with TELEGRAM_BOT_TOKEN or persisted token." }),
+  Object.freeze({ id: "mode", label: "Bridge mode is selected: polling or webhook." }),
+  Object.freeze({ id: "api", label: "openCodeUrl points to your reachable OpenCode API." }),
+  Object.freeze({ id: "path", label: "sessionStorePath points to a persistent writable location." }),
+  Object.freeze({ id: "webhook", label: "For webhook mode: TELEGRAM_WEBHOOK_URL, TELEGRAM_WEBHOOK_PATH, and HTTPS ingress are configured." }),
+  Object.freeze({ id: "notify", label: "Notifications are enabled per chat with /notify on after a test message." }),
+  Object.freeze({ id: "alarm", label: "Session bell/alarm is enabled for each OpenCode session that should emit proactive alerts." }),
+]) as readonly Readonly<ChecklistItem>[]
+
+const commands = ["/pending", "/inbox", "/notify on", "/notify off", "/notify status", "/new", "/status", "/sessions", "/switch <session-id|index>", "/help"] as const
+const sections = ["Readiness checklist", "Prerequisites", "Setup steps", "Command usage", "Security best practices", "Troubleshooting quick checks"] as const
+const requiredKeys = ["TELEGRAM_BOT_TOKEN", "TELEGRAM_WEBHOOK_SECRET", "openCodeUrl", "webhookUrl"] as const
+
+export const TELEGRAM_GUIDE_COMMANDS = [...commands]
+export const TELEGRAM_GUIDE_SECTIONS = [...sections]
+export const TELEGRAM_GUIDE_TITLE = "Telegram Setup Guide"
+export const TELEGRAM_GUIDE_REQUIRED_KEYS = [...requiredKeys]

--- a/app-prefixable/src/components/telegram-setup-guide.tsx
+++ b/app-prefixable/src/components/telegram-setup-guide.tsx
@@ -1,24 +1,11 @@
 import { For, createMemo, createSignal } from "solid-js"
+import { TELEGRAM_GUIDE_COMMANDS, TELEGRAM_GUIDE_REQUIRED_KEYS, TELEGRAM_GUIDE_SECTIONS, TELEGRAM_GUIDE_TITLE, TELEGRAM_READINESS_CHECKS } from "./telegram-setup-guide-constants"
 
-type ChecklistItem = {
-  id: string
-  label: string
-}
+export { TELEGRAM_GUIDE_COMMANDS, TELEGRAM_GUIDE_REQUIRED_KEYS, TELEGRAM_GUIDE_SECTIONS, TELEGRAM_GUIDE_TITLE, TELEGRAM_READINESS_CHECKS }
 
-const checklist = Object.freeze([
-  Object.freeze({ id: "token", label: "Bot token is set with TELEGRAM_BOT_TOKEN or persisted token." }),
-  Object.freeze({ id: "mode", label: "Bridge mode is selected: polling or webhook." }),
-  Object.freeze({ id: "api", label: "openCodeUrl points to your reachable OpenCode API." }),
-  Object.freeze({ id: "path", label: "sessionStorePath points to a persistent writable location." }),
-  Object.freeze({ id: "webhook", label: "For webhook mode: TELEGRAM_WEBHOOK_URL, TELEGRAM_WEBHOOK_PATH, and HTTPS ingress are configured." }),
-  Object.freeze({ id: "notify", label: "Notifications are enabled per chat with /notify on after a test message." }),
-  Object.freeze({ id: "alarm", label: "Session bell/alarm is enabled for each OpenCode session that should emit proactive alerts." }),
-]) as readonly Readonly<ChecklistItem>[]
-
-const commands = ["/pending", "/inbox", "/notify on", "/notify off", "/notify status", "/new", "/status", "/sessions", "/switch <session-id|index>", "/help"] as const
-const sections = ["Readiness checklist", "Prerequisites", "Setup steps", "Command usage", "Security best practices", "Troubleshooting quick checks"] as const
-const title = "Telegram Setup Guide"
-const requiredKeys = ["TELEGRAM_BOT_TOKEN", "TELEGRAM_WEBHOOK_SECRET", "openCodeUrl", "webhookUrl"] as const
+const checklist = TELEGRAM_READINESS_CHECKS
+const commands = TELEGRAM_GUIDE_COMMANDS
+const title = TELEGRAM_GUIDE_TITLE
 
 export function TelegramSetupGuide() {
   const [done, setDone] = createSignal(new Set<string>())
@@ -168,9 +155,3 @@ export function TelegramSetupGuide() {
     </div>
   )
 }
-
-export const TELEGRAM_GUIDE_COMMANDS = [...commands]
-export const TELEGRAM_READINESS_CHECKS = checklist
-export const TELEGRAM_GUIDE_SECTIONS = [...sections]
-export const TELEGRAM_GUIDE_TITLE = title
-export const TELEGRAM_GUIDE_REQUIRED_KEYS = [...requiredKeys]

--- a/app-prefixable/tests/telegram-guide.test.tsx
+++ b/app-prefixable/tests/telegram-guide.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { TELEGRAM_GUIDE_COMMANDS, TELEGRAM_GUIDE_REQUIRED_KEYS, TELEGRAM_GUIDE_SECTIONS, TELEGRAM_GUIDE_TITLE, TELEGRAM_READINESS_CHECKS } from "../src/components/telegram-setup-guide"
+import { TELEGRAM_GUIDE_COMMANDS, TELEGRAM_GUIDE_REQUIRED_KEYS, TELEGRAM_GUIDE_SECTIONS, TELEGRAM_GUIDE_TITLE, TELEGRAM_READINESS_CHECKS } from "../src/components/telegram-setup-guide-constants"
 import { SETTINGS_BASE_TABS } from "../src/pages/settings-tabs"
 
 describe("Telegram setup guide UI", () => {


### PR DESCRIPTION
## Summary
- Extract telegram setup guide constants into a separate `.ts` file to avoid importing JSX-containing modules in tests
- Test now imports from the plain TypeScript constants file, avoiding the `react/jsx-dev-runtime` resolution error

Closes #397