### PR TITLE
fix: handle OpenAI auth in remote UI

### DIFF
--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -599,7 +599,7 @@ Add your project-specific instructions here.
         method: result.method,
         browserHostname: window.location.hostname,
       })) {
-        setError(`${providerName} browser authentication redirects to localhost and is only supported when this UI runs on your local machine. Use API key authentication or a headless/code method instead.`)
+        setError(`${providerName} browser authentication redirects to a loopback address (localhost/127.0.0.1/::1) and is only supported when this UI runs on your local machine. Use API key authentication or a headless/code method instead.`)
         return
       }
 

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -20,6 +20,7 @@ import { SETTINGS_BASE_TABS } from "./settings-tabs"
 import { TelegramSettings } from "../components/telegram-settings"
 import { invalidateTelegramSourceIdCache, writeFile } from "../utils/extended-api"
 import { ALARM_CHANNELS_STORAGE_KEY, readAlarmChannels, writeAlarmChannels, type AlarmChannels } from "../utils/notify"
+import { browserOAuthUnsupported, extractProviderAuthCode, providerOAuthMethodUnsupported } from "../utils/provider-auth"
 import type { TelegramHealthResponse, TelegramSettingsResponse } from "../utils/telegram-settings"
 import type { Config, PermissionActionConfig } from "../sdk/client"
 
@@ -589,11 +590,18 @@ Add your project-specific instructions here.
     const result = await providers.startOAuth(providerID, methodIndex)
 
     if (result) {
-      // Extract code from instructions (e.g., "Enter code: XXXX-YYYY" -> "XXXX-YYYY")
-      const codeMatch = result.instructions.match(/:\s*([A-Z0-9]{4}-[A-Z0-9]{4})/i)
-      const code = codeMatch ? codeMatch[1] : ""
+      const code = extractProviderAuthCode(result.instructions)
 
       const providerName = getProviderDisplayName(providerID)
+
+      if (browserOAuthUnsupported({
+        authUrl: result.url,
+        method: result.method,
+        browserHostname: window.location.hostname,
+      })) {
+        setError(`${providerName} browser authentication redirects to localhost and is only supported when this UI runs on your local machine. Use API key authentication or a headless/code method instead.`)
+        return
+      }
 
       if (result.method === "code") {
         // User needs to enter a code manually
@@ -642,6 +650,10 @@ Add your project-specific instructions here.
     } else {
       setError("Failed to start authentication.")
     }
+  }
+
+  function oauthMethodUnsupported(providerID: string, label: string) {
+    return providerOAuthMethodUnsupported({ providerID, label, browserHostname: window.location.hostname })
   }
 
   async function handleOAuthComplete() {
@@ -1139,7 +1151,7 @@ Add your project-specific instructions here.
                         <Show when={pending().code}>
                           <div class="mb-3">
                             <div class="text-xs mb-1" style={{ color: "var(--text-weak)" }}>
-                              Enter this code on GitHub:
+                              Enter this code on the provider page:
                             </div>
                             <div class="flex items-center gap-2">
                               <code
@@ -1167,6 +1179,24 @@ Add your project-specific instructions here.
                                 </Show>
                               </button>
                             </div>
+                          </div>
+                        </Show>
+
+                        <Show when={pending().instructions}>
+                          <div class="mb-3">
+                            <div class="text-xs mb-1" style={{ color: "var(--text-weak)" }}>
+                              Provider instructions:
+                            </div>
+                            <pre
+                              class="text-xs whitespace-pre-wrap break-words px-3 py-2 rounded"
+                              style={{
+                                background: "var(--background-base)",
+                                color: "var(--text-base)",
+                                border: "1px solid var(--border-base)",
+                              }}
+                            >
+                              {pending().instructions}
+                            </pre>
                           </div>
                         </Show>
 
@@ -1397,21 +1427,28 @@ Add your project-specific instructions here.
                                   }
                                 >
                                   {/* OAuth method */}
