### PR TITLE
fix: pin Kubeflow OpenCode CLI version

### DIFF
--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -75,6 +75,7 @@ jobs:
             -t $LATEST_TAG \
             -f docker/kubeflow/Dockerfile \
             --platform linux/amd64 \
+            --build-arg OPENCODE_VERSION=1.14.48 \
             --build-arg S6_OVERLAY_VERSION=3.1.6.2 \
             --build-arg KF_EXAMPLES_REPO=https://github.com/prokube-ai/kubeflow-examples.git \
             --label "org.opencontainers.image.title=OpenCode Prefixable UI" \

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -49,9 +49,10 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
     mv /root/.bun/bin/bun /usr/local/bin/bun && \
     rm -rf /root/.bun
 
-# Install OpenCode CLI
+# Install OpenCode CLI. Update OPENCODE_VERSION after checking upstream releases.
+ARG OPENCODE_VERSION=1.14.48
 ENV SHELL=/bin/bash
-RUN curl -fsSL https://opencode.ai/install | bash && \
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --version "${OPENCODE_VERSION}" && \
     mv /root/.opencode/bin/opencode /usr/local/bin/opencode && \
     rm -rf /root/.opencode
 


### PR DESCRIPTION
## Summary
- Pin the Kubeflow image OpenCode CLI install to `1.14.48` via `OPENCODE_VERSION`.
- Pass the same version as a CI Docker build arg so workflow builds remain explicit.
- Chosen version source: npm `opencode-ai/latest` and GitHub latest release both report stable `1.14.48` / `v1.14.48`.

Closes #215
Supersedes #225