### PR TITLE
fix: refresh tool state during session sync

### DIFF
--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -71,6 +71,62 @@ export function applyPartDelta(part: Part, field: string, delta: string) {
   return { ...part, text: `${part.text ?? ""}${delta}` }
 }
 
+function toolRank(part: Extract<Part, { type: "tool" }>) {
+  if (part.state.status === "pending") return 0
+  if (part.state.status === "running") return 1
+  return 2
+}
+
+function toolTime(part: Extract<Part, { type: "tool" }>) {
+  if (part.state.status === "pending") return 0
+  if (part.state.status === "running") return part.state.time.start
+  return part.state.time.end
+}
+
+function mergeSyncedPart(existing: Part, synced: Part) {
+  if (existing.type !== synced.type) return synced
+  if (existing.type !== "tool" || synced.type !== "tool") return existing
+
+  const existingRank = toolRank(existing)
+  const syncedRank = toolRank(synced)
+  if (syncedRank > existingRank) return synced
+  if (existingRank > syncedRank) return existing
+
+  return toolTime(synced) > toolTime(existing) ? synced : existing
+}
+
+function mergeSyncedMessage(existing: MessageWithParts, synced: MessageWithParts) {
+  const parts = synced.parts.map((part) => {
+    const current = existing.parts.find((p) => p.id === part.id)
+    if (!current) return part
+    return mergeSyncedPart(current, part)
+  })
+
+  for (const part of existing.parts) {
+    if (parts.find((p) => p.id === part.id)) continue
+    parts.push(part)
+  }
+
+  return { info: synced.info, parts: sortParts(parts) }
+}
+
+export function mergeSessionMessages(existing: MessageWithParts[] | undefined, synced: MessageWithParts[]) {
+  if (!existing || existing.length === 0) return synced
+
+  const merged = synced.map((msg) => {
+    const current = existing.find((m) => m.info.id === msg.info.id)
+    if (!current) return msg
+    return mergeSyncedMessage(current, msg)
+  })
+
+  for (const msg of existing) {
+    if (merged.find((m) => m.info.id === msg.info.id)) continue
+    merged.push(msg)
+  }
+
+  return merged.sort((a, b) => cmp(a.info.id, b.info.id))
+}
+
 function messageUpdateParts(
   messages: MessageWithParts[],
   index: number | undefined,
@@ -458,26 +514,7 @@ export function SyncProvider(props: ParentProps) {
               .filter((m): m is MessageWithParts => !!m?.info?.id)
               .sort((a, b) => cmp(a.info.id, b.info.id))
 
-            setStore("message", sessionID, (existing: MessageWithParts[]) => {
-              if (!existing || existing.length === 0) return synced
-
-              // Merge: use existing message if it has more recent parts
-              const merged = synced.map((s) => {
-                const e = existing.find((m) => m.info.id === s.info.id)
-                if (!e) return s
-                // Keep existing if it has more parts (SSE updates arrived)
-                return e.parts.length >= s.parts.length ? e : s
-              })
-
-              // Add any messages from existing that aren't in synced (new SSE messages)
-              for (const e of existing) {
-                if (!merged.find((m) => m.info.id === e.info.id)) {
-                  merged.push(e)
-                }
-              }
-
-              return merged.sort((a, b) => cmp(a.info.id, b.info.id))
-            })
+            setStore("message", sessionID, (existing: MessageWithParts[]) => mergeSessionMessages(existing, synced))
 
             // Update parts
             const msgs = store.message[sessionID] ?? []

--- a/app-prefixable/tests/sync.test.ts
+++ b/app-prefixable/tests/sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { applyPartDelta, mergeMessageUpdate, mergePartUpdate } from "../src/context/sync"
+import { applyPartDelta, mergeMessageUpdate, mergePartUpdate, mergeSessionMessages } from "../src/context/sync"
+import type { MessageWithParts } from "../src/context/sync"
 import type { Message, Part } from "../src/sdk/client"
 
 const user = (id: string, sessionID = "ses_1"): Message => ({
@@ -18,6 +19,38 @@ const text = (id: string, messageID: string, value = ""): Part => ({
   type: "text",
   text: value,
 })
+
+const pendingTool = (id: string, messageID: string): Part => ({
+  id,
+  sessionID: "ses_1",
+  messageID,
+  type: "tool",
+  callID: "call_1",
+  tool: "apply_patch",
+  state: { status: "pending", input: {}, raw: "{}" },
+})
+
+const completedTool = (id: string, messageID: string): Part => ({
+  id,
+  sessionID: "ses_1",
+  messageID,
+  type: "tool",
+  callID: "call_1",
+  tool: "apply_patch",
+  state: { status: "completed", input: {}, output: "ok", title: "Patched", metadata: {}, time: { start: 1, end: 2 } },
+})
+
+const runningTool = (id: string, messageID: string, start: number): Part => ({
+  id,
+  sessionID: "ses_1",
+  messageID,
+  type: "tool",
+  callID: "call_1",
+  tool: "apply_patch",
+  state: { status: "running", input: {}, time: { start } },
+})
+
+const message = (info: Message, parts: Part[]): MessageWithParts => ({ info, parts })
 
 describe("sync event helpers", () => {
   test("message.updated inserts messages that are not loaded yet", () => {
@@ -61,5 +94,35 @@ describe("sync event helpers", () => {
       id: "part_1",
       text: "hello",
     })
+  })
+
+  test("session sync replaces stale pending tool parts when part count is unchanged", () => {
+    const existing = [message(user("msg_1"), [pendingTool("part_1", "msg_1")])]
+    const synced = [message(user("msg_1"), [completedTool("part_1", "msg_1")])]
+
+    expect(mergeSessionMessages(existing, synced)[0].parts[0]).toMatchObject({
+      type: "tool",
+      state: { status: "completed" },
+    })
+  })
+
+  test("session sync preserves newer SSE tool updates", () => {
+    const existing = [message(user("msg_1"), [runningTool("part_1", "msg_1", 5)])]
+    const synced = [message(user("msg_1"), [runningTool("part_1", "msg_1", 1)])]
+
+    expect(mergeSessionMessages(existing, synced)[0].parts[0]).toMatchObject({
+      type: "tool",
+      state: { status: "running", time: { start: 5 } },
+    })
+  })
+
+  test("session sync preserves SSE-only messages and parts", () => {
+    const existing = [message(user("msg_1"), [text("part_1", "msg_1"), text("part_2", "msg_1")]), message(user("msg_2"), [])]
+    const synced = [message(user("msg_1"), [text("part_1", "msg_1")])]
+
+    const merged = mergeSessionMessages(existing, synced)
+
+    expect(merged.map((m) => m.info.id)).toEqual(["msg_1", "msg_2"])
+    expect(merged[0].parts.map((p) => p.id)).toEqual(["part_1", "part_2"])
   })
 })


### PR DESCRIPTION
## Summary
- Replace the stale part-count session sync merge with a part-aware merge for loaded messages.
- Allow full session sync to advance same-ID tool parts from pending/running to newer states while preserving newer SSE tool updates.
- Preserve SSE-only messages and parts during full sync.

## Testing
- `bun test tests/sync.test.ts`
- `bun run build`
- `bun run typecheck` fails on existing project-wide TypeScript errors outside this change: `src/app.tsx`, `src/context/server.tsx`, `src/context/theme.tsx`, `src/entry.tsx`, `src/pages/layout.tsx`, and `../shared/proxy.ts`.

Closes #379
Supersedes #381