### PR TITLE
fix: restore live chat sync updates

### DIFF
--- a/app-prefixable/src/components/review-panel.tsx
+++ b/app-prefixable/src/components/review-panel.tsx
@@ -9,7 +9,7 @@ import {
 import * as Diff from "diff";
 import type { FileDiff, FileNode } from "../sdk/client";
 import { useSDK } from "../context/sdk";
-import { useEvents } from "../context/events";
+import { sessionStatusEvent, useEvents } from "../context/events";
 import { useLayout } from "../context/layout";
 
 import { FileTree } from "./file-tree";
@@ -132,12 +132,9 @@ export function ReviewPanel(props: ReviewPanelProps) {
         }
       }
       // Reload on session status idle to catch completed changes
-      if (event.type === "session.status") {
-        const eventProps = event.properties as {
-          sessionID?: string;
-          status?: { type: string };
-        };
-        if (eventProps.sessionID === id && eventProps.status?.type === "idle") {
+      const statusEvent = sessionStatusEvent(event);
+      if (statusEvent) {
+        if (statusEvent.sessionID === id && statusEvent.status.type === "idle") {
           loadDiffs();
         }
       }

--- a/app-prefixable/src/components/session-sidebar.tsx
+++ b/app-prefixable/src/components/session-sidebar.tsx
@@ -135,8 +135,8 @@ export function SessionSidebar(props: SessionSidebarProps) {
       }
       // Reload messages when assistant message completes (for token updates)
       if (event.type === "message.updated") {
-        const props = event.properties as { sessionID?: string }
-        if (props.sessionID === id) {
+        const props = event.properties as { sessionID?: string; info?: { sessionID?: string } }
+        if ((props.info?.sessionID ?? props.sessionID) === id) {
           loadMessages(id)
         }
       }

--- a/app-prefixable/src/components/session-sidebar.tsx
+++ b/app-prefixable/src/components/session-sidebar.tsx
@@ -135,8 +135,8 @@ export function SessionSidebar(props: SessionSidebarProps) {
       }
       // Reload messages when assistant message completes (for token updates)
       if (event.type === "message.updated") {
-        const props = event.properties as { sessionID?: string; info?: { sessionID?: string } }
-        if ((props.info?.sessionID ?? props.sessionID) === id) {
+        const eventProps = event.properties as { sessionID?: string; info?: { sessionID?: string } }
+        if ((eventProps.info?.sessionID ?? eventProps.sessionID) === id) {
           loadMessages(id)
         }
       }

--- a/app-prefixable/src/context/events.tsx
+++ b/app-prefixable/src/context/events.tsx
@@ -7,6 +7,19 @@ import { createSSEParser } from "../utils/sse"
 
 type EventHandler = (event: Event) => void
 
+type SessionStatusEvent = {
+  sessionID: string
+  status: SessionStatus
+}
+
+export function sessionStatusEvent(event: { type: string; properties?: unknown }): SessionStatusEvent | undefined {
+  const props = event.properties as { sessionID?: string; status?: SessionStatus } | undefined
+  if (!props?.sessionID) return undefined
+  if (event.type === "session.status" && props.status) return { sessionID: props.sessionID, status: props.status }
+  if (event.type === "session.idle") return { sessionID: props.sessionID, status: { type: "idle" } }
+  return undefined
+}
+
 interface EventContextValue {
   subscribe: (handler: EventHandler) => () => void
   status: Record<string, SessionStatus>
@@ -41,12 +54,10 @@ export function EventProvider(props: ParentProps) {
       console.log("[Events] Received:", event.type, event.properties)
 
       // Update session status
-      if (event.type === "session.status") {
-        const props = event.properties
-        if (props?.sessionID && props?.status) {
-          sseSeenStatuses.add(props.sessionID as string)
-          setStatus(props.sessionID, props.status)
-        }
+      const statusEvent = sessionStatusEvent(event)
+      if (statusEvent) {
+        sseSeenStatuses.add(statusEvent.sessionID)
+        setStatus(statusEvent.sessionID, statusEvent.status)
       }
 
       // Track pending questions

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -51,6 +51,7 @@ interface SyncContextValue {
 const SyncContext = createContext<SyncContextValue>()
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
+const appendablePartFields = new Set(["snapshot", "text"])
 
 function sortParts(parts: Part[]): Part[] {
   const withId = parts.filter((p) => !!p?.id).sort((a, b) => cmp(a.id, b.id))
@@ -62,10 +63,11 @@ export function mergePartUpdate(parts: Part[] | undefined, part: Part) {
   if (!parts) return sortParts([part])
   const idx = parts.findIndex((p) => p.id === part.id)
   if (idx === -1) return sortParts([...parts, part])
-  return sortParts(parts.map((p, i) => (i === idx ? part : p)))
+  return parts.map((p, i) => (i === idx ? part : p))
 }
 
 export function applyPartDelta(part: Part, field: string, delta: string) {
+  if (!appendablePartFields.has(field)) return part
   const value = (part as unknown as Record<string, unknown>)[field]
   if (value !== undefined && typeof value !== "string") return part
   return { ...part, [field]: `${value ?? ""}${delta}` } as Part

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -11,7 +11,7 @@ type SyncEvent = {
   properties: Record<string, unknown>
 }
 
-type MessageWithParts = {
+export type MessageWithParts = {
   info: Message
   parts: Part[]
 }
@@ -56,6 +56,40 @@ function sortParts(parts: Part[]): Part[] {
   const withId = parts.filter((p) => !!p?.id).sort((a, b) => cmp(a.id, b.id))
   const withoutId = parts.filter((p) => !p?.id)
   return [...withId, ...withoutId]
+}
+
+export function mergePartUpdate(parts: Part[] | undefined, part: Part) {
+  if (!parts) return sortParts([part])
+  const idx = parts.findIndex((p) => p.id === part.id)
+  if (idx === -1) return sortParts([...parts, part])
+  return sortParts(parts.map((p, i) => (i === idx ? part : p)))
+}
+
+export function applyPartDelta(part: Part, field: string, delta: string) {
+  const value = (part as unknown as Record<string, unknown>)[field]
+  if (value !== undefined && typeof value !== "string") return part
+  return { ...part, [field]: `${value ?? ""}${delta}` } as Part
+}
+
+export function mergeMessageUpdate(
+  messages: MessageWithParts[] | undefined,
+  info: Message,
+  knownParts?: Part[],
+  eventParts?: Part[],
+) {
+  const current = messages ?? []
+  const match = binarySearch(current, info.id, (m) => m.info.id)
+  const parts = eventParts ? sortParts(eventParts) : knownParts ? sortParts(knownParts) : match.found ? current[match.index].parts : []
+  const next = { info, parts }
+
+  if (match.found) return current.map((m, i) => (i === match.index ? next : m))
+  const result = [...current]
+  result.splice(match.index, 0, next)
+  return result
+}
+
+function eventInfo<T>(props: Record<string, unknown>) {
+  return (props.info ?? props) as T
 }
 
 function errorText(err: unknown) {
@@ -161,7 +195,7 @@ export function SyncProvider(props: ParentProps) {
 
     // Session events
     if (event.type === "session.created") {
-      const session = props as unknown as Session
+      const session = eventInfo<Session>(props)
       if (!session?.id) return
       const target = session.time?.archived ? "archivedSession" : "session"
       setStore(
@@ -174,7 +208,7 @@ export function SyncProvider(props: ParentProps) {
     }
 
     if (event.type === "session.updated") {
-      const session = props as unknown as Session
+      const session = eventInfo<Session>(props)
       if (!session?.id) return
       const wasArchived = binarySearch(store.archivedSession, session.id, (s) => s.id).found
       const isArchived = !!session.time?.archived
@@ -226,7 +260,7 @@ export function SyncProvider(props: ParentProps) {
     }
 
     if (event.type === "session.deleted") {
-      const session = props as unknown as Session
+      const session = eventInfo<Session>(props)
       if (!session?.id) return
       // Remove from both lists
       setStore(
@@ -252,12 +286,7 @@ export function SyncProvider(props: ParentProps) {
       if (!part?.sessionID || !part?.messageID) return
 
       // Update or insert the part
-      setStore("part", part.messageID, (existing: Part[] | undefined) => {
-        if (!existing) return sortParts([part])
-        const idx = existing.findIndex((p) => p.id === part.id)
-        if (idx === -1) return sortParts([...existing, part])
-        return existing.map((p, i) => (i === idx ? part : p))
-      })
+      setStore("part", part.messageID, (existing: Part[] | undefined) => mergePartUpdate(existing, part))
 
       // Update parts in existing messages only - don't synthesize messages from parts
       setStore("message", part.sessionID, (msgs: MessageWithParts[]) => {
@@ -269,11 +298,32 @@ export function SyncProvider(props: ParentProps) {
         // Update existing message parts
         return msgs.map((m, i) => {
           if (i !== msgIdx) return m
-          const partIdx = m.parts.findIndex((p) => p.id === part.id)
-          const newParts = partIdx === -1 ? [...m.parts, part] : m.parts.map((p, pi) => (pi === partIdx ? part : p))
-          return { ...m, parts: newParts }
+          return { ...m, parts: mergePartUpdate(m.parts, part) }
         })
       })
+    }
+
+    if (event.type === "message.part.delta") {
+      const delta = props as { sessionID?: string; messageID?: string; partID?: string; field?: string; delta?: string }
+      if (!delta.sessionID || !delta.messageID || !delta.partID || !delta.field || delta.delta === undefined) return
+      const field = delta.field
+      const text = delta.delta
+
+      if (store.part[delta.messageID]) {
+        setStore("part", delta.messageID, (existing: Part[]) =>
+          existing.map((p) => (p.id === delta.partID ? applyPartDelta(p, field, text) : p)),
+        )
+      }
+
+      if (store.message[delta.sessionID]) {
+        setStore("message", delta.sessionID, (messages: MessageWithParts[]) => messages.map((m) => {
+          if (m.info.id !== delta.messageID) return m
+          return {
+            ...m,
+            parts: m.parts.map((p) => (p.id === delta.partID ? applyPartDelta(p, field, text) : p)),
+          }
+        }))
+      }
     }
 
     // Message created event
@@ -298,19 +348,13 @@ export function SyncProvider(props: ParentProps) {
     // Message updated event
     if (event.type === "message.updated") {
       const msgProps = props as { info?: Message; parts?: Part[] }
-      const info = msgProps.info
+      const info = eventInfo<Message>(props)
       const parts = msgProps.parts
       if (!info?.sessionID) return
 
-      setStore("message", info.sessionID, (existing: MessageWithParts[]) => {
-        if (!existing || existing.length === 0) return existing
-        return existing.map((m) => {
-          if (m.info.id !== info.id) return m
-          // Merge info and optionally update parts if provided
-          const updatedParts = parts ? sortParts(parts) : m.parts
-          return { info, parts: updatedParts }
-        })
-      })
+      setStore("message", info.sessionID, (existing: MessageWithParts[] | undefined) =>
+        mergeMessageUpdate(existing, info, store.part[info.id], parts),
+      )
 
       // Also update parts store if parts were provided
       if (parts && info.id) {

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -51,7 +51,6 @@ interface SyncContextValue {
 const SyncContext = createContext<SyncContextValue>()
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
-const appendablePartFields = new Set(["text"])
 
 function sortParts(parts: Part[]): Part[] {
   const withId = parts.filter((p) => !!p?.id).sort((a, b) => cmp(a.id, b.id))
@@ -67,10 +66,9 @@ export function mergePartUpdate(parts: Part[] | undefined, part: Part) {
 }
 
 export function applyPartDelta(part: Part, field: string, delta: string) {
-  if (!appendablePartFields.has(field)) return part
-  const value = (part as unknown as Record<string, unknown>)[field]
-  if (value !== undefined && typeof value !== "string") return part
-  return { ...part, [field]: `${value ?? ""}${delta}` } as Part
+  if (field !== "text") return part
+  if (!("text" in part)) return part
+  return { ...part, text: `${part.text ?? ""}${delta}` }
 }
 
 export function mergeMessageUpdate(

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -71,6 +71,18 @@ export function applyPartDelta(part: Part, field: string, delta: string) {
   return { ...part, text: `${part.text ?? ""}${delta}` }
 }
 
+function messageUpdateParts(
+  messages: MessageWithParts[],
+  index: number | undefined,
+  knownParts?: Part[],
+  eventParts?: Part[],
+) {
+  if (eventParts) return sortParts(eventParts)
+  if (knownParts) return sortParts(knownParts)
+  if (index !== undefined) return messages[index].parts
+  return []
+}
+
 export function mergeMessageUpdate(
   messages: MessageWithParts[] | undefined,
   info: Message,
@@ -79,7 +91,7 @@ export function mergeMessageUpdate(
 ) {
   const current = messages ?? []
   const match = binarySearch(current, info.id, (m) => m.info.id)
-  const parts = eventParts ? sortParts(eventParts) : knownParts ? sortParts(knownParts) : match.found ? current[match.index].parts : []
+  const parts = messageUpdateParts(current, match.found ? match.index : undefined, knownParts, eventParts)
   const next = { info, parts }
 
   if (match.found) return current.map((m, i) => (i === match.index ? next : m))

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -51,7 +51,7 @@ interface SyncContextValue {
 const SyncContext = createContext<SyncContextValue>()
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
-const appendablePartFields = new Set(["snapshot", "text"])
+const appendablePartFields = new Set(["text"])
 
 function sortParts(parts: Part[]): Part[] {
   const withId = parts.filter((p) => !!p?.id).sort((a, b) => cmp(a.id, b.id))

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -12,7 +12,7 @@ import {
 import { A, useLocation, useNavigate, useParams } from "@solidjs/router";
 import { useBasePath } from "../context/base-path";
 import { useSDK } from "../context/sdk";
-import { useEvents } from "../context/events";
+import { sessionStatusEvent, useEvents } from "../context/events";
 import { useProviders } from "../context/providers";
 import { useTerminal } from "../context/terminal";
 import { useLayout, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH } from "../context/layout";
@@ -1770,10 +1770,10 @@ export function Layout(props: ParentProps) {
   onMount(() => {
     const alarmUnsub = events.subscribe((event) => {
       // Track busy→idle transitions for all sessions
-      if (event.type === "session.status") {
-        const props = event.properties as { sessionID?: string; status?: { type?: string } } | undefined;
-        const sid = props?.sessionID;
-        const type = props?.status?.type;
+      const statusEvent = sessionStatusEvent(event);
+      if (statusEvent) {
+        const sid = statusEvent.sessionID;
+        const type = statusEvent.status.type;
         if (!sid || !type) return;
 
         if (type === "busy" || type === "retry") {

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -15,7 +15,7 @@ import { useParams, useNavigate } from "@solidjs/router";
 import { Button } from "../components/ui/button";
 import { Spinner } from "../components/ui/spinner";
 import { useSDK } from "../context/sdk";
-import { useEvents } from "../context/events";
+import { sessionStatusEvent, useEvents } from "../context/events";
 import { useSync } from "../context/sync";
 import { useProviders } from "../context/providers";
 import { useMCP } from "../context/mcp";
@@ -1495,12 +1495,9 @@ export function Session() {
         }
 
         // Handle status changes
-        if (event.type === "session.status") {
-          const props = event.properties as {
-            sessionID: string;
-            status: { type: string };
-          };
-          if (props.sessionID === id && props.status.type === "idle") {
+        const statusEvent = sessionStatusEvent(event);
+        if (statusEvent) {
+          if (statusEvent.sessionID === id && statusEvent.status.type === "idle") {
             console.log("[Session] Status idle");
             // Only clear optimistic message if no pending text or it was already matched
             if (!pendingUserMessageText()) {
@@ -1511,7 +1508,7 @@ export function Session() {
             // Reset local processing tracker (notifications now handled globally in Layout)
             wasProcessing.value = false;
             setProcessing(false);
-          } else if (props.sessionID === id) {
+          } else if (statusEvent.sessionID === id) {
             wasProcessing.value = true;
             setProcessing(true);
           }

--- a/app-prefixable/tests/events.test.ts
+++ b/app-prefixable/tests/events.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { sessionStatusEvent } from "../src/context/events"
+
+describe("sessionStatusEvent", () => {
+  test("normalizes session.status events", () => {
+    expect(sessionStatusEvent({
+      type: "session.status",
+      properties: { sessionID: "ses_1", status: { type: "busy" } },
+    })).toEqual({ sessionID: "ses_1", status: { type: "busy" } })
+  })
+
+  test("normalizes session.idle events", () => {
+    expect(sessionStatusEvent({
+      type: "session.idle",
+      properties: { sessionID: "ses_1" },
+    })).toEqual({ sessionID: "ses_1", status: { type: "idle" } })
+  })
+
+  test("ignores unrelated events", () => {
+    expect(sessionStatusEvent({ type: "message.updated", properties: {} })).toBeUndefined()
+  })
+})

--- a/app-prefixable/tests/sync.test.ts
+++ b/app-prefixable/tests/sync.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { applyPartDelta, mergeMessageUpdate, mergePartUpdate } from "../src/context/sync"
+import type { Message, Part } from "../src/sdk/client"
+
+const user = (id: string, sessionID = "ses_1"): Message => ({
+  id,
+  sessionID,
+  role: "user",
+  time: { created: 1 },
+  agent: "build",
+  model: { providerID: "prov", modelID: "model" },
+})
+
+const text = (id: string, messageID: string, value = ""): Part => ({
+  id,
+  sessionID: "ses_1",
+  messageID,
+  type: "text",
+  text: value,
+})
+
+describe("sync event helpers", () => {
+  test("message.updated inserts messages that are not loaded yet", () => {
+    const messages = mergeMessageUpdate(undefined, user("msg_1"))
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].info.id).toBe("msg_1")
+    expect(messages[0].parts).toEqual([])
+  })
+
+  test("message.updated attaches parts received before message info", () => {
+    const part = text("part_1", "msg_1", "hello")
+    const messages = mergeMessageUpdate(undefined, user("msg_1"), [part])
+
+    expect(messages[0].parts).toEqual([part])
+  })
+
+  test("message.part.updated upserts parts by id", () => {
+    const first = text("part_1", "msg_1", "hel")
+    const updated = text("part_1", "msg_1", "hello")
+
+    expect(mergePartUpdate([first], updated)).toEqual([updated])
+  })
+
+  test("message.part.delta appends string fields", () => {
+    expect(applyPartDelta(text("part_1", "msg_1", "hel"), "text", "lo")).toMatchObject({
+      text: "hello",
+    })
+  })
+})

--- a/app-prefixable/tests/sync.test.ts
+++ b/app-prefixable/tests/sync.test.ts
@@ -42,8 +42,23 @@ describe("sync event helpers", () => {
     expect(mergePartUpdate([first], updated)).toEqual([updated])
   })
 
+  test("message.part.updated preserves order when replacing existing parts", () => {
+    const first = text("part_1", "msg_1", "hello")
+    const second = text("part_2", "msg_1", "world")
+    const updated = text("part_1", "msg_1", "hi")
+
+    expect(mergePartUpdate([first, second], updated)).toEqual([updated, second])
+  })
+
   test("message.part.delta appends string fields", () => {
     expect(applyPartDelta(text("part_1", "msg_1", "hel"), "text", "lo")).toMatchObject({
+      text: "hello",
+    })
+  })
+
+  test("message.part.delta ignores non-appendable fields", () => {
+    expect(applyPartDelta(text("part_1", "msg_1", "hello"), "id", "_bad")).toMatchObject({
+      id: "part_1",
       text: "hello",
     })
   })


### PR DESCRIPTION
## Summary
- Upsert `message.updated` events into the sync store so new chat turns render without waiting for HTTP refresh.
- Preserve parts that arrive before message info and apply `message.part.delta` updates for streaming text.
- Handle wrapped `properties.info` payloads for session/message events and sidebar token reloads.

## Verification
- `bun test tests/sse.test.ts tests/sync.test.ts tests/proxy-response.test.ts`
- `bunx eslint src/context/sync.tsx src/components/session-sidebar.tsx tests/sync.test.ts` (warnings only from existing console/any patterns)
- `bun run typecheck` still fails on pre-existing errors outside this change (`Navigate replace`, server/theme/entry/layout/proxy types)
- `bun test tests/` still fails in `api-contract.test.ts` because the local `BASE_URL` server returned unexpected HTML/200 responses for saved-prompts contract tests

Manual live-chat verification for reviewer:
- Start OpenCode API with `opencode serve`.
- Start UI with `bun run dev` in `app-prefixable`.
- Open a session, send a prompt, and confirm user/assistant text and tool parts update without browser refresh.

Closes #400