### PR TITLE
fix: reduce settings SSE noise

### DIFF
--- a/app-prefixable/src/app.tsx
+++ b/app-prefixable/src/app.tsx
@@ -1,5 +1,5 @@
-import { Router, Route, Navigate, useParams } from "@solidjs/router"
-import { createSignal, onMount, onCleanup, For } from "solid-js"
+import { Router, Route, useNavigate, useParams } from "@solidjs/router"
+import { createEffect, createSignal, onMount, onCleanup, For, type Accessor } from "solid-js"
 import { BasePathProvider, useBasePath } from "./context/base-path"
 import { ServerProvider, useServer } from "./context/server"
 import { BrandingProvider } from "./context/branding"
@@ -24,7 +24,7 @@ function getLastSessionHref(encodedDir: string): string {
     const last = typeof window !== "undefined"
       ? window.localStorage.getItem(`opencode.lastSession.${dir}`)
       : null
-    if (!last || last.includes("..") || /[\/\\]/.test(last)) return "session"
+    if (!last || last.includes("..") || /[/\\]/.test(last)) return "session"
     return `session/${last}`
   } catch {
     return "session"
@@ -33,15 +33,19 @@ function getLastSessionHref(encodedDir: string): string {
 
 function DirectoryIndex() {
   const params = useParams<{ dir: string }>()
-  return <Navigate href={getLastSessionHref(params.dir)} replace />
+  const navigate = useNavigate()
+  createEffect(() => navigate(getLastSessionHref(params.dir), { replace: true }))
+  return null
 }
 
 function SessionIndex() {
   const params = useParams<{ dir: string }>()
+  const navigate = useNavigate()
   const href = getLastSessionHref(params.dir)
   if (href === "session") return <Session />
   const id = href.replace(/^session\//, "")
-  return <Navigate href={id} replace />
+  createEffect(() => navigate(id, { replace: true }))
+  return null
 }
 
 function AppRoutes() {
@@ -71,16 +75,21 @@ function AppRoutes() {
  * Reads the active directory from window.location (outside Router context).
  * Re-evaluates on popstate and on history.pushState/history.replaceState navigation.
  */
-function useActiveDirectory() {
+function useRouteState() {
   const [dir, setDir] = createSignal<string | undefined>(
     typeof window === "undefined" ? undefined : deriveDirectoryFromPathname(),
   )
+  const [pathname, setPathname] = createSignal(
+    typeof window === "undefined" ? "" : window.location.pathname,
+  )
 
   onMount(() => {
-    // Ensure correct value once mounted (covers SSR hydration)
-    setDir(deriveDirectoryFromPathname())
+    function update() {
+      setDir(deriveDirectoryFromPathname())
+      setPathname(window.location.pathname)
+    }
 
-    function update() { setDir(deriveDirectoryFromPathname()) }
+    update()
 
     // Patch pushState/replaceState to detect SolidJS Router navigations
     // instead of polling with setInterval
@@ -97,7 +106,10 @@ function useActiveDirectory() {
     })
   })
 
-  return dir
+  return {
+    activeDirectory: dir,
+    pathname,
+  }
 }
 
 function useProjectsList() {
@@ -129,7 +141,11 @@ function useProjectsList() {
   return projects
 }
 
-function AppWithServer(props: { projects: () => Project[]; activeDirectory: () => string | undefined }) {
+function AppWithServer(props: {
+  projects: () => Project[]
+  activeDirectory: Accessor<string | undefined>
+  pathname: Accessor<string>
+}) {
   const { serverUrl, activeServerKey } = useServer()
 
   // Key by server config to force full remount when switching or editing servers
@@ -141,7 +157,11 @@ function AppWithServer(props: { projects: () => Project[]; activeDirectory: () =
             <BrandingProvider>
               <RecentProjectsProvider>
                 <SavedPromptsProvider directory={props.activeDirectory}>
-                  <GlobalEventsProvider projects={props.projects} activeDirectory={props.activeDirectory}>
+                  <GlobalEventsProvider
+                    projects={props.projects}
+                    activeDirectory={props.activeDirectory}
+                    pathname={props.pathname}
+                  >
                     <CommandProvider>
                       <AppRoutes />
                     </CommandProvider>
@@ -158,11 +178,15 @@ function AppWithServer(props: { projects: () => Project[]; activeDirectory: () =
 
 export function App() {
   const projects = useProjectsList()
-  const activeDirectory = useActiveDirectory()
+  const route = useRouteState()
 
   return (
     <ServerProvider>
-      <AppWithServer projects={projects} activeDirectory={activeDirectory} />
+      <AppWithServer
+        projects={projects}
+        activeDirectory={route.activeDirectory}
+        pathname={route.pathname}
+      />
     </ServerProvider>
   )
 }

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -44,6 +44,7 @@ const GlobalEventsContext = createContext<GlobalEventsContextValue>()
 export function GlobalEventsProvider(props: ParentProps & {
   projects: () => { worktree: string }[]
   activeDirectory: () => string | undefined
+  pathname: () => string
 }) {
   const { authHeaders, serverUrl, activeServer } = useServer()
 
@@ -278,7 +279,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         parser.push("")
 
         throw new Error("SSE stream ended")
-      } catch (err) {
+      } catch {
         if (controller.signal.aborted) return
         if (disposed) return
         disconnectDirectory(dir)
@@ -458,11 +459,18 @@ export function GlobalEventsProvider(props: ParentProps & {
   // Active project is excluded — it has its own EventProvider.
   // Remote servers are skipped — local projects don't exist on remote servers.
   createEffect(on(
-    () => ({ dirs: props.projects().map((p) => p.worktree), active: props.activeDirectory(), isRemote: !activeServer().isDefault }),
+    () => ({
+      dirs: props.projects().map((p) => p.worktree),
+      active: props.activeDirectory(),
+      isRemote: !activeServer().isDefault,
+      isSettings: props.pathname().endsWith("/settings"),
+    }),
     (current) => {
       // When a remote server is active, disconnect all global event connections
       // since local projects don't exist on the remote server.
-      if (current.isRemote) {
+      // Also suspend these background connections on settings routes to avoid
+      // opening one SSE stream per saved project while the user edits settings.
+      if (current.isRemote || current.isSettings) {
         for (const dir of [...connections.keys()]) {
           disconnectDirectory(dir)
         }

--- a/app-prefixable/src/context/server.tsx
+++ b/app-prefixable/src/context/server.tsx
@@ -75,7 +75,7 @@ function loadServers(): ServerConfig[] {
         const parsed: ServerConfig[] = raw
           .filter(isValidServerEntry)
           .map((s) => {
-            const obj = s as Record<string, unknown>
+            const obj = s as unknown as Record<string, unknown>
             // Prefer credentials from sessionStorage; fall back to authMethod stub
             if (creds[obj.id as string]) {
               return { ...s, auth: normalizeAuth({ auth: creds[obj.id as string] } as unknown as Record<string, unknown>) }

--- a/app-prefixable/src/context/theme.tsx
+++ b/app-prefixable/src/context/theme.tsx
@@ -40,6 +40,10 @@ export function ThemeProvider(props: ParentProps) {
   const query = typeof window !== "undefined" && typeof window.matchMedia === "function"
     ? window.matchMedia("(prefers-color-scheme: dark)")
     : undefined
+  const legacyQuery = query as (MediaQueryList & {
+    addListener?: (listener: (event: MediaQueryListEvent) => void) => void
+    removeListener?: (listener: (event: MediaQueryListEvent) => void) => void
+  }) | undefined
 
   const [systemDark, setSystemDark] = createSignal(query?.matches ?? false)
 
@@ -48,9 +52,9 @@ export function ThemeProvider(props: ParentProps) {
     if ("addEventListener" in query) {
       query.addEventListener("change", handler)
       onCleanup(() => query.removeEventListener("change", handler))
-    } else if ("addListener" in query) {
-      query.addListener(handler)
-      onCleanup(() => query.removeListener(handler))
+    } else if (legacyQuery?.addListener && legacyQuery.removeListener) {
+      legacyQuery.addListener(handler)
+      onCleanup(() => legacyQuery.removeListener?.(handler))
     }
   }
 

--- a/app-prefixable/src/entry.tsx
+++ b/app-prefixable/src/entry.tsx
@@ -11,8 +11,10 @@ if (!root) {
   throw new Error("Root element not found")
 }
 
+const mount = root
+
 // Clear the loading text first
-root.innerHTML = ""
+mount.innerHTML = ""
 
 async function start() {
   const cleanup = await preventLegacyServiceWorkerCaching().catch((e) => {
@@ -27,17 +29,17 @@ async function start() {
   }
 
   console.log("[OpenCode] Rendering...")
-  render(() => <App />, root)
+  render(() => <App />, mount)
   console.log("[OpenCode] Rendered successfully")
-  console.log("[OpenCode] Root innerHTML:", root.innerHTML.slice(0, 200))
+  console.log("[OpenCode] Root innerHTML:", mount.innerHTML.slice(0, 200))
 }
 
 start().catch((e) => {
   console.error("[OpenCode] Render error:", e)
-  root.innerHTML = ""
+  mount.innerHTML = ""
   const message = document.createElement("div")
   message.style.color = "red"
   message.style.padding = "20px"
   message.textContent = `Error: ${e instanceof Error && e.message.trim() ? e.message : String(e)}`
-  root.appendChild(message)
+  mount.appendChild(message)
 })

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -886,7 +886,7 @@ export function Layout(props: ParentProps) {
     };
     schedule();
     onCleanup(() => {
-      if (timer) clearTimeout(timer);
+      if (timer !== undefined) clearTimeout(timer);
     });
   });
 

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -878,14 +878,16 @@ export function Layout(props: ParentProps) {
   const [now, setNow] = createSignal(new Date());
 
   onMount(() => {
-    const timer = { id: 0 as ReturnType<typeof setTimeout> };
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const schedule = () => {
       const next = new Date();
       next.setHours(24, 0, 0, 0);
-      timer.id = setTimeout(() => { setNow(new Date()); schedule(); }, next.getTime() - Date.now());
+      timer = setTimeout(() => { setNow(new Date()); schedule(); }, next.getTime() - Date.now());
     };
     schedule();
-    onCleanup(() => clearTimeout(timer.id));
+    onCleanup(() => {
+      if (timer) clearTimeout(timer);
+    });
   });
 
   const pinnedSessions = createMemo(() => {

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -127,15 +127,15 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
         return new Response(response.body, { status: response.status, headers: corsHeaders })
       }
 
-      const headers = new Headers(corsHeaders)
-      headers.set("Content-Type", "text/event-stream")
-      headers.set("Cache-Control", "no-cache")
-      headers.set("Connection", "keep-alive")
-      headers.set("X-Accel-Buffering", "no")
+      const sseHeaders = new Headers(corsHeaders)
+      sseHeaders.set("Content-Type", "text/event-stream")
+      sseHeaders.set("Cache-Control", "no-cache")
+      sseHeaders.set("Connection", "keep-alive")
+      sseHeaders.set("X-Accel-Buffering", "no")
 
       return new Response(response.body, {
         status: response.status,
-        headers,
+        headers: sseHeaders,
       })
     }
 

--- a/shared/proxy.ts
+++ b/shared/proxy.ts
@@ -115,7 +115,11 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
       body: req.method !== "GET" && req.method !== "HEAD" ? req.body : undefined,
     })
 
-    const corsHeaders = corsOrigin ? { "Access-Control-Allow-Origin": corsOrigin, Vary: "Origin" } : {}
+    const corsHeaders = new Headers()
+    if (corsOrigin) {
+      corsHeaders.set("Access-Control-Allow-Origin", corsOrigin)
+      corsHeaders.set("Vary", "Origin")
+    }
 
     if (isSSE) {
       if (!response.ok) {
@@ -123,15 +127,15 @@ export async function handleProxyRequest(path: string, req: Request): Promise<Re
         return new Response(response.body, { status: response.status, headers: corsHeaders })
       }
 
+      const headers = new Headers(corsHeaders)
+      headers.set("Content-Type", "text/event-stream")
+      headers.set("Cache-Control", "no-cache")
+      headers.set("Connection", "keep-alive")
+      headers.set("X-Accel-Buffering", "no")
+
       return new Response(response.body, {
         status: response.status,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          "Connection": "keep-alive",
-          "X-Accel-Buffering": "no",
-        },
+        headers,
       })
     }
 


### PR DESCRIPTION
## Summary
- Supersedes #385 by reapplying the still-relevant settings SSE and typecheck fixes on current `main`.
- Suspends inactive-project `GlobalEventsProvider` SSE connections while viewing settings routes.
- Replaces typed-unsupported `<Navigate replace>` usage with imperative `useNavigate(..., { replace: true })` redirects to preserve back-button behavior.

## Original PR
- Reworks the intent of #385: https://github.com/prokube/pk-opencode-webui/pull/385

## Testing
- `bun run typecheck`
- `bun run build`
- `bunx eslint src/app.tsx src/context/global-events.tsx`

## Notes
- Full `bun run lint` still fails on existing lint debt outside this change, including Solid ref `no-unassigned-vars`, empty blocks in `context/server.tsx`, and other pre-existing warnings/errors.