-                                  <button
-                                    type="button"
-                                    disabled={connecting()}
-                                    onClick={() => handleOAuthStart(selectedProvider()!, index())}
-                                    class="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-md text-sm font-medium transition-colors disabled:opacity-50"
-                                    style={{
-                                      background: "var(--interactive-base)",
-                                      color: "white",
-                                    }}
-                                  >
-                                    <Show when={connecting()} fallback={<ExternalLink class="w-4 h-4" />}>
-                                      <Spinner class="w-4 h-4" />
+                                  <div class="space-y-1">
+                                    <button
+                                      type="button"
+                                      disabled={connecting() || oauthMethodUnsupported(selectedProvider()!, method.label)}
+                                      onClick={() => handleOAuthStart(selectedProvider()!, index())}
+                                      class="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-md text-sm font-medium transition-colors disabled:opacity-50"
+                                      style={{
+                                        background: "var(--interactive-base)",
+                                        color: "white",
+                                      }}
+                                    >
+                                      <Show when={connecting()} fallback={<ExternalLink class="w-4 h-4" />}>
+                                        <Spinner class="w-4 h-4" />
+                                      </Show>
+                                      {method.label}
+                                    </button>
+                                    <Show when={oauthMethodUnsupported(selectedProvider()!, method.label)}>
+                                      <p class="text-xs" style={{ color: "var(--text-weak)" }}>
+                                        Browser authentication uses a localhost callback and is only supported when this UI runs on your local machine. Use API key authentication or a headless/code method in notebooks.
+                                      </p>
                                     </Show>
-                                    {method.label}
-                                  </button>
+                                  </div>
                                 </Show>
                               )}
                             </For>

--- a/app-prefixable/src/utils/provider-auth.ts
+++ b/app-prefixable/src/utils/provider-auth.ts
@@ -1,0 +1,38 @@
+export function isLocalBrowserHost(hostname: string) {
+  const host = hostname.toLowerCase()
+  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]"
+}
+
+function urlHasLoopbackTarget(value: string): boolean {
+  try {
+    const url = new URL(value)
+    if (isLocalBrowserHost(url.hostname)) return true
+    for (const param of url.searchParams.values()) {
+      if (urlHasLoopbackTarget(param)) return true
+    }
+  } catch {
+    return /(?:^|[^a-z0-9.-])(localhost|127\.0\.0\.1|\[::1\]|::1)(?::\d+)?(?:\/|$)/i.test(value)
+  }
+  return false
+}
+
+export function browserOAuthUnsupported(input: { authUrl: string; method: "auto" | "code"; browserHostname: string }) {
+  if (input.method !== "auto") return false
+  if (isLocalBrowserHost(input.browserHostname)) return false
+  return urlHasLoopbackTarget(input.authUrl)
+}
+
+export function providerOAuthMethodUnsupported(input: { providerID: string; label: string; browserHostname: string }) {
+  if (isLocalBrowserHost(input.browserHostname)) return false
+  if (input.providerID !== "openai") return false
+  return /\b(browser|local)\b/i.test(input.label)
+}
+
+export function extractProviderAuthCode(instructions: string) {
+  const text = instructions.replace(/https?:\/\/\S+/gi, " ")
+  const labeled = text.match(/:\s*([A-Z0-9][A-Z0-9-]{5,20}[A-Z0-9])/i)
+  if (labeled) return labeled[1].toUpperCase()
+
+  const fallback = text.match(/\b[A-Z0-9]{4}-[A-Z0-9]{4}\b|\b[A-Z0-9]{9}\b/i)
+  return fallback?.[0].toUpperCase() ?? ""
+}

--- a/app-prefixable/src/utils/provider-auth.ts
+++ b/app-prefixable/src/utils/provider-auth.ts
@@ -1,6 +1,6 @@
 export function isLocalBrowserHost(hostname: string) {
   const host = hostname.toLowerCase()
-  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]"
+  return host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === "::1" || host === "[::1]"
 }
 
 function urlHasLoopbackTarget(value: string): boolean {
@@ -11,7 +11,7 @@ function urlHasLoopbackTarget(value: string): boolean {
       if (urlHasLoopbackTarget(param)) return true
     }
   } catch {
-    return /(?:^|[^a-z0-9.-])(localhost|127\.0\.0\.1|\[::1\]|::1)(?::\d+)?(?:\/|$)/i.test(value)
+    return /(?:^|[^a-z0-9.-])(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1)(?::\d+)?(?:\/|$)/i.test(value)
   }
   return false
 }

