### PR TITLE
feat: add review panel diff modes

### DIFF
--- a/app-prefixable/src/components/review-panel.tsx
+++ b/app-prefixable/src/components/review-panel.tsx
@@ -10,7 +10,8 @@ import * as Diff from "diff";
 import type { FileDiff, FileNode } from "../sdk/client";
 import { useSDK } from "../context/sdk";
 import { sessionStatusEvent, useEvents } from "../context/events";
-import { useLayout } from "../context/layout";
+import { useLayout, type ReviewMode } from "../context/layout";
+import { useSync } from "../context/sync";
 
 import { FileTree } from "./file-tree";
 import { FileViewer } from "./file-viewer";
@@ -41,10 +42,22 @@ interface ReviewPanelProps {
   sessionId: string;
 }
 
+const REVIEW_MODES: Array<{ value: ReviewMode; label: string; title: string }> = [
+  { value: "session", label: "Session", title: "Show session changes" },
+  { value: "git", label: "Git", title: "Show uncommitted changes" },
+  { value: "branch", label: "Branch", title: "Show current branch changes" },
+  { value: "turn", label: "Turn", title: "Show last turn changes" },
+];
+
+function lastUserMessageID(messages: ReturnType<ReturnType<typeof useSync>["messages"]>) {
+  return messages.toReversed().find((message) => message.info.role === "user")?.info.id;
+}
+
 export function ReviewPanel(props: ReviewPanelProps) {
   const { client, directory } = useSDK();
   const events = useEvents();
   const layout = useLayout();
+  const sync = useSync();
 
   const [diffs, setDiffs] = createSignal<FileDiff[]>([]);
   const [selected, setSelected] = createSignal<string | null>(null);
@@ -54,55 +67,83 @@ export function ReviewPanel(props: ReviewPanelProps) {
 
   // Track the latest request to prevent race conditions
   let version = 0;
+  let previousSessionId: string | undefined;
 
-  async function checkGitRepo() {
-    try {
-      // Try to get VCS info - if it fails or returns no branch, it's not a git repo
-      const res = await client.vcs.get({ directory });
-      setIsGitRepo(res.data?.branch !== undefined);
-    } catch {
-      setIsGitRepo(false);
+  const mode = () => layout.review.mode();
+  const isGitMode = createMemo(() => mode() === "git" || mode() === "branch");
+  const lastMessageID = createMemo(() => lastUserMessageID(sync.messages(props.sessionId)));
+
+  function isNotGitRepoError(error: unknown) {
+    if (!error) return false;
+    const text = typeof error === "string" ? error : JSON.stringify(error);
+    return /not a git repository|not a repository|outside repository/i.test(text);
+  }
+
+  async function checkGitRepo(current: number) {
+    const res = await client.vcs.get({ directory }, { throwOnError: false });
+    if (current !== version) return;
+    if (res.data) {
+      setIsGitRepo(true);
+      return;
     }
+    if (isNotGitRepoError(res.error)) {
+      setIsGitRepo(false);
+      return;
+    }
+    setIsGitRepo(null);
+  }
+
+  function setFiles(files: FileDiff[]) {
+    setDiffs(files);
+    const filesByPath = files.map((d) => d.file);
+    const sel = selected();
+    if (!sel || !filesByPath.includes(sel)) setSelected(files[0]?.file ?? null);
   }
 
   async function loadDiffs() {
     const current = ++version;
+    const currentMode = mode();
+    if (currentMode === "git" || currentMode === "branch") setIsGitRepo(null);
     setLoading(true);
     try {
-      const res = await client.session.diff({ sessionID: props.sessionId, directory });
+      const res = currentMode === "git" || currentMode === "branch"
+        ? await client.vcs.diff({ directory, mode: currentMode }, { throwOnError: false })
+        : await client.session.diff({
+          sessionID: props.sessionId,
+          directory,
+          messageID: currentMode === "turn" ? lastMessageID() : undefined,
+        }, { throwOnError: false });
       // Only update state if this is still the latest request
       if (current !== version) return;
       if (res.data) {
-        setDiffs(res.data);
+        setFiles(res.data);
         setIsGitRepo(true); // If we got diffs, it's definitely a git repo
-        // Auto-select first file if none selected or selection no longer exists
-        const files = res.data.map((d) => d.file);
-        const sel = selected();
-        if (!sel || !files.includes(sel)) {
-          setSelected(res.data.length > 0 ? res.data[0].file : null);
-        }
-      } else {
-        // No diffs returned - check if it's because no git repo
-        await checkGitRepo();
+        return;
       }
+      setFiles([]);
+      if (isGitMode() || isNotGitRepoError(res.error)) await checkGitRepo(current);
     } catch (e) {
       if (current !== version) return;
       console.error("[ReviewPanel] Failed to load diffs:", e);
       // Check if it's a git repo issue
-      await checkGitRepo();
+      setFiles([]);
+      if (isGitMode() || isNotGitRepoError(e)) await checkGitRepo(current);
     } finally {
       if (current === version) setLoading(false);
     }
   }
 
-  // Load diffs when session changes
+  // Load diffs when session, mode, or relevant turn changes
   createEffect(() => {
     const id = props.sessionId;
+    const currentMode = mode();
+    if (currentMode === "turn") lastMessageID();
     if (id) {
-      // Reset selection when session changes
-      setSelected(null);
+      if (previousSessionId !== id) setSelected(null);
+      previousSessionId = id;
       loadDiffs();
     } else {
+      previousSessionId = undefined;
       setDiffs([]);
       setSelected(null);
     }
@@ -119,16 +160,9 @@ export function ReviewPanel(props: ReviewPanelProps) {
           sessionID?: string;
           diff?: FileDiff[];
         };
-        if (eventProps.sessionID === id && eventProps.diff) {
-          setDiffs(eventProps.diff);
-          // Auto-select first file if none selected or selection no longer exists
-          const files = eventProps.diff.map((d) => d.file);
-          const sel = selected();
-          if (!sel || !files.includes(sel)) {
-            setSelected(
-              eventProps.diff.length > 0 ? eventProps.diff[0].file : null,
-            );
-          }
+        if (mode() === "session" && eventProps.sessionID === id && eventProps.diff) {
+          setFiles(eventProps.diff);
+          setIsGitRepo(true);
         }
       }
       // Reload on session status idle to catch completed changes
@@ -139,7 +173,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
         }
       }
       if (event.type === "vcs.branch.updated") {
-        loadDiffs();
+        if (isGitMode()) loadDiffs();
       }
     });
 
@@ -192,6 +226,12 @@ export function ReviewPanel(props: ReviewPanelProps) {
   });
 
   const count = createMemo(() => diffs().length);
+  const emptyText = createMemo(() => {
+    if (mode() === "git") return "No uncommitted changes";
+    if (mode() === "branch") return "No branch changes";
+    if (mode() === "turn") return "No changes in the last turn";
+    return "No changes in this session";
+  });
 
   // List of changed file paths for filtering
   const diffFiles = createMemo(() => diffs().map((d) => d.file));
@@ -327,6 +367,8 @@ export function ReviewPanel(props: ReviewPanelProps) {
             >
               <div class="flex items-center gap-2">
                 <button
+                  type="button"
+                  aria-label="Refresh diff list"
                   onClick={() => loadDiffs()}
                   class="p-1 rounded hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
                   style={{ color: "var(--icon-weak)" }}
@@ -339,6 +381,8 @@ export function ReviewPanel(props: ReviewPanelProps) {
                 </button>
               </div>
               <button
+                type="button"
+                aria-label="Close review panel"
                 onClick={() => layout.review.close()}
                 class="p-1 rounded hover:bg-black/5 dark:hover:bg-white/5"
                 style={{ color: "var(--icon-weak)" }}
@@ -347,7 +391,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
               </button>
             </div>
 
-            {/* Tabs for Changed Files / All Files */}
+            {/* Mode selector + tabs for Changed Files / All Files */}
             <Tabs
               variant="pill"
               value={tab()}
@@ -367,6 +411,33 @@ export function ReviewPanel(props: ReviewPanelProps) {
                 class="px-2 py-2"
                 style={{ "border-bottom": "1px solid var(--border-base)" }}
               >
+                <div class="flex gap-1 mb-2" role="group" aria-label="Diff mode">
+                  <For each={REVIEW_MODES}>
+                    {(item) => (
+                      <button
+                        type="button"
+                        onClick={() => layout.review.setMode(item.value)}
+                        aria-pressed={mode() === item.value}
+                        aria-label={`Switch to ${item.label.toLowerCase()} diff mode`}
+                        class="flex-1 px-2 py-1 text-xs rounded transition-colors"
+                        style={{
+                          background:
+                            mode() === item.value
+                              ? "var(--interactive-base)"
+                              : "var(--surface-base)",
+                          color:
+                            mode() === item.value
+                              ? "var(--text-on-interactive)"
+                              : "var(--text-weak)",
+                          border: "1px solid var(--border-base)",
+                        }}
+                        title={item.title}
+                      >
+                        {item.label}
+                      </button>
+                    )}
+                  </For>
+                </div>
                 <Tabs.List class="flex gap-1">
                   <Tabs.Trigger
                     value="changes"
@@ -415,7 +486,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
                           style={{ color: "var(--text-weak)" }}
                         >
                           <Show
-                            when={isGitRepo() === true}
+                            when={!isGitMode() || isGitRepo() !== false}
                             fallback={
                               <div class="flex flex-col items-center gap-2">
                                 <GitBranch
@@ -432,7 +503,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
                               </div>
                             }
                           >
-                            <span>No changes in this session</span>
+                            <span>{emptyText()}</span>
                           </Show>
                         </div>
                       }
@@ -466,7 +537,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
                         >
                           {count() > 0
                             ? "Select a file to view changes"
-                            : "No changes in this session"}
+                            : emptyText()}
                         </span>
                       </div>
                     }

--- a/app-prefixable/src/components/review-panel.tsx
+++ b/app-prefixable/src/components/review-panel.tsx
@@ -7,7 +7,7 @@ import {
   For,
 } from "solid-js";
 import * as Diff from "diff";
-import type { FileDiff, FileNode } from "../sdk/client";
+import type { FileDiff, FileNode, VcsFileDiff } from "../sdk/client";
 import { useSDK } from "../context/sdk";
 import { sessionStatusEvent, useEvents } from "../context/events";
 import { useLayout, type ReviewMode } from "../context/layout";
@@ -42,6 +42,8 @@ interface ReviewPanelProps {
   sessionId: string;
 }
 
+type ReviewDiff = FileDiff | VcsFileDiff;
+
 const REVIEW_MODES: Array<{ value: ReviewMode; label: string; title: string }> = [
   { value: "session", label: "Session", title: "Show session changes" },
   { value: "git", label: "Git", title: "Show uncommitted changes" },
@@ -59,7 +61,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
   const layout = useLayout();
   const sync = useSync();
 
-  const [diffs, setDiffs] = createSignal<FileDiff[]>([]);
+  const [diffs, setDiffs] = createSignal<ReviewDiff[]>([]);
   const [selected, setSelected] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
   const [tab, setTab] = createSignal<"changes" | "all">("changes");
@@ -73,10 +75,23 @@ export function ReviewPanel(props: ReviewPanelProps) {
   const isGitMode = createMemo(() => mode() === "git" || mode() === "branch");
   const lastMessageID = createMemo(() => lastUserMessageID(sync.messages(props.sessionId)));
 
+  function errorText(error: unknown) {
+    if (!error) return "";
+    if (error instanceof Error) return error.message;
+    if (typeof error === "string") return error;
+    if (typeof error !== "object") return String(error);
+
+    const obj = error as Record<string, unknown>;
+    const data = obj.data && typeof obj.data === "object"
+      ? obj.data as Record<string, unknown>
+      : undefined;
+    return [obj.message, obj.error, obj.detail, data?.message]
+      .filter((item) => typeof item === "string")
+      .join(" ");
+  }
+
   function isNotGitRepoError(error: unknown) {
-    if (!error) return false;
-    const text = typeof error === "string" ? error : JSON.stringify(error);
-    return /not a git repository|not a repository|outside repository/i.test(text);
+    return /not a git repository|not a repository|outside repository/i.test(errorText(error));
   }
 
   async function checkGitRepo(current: number) {
@@ -93,7 +108,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
     setIsGitRepo(null);
   }
 
-  function setFiles(files: FileDiff[]) {
+  function setFiles(files: ReviewDiff[]) {
     setDiffs(files);
     const filesByPath = files.map((d) => d.file);
     const sel = selected();
@@ -108,11 +123,13 @@ export function ReviewPanel(props: ReviewPanelProps) {
     try {
       const res = currentMode === "git" || currentMode === "branch"
         ? await client.vcs.diff({ directory, mode: currentMode }, { throwOnError: false })
-        : await client.session.diff({
-          sessionID: props.sessionId,
-          directory,
-          messageID: currentMode === "turn" ? lastMessageID() : undefined,
-        }, { throwOnError: false });
+        : currentMode === "turn" && !lastMessageID()
+          ? { data: [] as ReviewDiff[], error: undefined }
+          : await client.session.diff({
+            sessionID: props.sessionId,
+            directory,
+            messageID: currentMode === "turn" ? lastMessageID() : undefined,
+          }, { throwOnError: false });
       // Only update state if this is still the latest request
       if (current !== version) return;
       if (res.data) {
@@ -189,6 +206,7 @@ export function ReviewPanel(props: ReviewPanelProps) {
   const patch = createMemo(() => {
     const diff = selectedDiff();
     if (!diff) return "";
+    if ("patch" in diff) return diff.patch;
     return createPatch(diff.file, diff.before, diff.after);
   });
 

--- a/app-prefixable/src/components/review-panel.tsx
+++ b/app-prefixable/src/components/review-panel.tsx
@@ -50,7 +50,7 @@ const REVIEW_MODES: Array<{ value: ReviewMode; label: string; title: string }> =
 ];
 
 function lastUserMessageID(messages: ReturnType<ReturnType<typeof useSync>["messages"]>) {
-  return messages.toReversed().find((message) => message.info.role === "user")?.info.id;
+  return messages.slice().reverse().find((message) => message.info.role === "user")?.info.id;
 }
 
 export function ReviewPanel(props: ReviewPanelProps) {

--- a/app-prefixable/src/context/layout.tsx
+++ b/app-prefixable/src/context/layout.tsx
@@ -12,8 +12,11 @@ const LAYOUT_STORAGE_KEY = "opencode.layout";
 const DEFAULT_REVIEW_WIDTH = 320;
 const DEFAULT_INFO_WIDTH = 256;
 const DEFAULT_SIDEBAR_WIDTH = 256;
+const DEFAULT_REVIEW_MODE = "session";
 export const SIDEBAR_MIN_WIDTH = 180;
 export const SIDEBAR_MAX_WIDTH = 480;
+
+export type ReviewMode = "session" | "git" | "branch" | "turn";
 
 interface PanelState {
   opened: boolean;
@@ -29,6 +32,7 @@ interface LayoutState {
   review: PanelState;
   info: PanelState;
   sidebar: { width?: number };
+  reviewMode?: ReviewMode;
   tabs?: FileTab[];
   activeTab?: string | null; // null = Review tab, string = file path
 }
@@ -38,10 +42,12 @@ interface LayoutContextValue {
   review: {
     opened: () => boolean;
     width: () => number;
+    mode: () => ReviewMode;
     toggle: () => void;
     open: () => void;
     close: () => void;
     resize: (width: number) => void;
+    setMode: (mode: ReviewMode) => void;
   };
   // Info panel (todos, context usage)
   info: {
@@ -68,6 +74,10 @@ interface LayoutContextValue {
 }
 
 const LayoutContext = createContext<LayoutContextValue>();
+
+function isReviewMode(value: unknown): value is ReviewMode {
+  return value === "session" || value === "git" || value === "branch" || value === "turn";
+}
 
 function basename(path: string) {
   const idx = path.lastIndexOf("/");
@@ -98,6 +108,9 @@ function loadState(): LayoutState {
         sidebar: {
           width: parsed.sidebar?.width ?? DEFAULT_SIDEBAR_WIDTH,
         },
+        reviewMode: isReviewMode(parsed.reviewMode)
+          ? parsed.reviewMode
+          : DEFAULT_REVIEW_MODE,
         tabs,
         activeTab,
       };
@@ -109,6 +122,7 @@ function loadState(): LayoutState {
     review: { opened: false, width: DEFAULT_REVIEW_WIDTH },
     info: { opened: false, width: DEFAULT_INFO_WIDTH },
     sidebar: { width: DEFAULT_SIDEBAR_WIDTH },
+    reviewMode: DEFAULT_REVIEW_MODE,
     tabs: [],
     activeTab: null,
   };
@@ -129,6 +143,9 @@ export function LayoutProvider(props: ParentProps) {
   const [reviewOpened, setReviewOpened] = createSignal(initial.review.opened);
   const [reviewWidth, setReviewWidth] = createSignal(
     initial.review.width ?? DEFAULT_REVIEW_WIDTH,
+  );
+  const [reviewMode, setReviewMode] = createSignal<ReviewMode>(
+    initial.reviewMode ?? DEFAULT_REVIEW_MODE,
   );
 
   // Info panel state
@@ -156,6 +173,7 @@ export function LayoutProvider(props: ParentProps) {
       review: { opened: reviewOpened(), width: reviewWidth() },
       info: { opened: infoOpened(), width: infoWidth() },
       sidebar: { width: sidebarWidth() },
+      reviewMode: reviewMode(),
       tabs: fileTabs(),
       activeTab: activeTab(),
     });
@@ -165,6 +183,7 @@ export function LayoutProvider(props: ParentProps) {
     review: {
       opened: reviewOpened,
       width: reviewWidth,
+      mode: reviewMode,
       toggle: () => {
         setReviewOpened((v) => !v);
         persist();
@@ -179,6 +198,11 @@ export function LayoutProvider(props: ParentProps) {
       },
       resize: (width: number) => {
         setReviewWidth(width);
+        persist();
+      },
+      setMode: (mode: ReviewMode) => {
+        if (reviewMode() === mode) return;
+        setReviewMode(mode);
         persist();
       },
     },

--- a/app-prefixable/src/sdk/client.ts
+++ b/app-prefixable/src/sdk/client.ts
@@ -1,9 +1,30 @@
 export * from "./gen/types.gen.js"
 
 import { createClient } from "./gen/client/client.gen.js"
-import { type Config } from "./gen/client/types.gen.js"
+import {
+  type Client,
+  type Config,
+  type RequestResult,
+} from "./gen/client/types.gen.js"
 import { OpencodeClient } from "./gen/sdk.gen.js"
+import type { FileDiff } from "./gen/types.gen.js"
 export { type Config as OpencodeClientConfig, OpencodeClient }
+
+export type VcsDiffMode = "git" | "branch"
+
+type VcsDiffParameters = {
+  directory?: string
+  mode?: VcsDiffMode
+}
+
+type VcsDiffOptions = Partial<Omit<Parameters<Client["get"]>[0], "url" | "query">>
+
+type VcsDiffClient = {
+  diff: <ThrowOnError extends boolean = false>(
+    parameters?: VcsDiffParameters,
+    options?: VcsDiffOptions & { throwOnError?: ThrowOnError },
+  ) => RequestResult<FileDiff[], unknown, ThrowOnError>
+}
 
 export function createOpencodeClient(config?: Config & { directory?: string }) {
   if (!config?.fetch) {
@@ -28,5 +49,20 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   }
 
   const client = createClient(config)
-  return new OpencodeClient({ client })
+  const sdk = new OpencodeClient({ client })
+  const diff: VcsDiffClient["diff"] = <ThrowOnError extends boolean = false>(
+    parameters?: VcsDiffParameters,
+    options?: VcsDiffOptions & { throwOnError?: ThrowOnError },
+  ) => client.get<FileDiff[], unknown, ThrowOnError>({
+    ...options,
+    url: "/vcs/diff",
+    query: {
+      directory: parameters?.directory,
+      mode: parameters?.mode,
+    },
+  })
+
+  return Object.assign(sdk, {
+    vcs: Object.assign(sdk.vcs, { diff }),
+  })
 }

--- a/app-prefixable/src/sdk/client.ts
+++ b/app-prefixable/src/sdk/client.ts
@@ -62,7 +62,6 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
     },
   })
 
-  return Object.assign(sdk, {
-    vcs: Object.assign(sdk.vcs, { diff }),
-  })
+  Object.assign(sdk.vcs, { diff })
+  return sdk
 }

--- a/app-prefixable/src/sdk/client.ts
+++ b/app-prefixable/src/sdk/client.ts
@@ -7,10 +7,17 @@ import {
   type RequestResult,
 } from "./gen/client/types.gen.js"
 import { OpencodeClient } from "./gen/sdk.gen.js"
-import type { FileDiff } from "./gen/types.gen.js"
 export { type Config as OpencodeClientConfig, OpencodeClient }
 
 export type VcsDiffMode = "git" | "branch"
+
+export type VcsFileDiff = {
+  file: string
+  patch: string
+  additions: number
+  deletions: number
+  status?: "added" | "deleted" | "modified"
+}
 
 type VcsDiffParameters = {
   directory?: string
@@ -23,10 +30,14 @@ type VcsDiffClient = {
   diff: <ThrowOnError extends boolean = false>(
     parameters?: VcsDiffParameters,
     options?: VcsDiffOptions & { throwOnError?: ThrowOnError },
-  ) => RequestResult<FileDiff[], unknown, ThrowOnError>
+  ) => RequestResult<VcsFileDiff[], unknown, ThrowOnError>
 }
 
-export function createOpencodeClient(config?: Config & { directory?: string }) {
+type OpencodeClientWithVcsDiff = OpencodeClient & {
+  vcs: OpencodeClient["vcs"] & VcsDiffClient
+}
+
+export function createOpencodeClient(config?: Config & { directory?: string }): OpencodeClientWithVcsDiff {
   if (!config?.fetch) {
     const customFetch: any = (req: any) => {
       // @ts-ignore
@@ -53,7 +64,7 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   const diff: VcsDiffClient["diff"] = <ThrowOnError extends boolean = false>(
     parameters?: VcsDiffParameters,
     options?: VcsDiffOptions & { throwOnError?: ThrowOnError },
-  ) => client.get<FileDiff[], unknown, ThrowOnError>({
+  ) => client.get<VcsFileDiff[], unknown, ThrowOnError>({
     ...options,
     url: "/vcs/diff",
     query: {
@@ -63,5 +74,5 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   })
 
   Object.assign(sdk.vcs, { diff })
-  return sdk
+  return sdk as OpencodeClientWithVcsDiff
 }

--- a/app-prefixable/tests/api-contract.test.ts
+++ b/app-prefixable/tests/api-contract.test.ts
@@ -219,6 +219,41 @@ describe("OpenCode API Contract", () => {
     });
   });
 
+  // VCS Endpoints
+  describe("VCS API", () => {
+    test("GET /vcs/diff?mode=git endpoint exists", async () => {
+      if (skipIfNoServer()) return;
+      const res = await fetch(`${BASE_URL}/vcs/diff?mode=git`);
+      expect(res.status).not.toBe(404);
+      if (!res.ok) return;
+
+      const data = await res.json();
+      expect(Array.isArray(data)).toBe(true);
+      for (const diff of data) {
+        expect(typeof diff.file).toBe("string");
+        expect(typeof diff.patch).toBe("string");
+        expect(typeof diff.additions).toBe("number");
+        expect(typeof diff.deletions).toBe("number");
+      }
+    });
+
+    test("GET /vcs/diff?mode=branch endpoint exists", async () => {
+      if (skipIfNoServer()) return;
+      const res = await fetch(`${BASE_URL}/vcs/diff?mode=branch`);
+      expect(res.status).not.toBe(404);
+      if (!res.ok) return;
+
+      const data = await res.json();
+      expect(Array.isArray(data)).toBe(true);
+      for (const diff of data) {
+        expect(typeof diff.file).toBe("string");
+        expect(typeof diff.patch).toBe("string");
+        expect(typeof diff.additions).toBe("number");
+        expect(typeof diff.deletions).toBe("number");
+      }
+    });
+  });
+
   // PTY Endpoints
   describe("PTY API", () => {
     test("GET /pty returns pty list", async () => {


### PR DESCRIPTION
## Summary
- Adds persistent review panel modes for session, git working tree, branch, and last turn diffs.
- Uses current `session.diff` support for session/turn diffs and a small non-generated SDK wrapper for `/vcs/diff` instead of editing generated files by hand.
- Keeps current session diff event behavior scoped to session mode and reloads VCS diffs on branch updates.

Closes #230
Supersedes #344

## Validation
- `bun run build`
- `bun test tests/api-contract.test.ts`
- `bunx eslint src/components/review-panel.tsx src/context/layout.tsx src/sdk/client.ts` (only warning: `src/sdk/client.ts` is ignored by repo lint config)

## Notes
- Full `bun run typecheck` still fails on existing unrelated baseline TypeScript errors in `app.tsx`, `server.tsx`, `theme.tsx`, `entry.tsx`, `pages/layout.tsx`, and `shared/proxy.ts`.
- Full `bun run lint` still fails on existing unrelated baseline lint errors across the repo.