### PR TITLE
fix: stabilize tool invocation summaries

### DIFF
--- a/app-prefixable/src/components/tool-part.tsx
+++ b/app-prefixable/src/components/tool-part.tsx
@@ -165,9 +165,6 @@ function truncateSummary(value: string): string {
 }
 
 function getInvocationSummary(tool: string, state: ToolState): string | undefined {
-  const status = getStatus(state);
-  if (status !== "running" && status !== "pending") return undefined;
-
   const input = getInput(state);
   if (!input) return undefined;
 


### PR DESCRIPTION
## Summary
- Keep tool invocation summaries rendered after tools complete so active tool headers do not collapse while responses stream.
- Preserve pending/running command and invocation details and existing expand/collapse behavior.

## Test
- cd app-prefixable && bun run build

Closes #415