--- a/app-prefixable/tests/provider-auth.test.ts
+++ b/app-prefixable/tests/provider-auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { browserOAuthUnsupported, extractProviderAuthCode, isLocalBrowserHost, providerOAuthMethodUnsupported } from "../src/utils/provider-auth"
+
+describe("provider auth helpers", () => {
+  test("extracts GitHub-style device codes", () => {
+    expect(extractProviderAuthCode("Enter code: ABCD-EFGH")).toBe("ABCD-EFGH")
+  })
+
+  test("extracts OpenAI-style 9 character codes", () => {
+    expect(extractProviderAuthCode("Enter this code when prompted: A1B2C3D4E")).toBe("A1B2C3D4E")
+  })
+
+  test("ignores authorization URLs while extracting codes", () => {
+    expect(extractProviderAuthCode("Open https://example.com/device and enter code: 123456789")).toBe("123456789")
+  })
+
+  test("detects local browser hosts", () => {
+    expect(isLocalBrowserHost("localhost")).toBe(true)
+    expect(isLocalBrowserHost("127.0.0.1")).toBe(true)
+    expect(isLocalBrowserHost("notebook.example.com")).toBe(false)
+  })
+
+  test("blocks remote browser OAuth that redirects to loopback", () => {
+    const authUrl = "https://auth.openai.com/oauth?redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fcallback"
+    expect(browserOAuthUnsupported({ authUrl, method: "auto", browserHostname: "notebook.example.com" })).toBe(true)
+  })
+
+  test("allows local browser OAuth with loopback redirects", () => {
+    const authUrl = "https://auth.openai.com/oauth?redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fcallback"
+    expect(browserOAuthUnsupported({ authUrl, method: "auto", browserHostname: "localhost" })).toBe(false)
+  })
+
+  test("allows code methods even on remote hosts", () => {
+    const authUrl = "https://auth.openai.com/device"
+    expect(browserOAuthUnsupported({ authUrl, method: "code", browserHostname: "notebook.example.com" })).toBe(false)
+  })
+
+  test("marks OpenAI browser methods unsupported on remote hosts", () => {
+    expect(providerOAuthMethodUnsupported({ providerID: "openai", label: "Browser login", browserHostname: "notebook.example.com" })).toBe(true)
+  })
+
+  test("keeps OpenAI headless methods available on remote hosts", () => {
+    expect(providerOAuthMethodUnsupported({ providerID: "openai", label: "Headless login", browserHostname: "notebook.example.com" })).toBe(false)
+  })
+})

--- a/app-prefixable/tests/provider-auth.test.ts
+++ b/app-prefixable/tests/provider-auth.test.ts
@@ -17,6 +17,7 @@ describe("provider auth helpers", () => {
   test("detects local browser hosts", () => {
     expect(isLocalBrowserHost("localhost")).toBe(true)
     expect(isLocalBrowserHost("127.0.0.1")).toBe(true)
+    expect(isLocalBrowserHost("0.0.0.0")).toBe(true)
     expect(isLocalBrowserHost("notebook.example.com")).toBe(false)
   })
 


### PR DESCRIPTION
## Summary
- Block OpenAI browser OAuth methods that require localhost callbacks when the UI is running from a remote notebook/cluster host.
- Support provider-neutral code extraction for GitHub-style and OpenAI-style device codes.
- Show provider-neutral OAuth instructions in Settings instead of hardcoded GitHub wording.

## Verification
- `bun test tests/provider-auth.test.ts tests/saved-prompts-contract.test.ts`
- `bun run build`
- `bun run typecheck` still fails on pre-existing type errors outside this change (`Navigate replace`, `theme`, `entry`, `layout`, `shared/proxy`).
- `bunx eslint src/utils/provider-auth.ts tests/provider-auth.test.ts`

Closes #402