### PR TITLE
fix: respect manual chat scroll position

### DIFF
--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -168,14 +168,46 @@ export function MessageTimeline(props: {
     return scrollHeight - scrollTop - clientHeight < 100
   }
 
+  function isAtBottom(): boolean {
+    if (!containerRef) return true
+    return containerRef.scrollHeight - containerRef.scrollTop - containerRef.clientHeight < SCROLL_INTENT_THRESHOLD
+  }
+
+  function clearProgrammaticScroll() {
+    programmaticScroll = false
+    if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
+    programmaticScrollTimer = undefined
+  }
+
+  function scheduleProgrammaticScrollEnd() {
+    if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
+    programmaticScrollTimer = window.setTimeout(() => {
+      clearProgrammaticScroll()
+    }, 150)
+  }
+
+  function engageManualScrollLock() {
+    clearProgrammaticScroll()
+    manualScrollLock = true
+    setUserScrolledUp(true)
+  }
+
+  function releaseManualScrollLock() {
+    manualScrollLock = false
+    setUserScrolledUp(false)
+  }
+
   // Handle scroll
   function handleScroll() {
     const nearBottom = isNearBottom()
+    const atBottom = isAtBottom()
     const top = containerRef?.scrollTop ?? 0
     const scrollingDown = top > lastScrollTop
     lastScrollTop = top
 
     if (programmaticScroll) {
+      if (atBottom) clearProgrammaticScroll()
+      else scheduleProgrammaticScrollEnd()
       props.onScroll?.(nearBottom)
       return
     }
@@ -186,20 +218,22 @@ export function MessageTimeline(props: {
       return
     }
 
-    if (!manualScrollLock || scrollingDown) {
-      manualScrollLock = false
+    if (!manualScrollLock) {
       setUserScrolledUp(false)
+      props.onScroll?.(nearBottom)
+      return
+    }
+
+    if (atBottom && scrollingDown) {
+      releaseManualScrollLock()
     }
     props.onScroll?.(nearBottom)
   }
 
   function handleWheel(event: WheelEvent) {
-    if (!containerRef || containerRef.scrollTop <= 0) return
-    if (event.deltaY < -SCROLL_INTENT_THRESHOLD) {
-      programmaticScroll = false
-      manualScrollLock = true
-      setUserScrolledUp(true)
-    }
+    const unit = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : containerRef?.clientHeight ?? 1
+    const delta = event.deltaMode === WheelEvent.DOM_DELTA_PIXEL ? event.deltaY : event.deltaY * unit
+    if (delta < -SCROLL_INTENT_THRESHOLD) engageManualScrollLock()
   }
 
   function handleTouchStart(event: TouchEvent) {
@@ -208,29 +242,26 @@ export function MessageTimeline(props: {
 
   function handleTouchMove(event: TouchEvent) {
     const y = event.touches[0]?.clientY
-    if (containerRef && containerRef.scrollTop > 0 && touchY !== undefined && y !== undefined) {
+    if (touchY !== undefined && y !== undefined) {
       const delta = y - touchY
-      if (delta > SCROLL_INTENT_THRESHOLD) {
-        programmaticScroll = false
-        manualScrollLock = true
-        setUserScrolledUp(true)
-      }
+      if (delta > SCROLL_INTENT_THRESHOLD) engageManualScrollLock()
     }
     touchY = y
+  }
+
+  function handleTouchEnd() {
+    touchY = undefined
   }
 
   // Scroll to bottom
   function scrollToBottom(force = false) {
     if (userScrolledUp() && !force) return
-    if (force) manualScrollLock = false
+    if (force) releaseManualScrollLock()
     requestAnimationFrame(() => {
       if (userScrolledUp() && !force) return
       programmaticScroll = true
       endRef?.scrollIntoView({ behavior: "smooth" })
-      if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
-      programmaticScrollTimer = window.setTimeout(() => {
-        programmaticScroll = false
-      }, 500)
+      scheduleProgrammaticScrollEnd()
     })
   }
 
@@ -283,6 +314,8 @@ export function MessageTimeline(props: {
       onWheel={handleWheel}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
       class="flex-1 overflow-y-auto p-6"
       style={{ background: "var(--background-stronger)" }}
     >

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -81,10 +81,8 @@ export function MessageTimeline(props: {
   let containerRef: HTMLDivElement | undefined
   let endRef: HTMLDivElement | undefined
   let touchY: number | undefined
-  // These flags mirror DOM scroll state and do not drive rendering directly.
+  // These flags mirror DOM scroll intent and do not drive rendering directly.
   const scroll = {
-    programmatic: false,
-    timer: undefined as number | undefined,
     manualLock: false,
     lastTop: undefined as number | undefined,
   }
@@ -97,7 +95,6 @@ export function MessageTimeline(props: {
   })
   onCleanup(() => {
     if (tick !== undefined) clearInterval(tick)
-    if (scroll.timer !== undefined) clearTimeout(scroll.timer)
   })
 
   // Track which turns are expanded
@@ -144,9 +141,7 @@ export function MessageTimeline(props: {
     // Restore scroll position after DOM update
     requestAnimationFrame(() => {
       if (containerRef) {
-        beginProgrammaticScroll()
         containerRef.scrollTop = containerRef.scrollHeight - scrollBottom
-        scheduleProgrammaticScrollEnd()
       }
     })
   }
@@ -174,26 +169,7 @@ export function MessageTimeline(props: {
     return scrollHeight - scrollTop - clientHeight < 100
   }
 
-  function clearProgrammaticScroll() {
-    scroll.programmatic = false
-    if (scroll.timer !== undefined) clearTimeout(scroll.timer)
-    scroll.timer = undefined
-  }
-
-  function scheduleProgrammaticScrollEnd() {
-    if (scroll.timer !== undefined) clearTimeout(scroll.timer)
-    scroll.timer = window.setTimeout(() => {
-      clearProgrammaticScroll()
-    }, 2_000)
-  }
-
-  function beginProgrammaticScroll() {
-    scroll.programmatic = true
-    scheduleProgrammaticScrollEnd()
-  }
-
   function engageManualScrollLock() {
-    clearProgrammaticScroll()
     scroll.manualLock = true
     setUserScrolledUp(true)
   }
@@ -219,9 +195,6 @@ export function MessageTimeline(props: {
 
     if (scrollingUp) {
       engageManualScrollLock()
-    } else if (scroll.programmatic) {
-      if (nearBottom) clearProgrammaticScroll()
-      else scheduleProgrammaticScrollEnd()
     } else if (!scroll.manualLock) {
       setUserScrolledUp(false)
     } else if (nearBottom && scrollingDown) {
@@ -258,14 +231,9 @@ export function MessageTimeline(props: {
   function scrollToBottom(force = false) {
     if (userScrolledUp() && !force) return
     if (force) releaseManualScrollLock()
-    beginProgrammaticScroll()
     requestAnimationFrame(() => {
-      if (userScrolledUp() && !force) {
-        clearProgrammaticScroll()
-        return
-      }
+      if (userScrolledUp() && !force) return
       endRef?.scrollIntoView({ behavior: "smooth" })
-      scheduleProgrammaticScrollEnd()
     })
   }
 

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -12,6 +12,7 @@ import { extractTextContent } from "../utils/message"
 // Number of turns to render initially and on each "load more"
 const TURNS_PER_BATCH = 10
 const INITIAL_TURNS = 5
+const SCROLL_INTENT_THRESHOLD = 4
 
 // Compute turn-level timing from user and assistant message timestamps
 function computeTurnTime(user: DisplayMessage, assistants: DisplayMessage[]): Turn["time"] {
@@ -78,10 +79,14 @@ export function MessageTimeline(props: {
 }) {
   let containerRef: HTMLDivElement | undefined
   let endRef: HTMLDivElement | undefined
-  let programmaticScroll = false
-  let programmaticScrollTimer: number | undefined
-  let manualScrollLock = false
-  let lastScrollTop: number | undefined
+  let touchY: number | undefined
+  // These flags mirror DOM scroll state and do not drive rendering directly.
+  const scroll = {
+    programmatic: false,
+    timer: undefined as number | undefined,
+    manualLock: false,
+    lastTop: undefined as number | undefined,
+  }
 
   // Shared clock signal for relative timestamps — one timer for all turns
   const [now, setNow] = createSignal(Date.now())
@@ -91,7 +96,7 @@ export function MessageTimeline(props: {
   })
   onCleanup(() => {
     if (tick !== undefined) clearInterval(tick)
-    if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
+    if (scroll.timer !== undefined) clearTimeout(scroll.timer)
   })
 
   // Track which turns are expanded
@@ -138,7 +143,9 @@ export function MessageTimeline(props: {
     // Restore scroll position after DOM update
     requestAnimationFrame(() => {
       if (containerRef) {
+        beginProgrammaticScroll()
         containerRef.scrollTop = containerRef.scrollHeight - scrollBottom
+        scheduleProgrammaticScrollEnd()
       }
     })
   }
@@ -167,76 +174,97 @@ export function MessageTimeline(props: {
   }
 
   function clearProgrammaticScroll() {
-    programmaticScroll = false
-    if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
-    programmaticScrollTimer = undefined
+    scroll.programmatic = false
+    if (scroll.timer !== undefined) clearTimeout(scroll.timer)
+    scroll.timer = undefined
   }
 
   function scheduleProgrammaticScrollEnd() {
-    if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
-    programmaticScrollTimer = window.setTimeout(() => {
+    if (scroll.timer !== undefined) clearTimeout(scroll.timer)
+    scroll.timer = window.setTimeout(() => {
       clearProgrammaticScroll()
-    }, 1_000)
+    }, 2_000)
+  }
+
+  function beginProgrammaticScroll() {
+    scroll.programmatic = true
+    scheduleProgrammaticScrollEnd()
   }
 
   function engageManualScrollLock() {
     clearProgrammaticScroll()
-    manualScrollLock = true
+    scroll.manualLock = true
     setUserScrolledUp(true)
   }
 
   function releaseManualScrollLock() {
-    manualScrollLock = false
+    scroll.manualLock = false
     setUserScrolledUp(false)
+  }
+
+  function canScrollUp(): boolean {
+    if (!containerRef) return false
+    return containerRef.scrollHeight > containerRef.clientHeight && containerRef.scrollTop > 0
   }
 
   // Handle scroll
   function handleScroll() {
     const nearBottom = isNearBottom()
     const top = containerRef?.scrollTop ?? 0
-    const previous = lastScrollTop
+    const previous = scroll.lastTop
     const scrollingUp = previous !== undefined && top < previous
     const scrollingDown = previous !== undefined && top > previous
-    lastScrollTop = top
+    scroll.lastTop = top
 
-    if (programmaticScroll) {
+    if (scroll.programmatic) {
       if (nearBottom) clearProgrammaticScroll()
       else scheduleProgrammaticScrollEnd()
-      props.onScroll?.(nearBottom)
-      return
-    }
-
-    if (scrollingUp) {
+    } else if (scrollingUp) {
       engageManualScrollLock()
-      props.onScroll?.(nearBottom)
-      return
-    }
-
-    if (!nearBottom) {
+    } else if (!nearBottom) {
       engageManualScrollLock()
-      props.onScroll?.(nearBottom)
-      return
-    }
-
-    if (!manualScrollLock) {
+    } else if (!scroll.manualLock) {
       setUserScrolledUp(false)
-      props.onScroll?.(nearBottom)
-      return
-    }
-
-    if (scrollingDown) {
+    } else if (scrollingDown) {
       releaseManualScrollLock()
     }
+
     props.onScroll?.(nearBottom)
+  }
+
+  function handleWheel(event: WheelEvent) {
+    const page = containerRef?.clientHeight ?? 1
+    const unit = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : page
+    const delta = event.deltaMode === WheelEvent.DOM_DELTA_PIXEL ? event.deltaY : event.deltaY * unit
+    if (delta < -SCROLL_INTENT_THRESHOLD && canScrollUp()) engageManualScrollLock()
+  }
+
+  function handleTouchStart(event: TouchEvent) {
+    touchY = event.touches[0]?.clientY
+  }
+
+  function handleTouchMove(event: TouchEvent) {
+    const y = event.touches[0]?.clientY
+    if (touchY !== undefined && y !== undefined && y - touchY > SCROLL_INTENT_THRESHOLD && canScrollUp()) {
+      engageManualScrollLock()
+    }
+    touchY = y
+  }
+
+  function handleTouchEnd() {
+    touchY = undefined
   }
 
   // Scroll to bottom
   function scrollToBottom(force = false) {
     if (userScrolledUp() && !force) return
     if (force) releaseManualScrollLock()
+    beginProgrammaticScroll()
     requestAnimationFrame(() => {
-      if (userScrolledUp() && !force) return
-      programmaticScroll = true
+      if (userScrolledUp() && !force) {
+        clearProgrammaticScroll()
+        return
+      }
       endRef?.scrollIntoView({ behavior: "smooth" })
       scheduleProgrammaticScrollEnd()
     })
@@ -253,6 +281,7 @@ export function MessageTimeline(props: {
 
   // Scroll to bottom on mount
   onMount(() => {
+    scroll.lastTop = containerRef?.scrollTop
     setTimeout(() => scrollToBottom(true), 100)
   })
 
@@ -288,6 +317,11 @@ export function MessageTimeline(props: {
     <div
       ref={containerRef}
       onScroll={handleScroll}
+      onWheel={handleWheel}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
       class="flex-1 overflow-y-auto p-6"
       style={{ background: "var(--background-stronger)" }}
     >

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -12,7 +12,6 @@ import { extractTextContent } from "../utils/message"
 // Number of turns to render initially and on each "load more"
 const TURNS_PER_BATCH = 10
 const INITIAL_TURNS = 5
-const SCROLL_INTENT_THRESHOLD = 4
 
 // Compute turn-level timing from user and assistant message timestamps
 function computeTurnTime(user: DisplayMessage, assistants: DisplayMessage[]): Turn["time"] {
@@ -82,8 +81,7 @@ export function MessageTimeline(props: {
   let programmaticScroll = false
   let programmaticScrollTimer: number | undefined
   let manualScrollLock = false
-  let lastScrollTop = 0
-  let touchY: number | undefined
+  let lastScrollTop: number | undefined
 
   // Shared clock signal for relative timestamps — one timer for all turns
   const [now, setNow] = createSignal(Date.now())
@@ -168,11 +166,6 @@ export function MessageTimeline(props: {
     return scrollHeight - scrollTop - clientHeight < 100
   }
 
-  function isAtBottom(): boolean {
-    if (!containerRef) return true
-    return containerRef.scrollHeight - containerRef.scrollTop - containerRef.clientHeight < SCROLL_INTENT_THRESHOLD
-  }
-
   function clearProgrammaticScroll() {
     programmaticScroll = false
     if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
@@ -183,7 +176,7 @@ export function MessageTimeline(props: {
     if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
     programmaticScrollTimer = window.setTimeout(() => {
       clearProgrammaticScroll()
-    }, 150)
+    }, 1_000)
   }
 
   function engageManualScrollLock() {
@@ -200,20 +193,27 @@ export function MessageTimeline(props: {
   // Handle scroll
   function handleScroll() {
     const nearBottom = isNearBottom()
-    const atBottom = isAtBottom()
     const top = containerRef?.scrollTop ?? 0
-    const scrollingDown = top > lastScrollTop
+    const previous = lastScrollTop
+    const scrollingUp = previous !== undefined && top < previous
+    const scrollingDown = previous !== undefined && top > previous
     lastScrollTop = top
 
     if (programmaticScroll) {
-      if (atBottom) clearProgrammaticScroll()
+      if (nearBottom) clearProgrammaticScroll()
       else scheduleProgrammaticScrollEnd()
       props.onScroll?.(nearBottom)
       return
     }
 
+    if (scrollingUp) {
+      engageManualScrollLock()
+      props.onScroll?.(nearBottom)
+      return
+    }
+
     if (!nearBottom) {
-      setUserScrolledUp(true)
+      engageManualScrollLock()
       props.onScroll?.(nearBottom)
       return
     }
@@ -224,33 +224,10 @@ export function MessageTimeline(props: {
       return
     }
 
-    if (atBottom && scrollingDown) {
+    if (scrollingDown) {
       releaseManualScrollLock()
     }
     props.onScroll?.(nearBottom)
-  }
-
-  function handleWheel(event: WheelEvent) {
-    const unit = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : containerRef?.clientHeight ?? 1
-    const delta = event.deltaMode === WheelEvent.DOM_DELTA_PIXEL ? event.deltaY : event.deltaY * unit
-    if (delta < -SCROLL_INTENT_THRESHOLD) engageManualScrollLock()
-  }
-
-  function handleTouchStart(event: TouchEvent) {
-    touchY = event.touches[0]?.clientY
-  }
-
-  function handleTouchMove(event: TouchEvent) {
-    const y = event.touches[0]?.clientY
-    if (touchY !== undefined && y !== undefined) {
-      const delta = y - touchY
-      if (delta > SCROLL_INTENT_THRESHOLD) engageManualScrollLock()
-    }
-    touchY = y
-  }
-
-  function handleTouchEnd() {
-    touchY = undefined
   }
 
   // Scroll to bottom
@@ -311,11 +288,6 @@ export function MessageTimeline(props: {
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      onWheel={handleWheel}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
-      onTouchCancel={handleTouchEnd}
       class="flex-1 overflow-y-auto p-6"
       style={{ background: "var(--background-stronger)" }}
     >

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -78,6 +78,8 @@ export function MessageTimeline(props: {
 }) {
   let containerRef: HTMLDivElement | undefined
   let endRef: HTMLDivElement | undefined
+  let programmaticScroll = false
+  let touchY: number | undefined
 
   // Shared clock signal for relative timestamps — one timer for all turns
   const [now, setNow] = createSignal(Date.now())
@@ -164,15 +166,34 @@ export function MessageTimeline(props: {
   // Handle scroll
   function handleScroll() {
     const nearBottom = isNearBottom()
+    if (programmaticScroll && userScrolledUp()) return
     setUserScrolledUp(!nearBottom)
     props.onScroll?.(nearBottom)
+  }
+
+  function handleWheel(event: WheelEvent) {
+    if (event.deltaY < 0) setUserScrolledUp(true)
+  }
+
+  function handleTouchStart(event: TouchEvent) {
+    touchY = event.touches[0]?.clientY
+  }
+
+  function handleTouchMove(event: TouchEvent) {
+    const y = event.touches[0]?.clientY
+    if (touchY !== undefined && y !== undefined && y > touchY) setUserScrolledUp(true)
+    touchY = y
   }
 
   // Scroll to bottom
   function scrollToBottom(force = false) {
     if (userScrolledUp() && !force) return
     requestAnimationFrame(() => {
-      endRef?.scrollIntoView({ behavior: "smooth" })
+      programmaticScroll = true
+      endRef?.scrollIntoView({ behavior: "auto" })
+      requestAnimationFrame(() => {
+        programmaticScroll = false
+      })
     })
   }
 
@@ -222,6 +243,9 @@ export function MessageTimeline(props: {
     <div
       ref={containerRef}
       onScroll={handleScroll}
+      onWheel={handleWheel}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
       class="flex-1 overflow-y-auto p-6"
       style={{ background: "var(--background-stronger)" }}
     >

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -12,6 +12,7 @@ import { extractTextContent } from "../utils/message"
 // Number of turns to render initially and on each "load more"
 const TURNS_PER_BATCH = 10
 const INITIAL_TURNS = 5
+const SCROLL_INTENT_THRESHOLD = 4
 
 // Compute turn-level timing from user and assistant message timestamps
 function computeTurnTime(user: DisplayMessage, assistants: DisplayMessage[]): Turn["time"] {
@@ -79,6 +80,9 @@ export function MessageTimeline(props: {
   let containerRef: HTMLDivElement | undefined
   let endRef: HTMLDivElement | undefined
   let programmaticScroll = false
+  let programmaticScrollTimer: number | undefined
+  let manualScrollLock = false
+  let lastScrollTop = 0
   let touchY: number | undefined
 
   // Shared clock signal for relative timestamps — one timer for all turns
@@ -89,6 +93,7 @@ export function MessageTimeline(props: {
   })
   onCleanup(() => {
     if (tick !== undefined) clearInterval(tick)
+    if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
   })
 
   // Track which turns are expanded
@@ -166,13 +171,35 @@ export function MessageTimeline(props: {
   // Handle scroll
   function handleScroll() {
     const nearBottom = isNearBottom()
-    if (programmaticScroll && userScrolledUp()) return
-    setUserScrolledUp(!nearBottom)
+    const top = containerRef?.scrollTop ?? 0
+    const scrollingDown = top > lastScrollTop
+    lastScrollTop = top
+
+    if (programmaticScroll) {
+      props.onScroll?.(nearBottom)
+      return
+    }
+
+    if (!nearBottom) {
+      setUserScrolledUp(true)
+      props.onScroll?.(nearBottom)
+      return
+    }
+
+    if (!manualScrollLock || scrollingDown) {
+      manualScrollLock = false
+      setUserScrolledUp(false)
+    }
     props.onScroll?.(nearBottom)
   }
 
   function handleWheel(event: WheelEvent) {
-    if (event.deltaY < 0) setUserScrolledUp(true)
+    if (!containerRef || containerRef.scrollTop <= 0) return
+    if (event.deltaY < -SCROLL_INTENT_THRESHOLD) {
+      programmaticScroll = false
+      manualScrollLock = true
+      setUserScrolledUp(true)
+    }
   }
 
   function handleTouchStart(event: TouchEvent) {
@@ -181,19 +208,29 @@ export function MessageTimeline(props: {
 
   function handleTouchMove(event: TouchEvent) {
     const y = event.touches[0]?.clientY
-    if (touchY !== undefined && y !== undefined && y > touchY) setUserScrolledUp(true)
+    if (containerRef && containerRef.scrollTop > 0 && touchY !== undefined && y !== undefined) {
+      const delta = y - touchY
+      if (delta > SCROLL_INTENT_THRESHOLD) {
+        programmaticScroll = false
+        manualScrollLock = true
+        setUserScrolledUp(true)
+      }
+    }
     touchY = y
   }
 
   // Scroll to bottom
   function scrollToBottom(force = false) {
     if (userScrolledUp() && !force) return
+    if (force) manualScrollLock = false
     requestAnimationFrame(() => {
+      if (userScrolledUp() && !force) return
       programmaticScroll = true
-      endRef?.scrollIntoView({ behavior: "auto" })
-      requestAnimationFrame(() => {
+      endRef?.scrollIntoView({ behavior: "smooth" })
+      if (programmaticScrollTimer !== undefined) clearTimeout(programmaticScrollTimer)
+      programmaticScrollTimer = window.setTimeout(() => {
         programmaticScroll = false
-      })
+      }, 500)
     })
   }
 

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -80,11 +80,10 @@ export function MessageTimeline(props: {
 }) {
   let containerRef: HTMLDivElement | undefined
   let endRef: HTMLDivElement | undefined
-  let touchY: number | undefined
+  let touchStartY: number | undefined
   // These flags mirror DOM scroll intent and do not drive rendering directly.
   const scroll = {
-    manualLock: false,
-    lastTop: undefined as number | undefined,
+    lastTop: 0,
   }
 
   // Shared clock signal for relative timestamps — one timer for all turns
@@ -170,18 +169,15 @@ export function MessageTimeline(props: {
   }
 
   function engageManualScrollLock() {
-    scroll.manualLock = true
+    if (containerRef) {
+      scroll.lastTop = containerRef.scrollTop
+      containerRef.scrollTop = containerRef.scrollTop
+    }
     setUserScrolledUp(true)
   }
 
   function releaseManualScrollLock() {
-    scroll.manualLock = false
     setUserScrolledUp(false)
-  }
-
-  function canScrollUp(): boolean {
-    if (!containerRef) return false
-    return containerRef.scrollHeight > containerRef.clientHeight && containerRef.scrollTop > 0
   }
 
   // Handle scroll
@@ -189,15 +185,13 @@ export function MessageTimeline(props: {
     const nearBottom = isNearBottom()
     const top = containerRef?.scrollTop ?? 0
     const previous = scroll.lastTop
-    const scrollingUp = previous !== undefined && top < previous
-    const scrollingDown = previous !== undefined && top > previous
+    const scrollingUp = top < previous
+    const scrollingDown = top > previous
     scroll.lastTop = top
 
     if (scrollingUp) {
       engageManualScrollLock()
-    } else if (!scroll.manualLock) {
-      setUserScrolledUp(false)
-    } else if (nearBottom && scrollingDown) {
+    } else if (userScrolledUp() && nearBottom && scrollingDown) {
       releaseManualScrollLock()
     }
 
@@ -206,25 +200,24 @@ export function MessageTimeline(props: {
 
   function handleWheel(event: WheelEvent) {
     const page = containerRef?.clientHeight ?? 1
-    const unit = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : page
-    const delta = event.deltaMode === WheelEvent.DOM_DELTA_PIXEL ? event.deltaY : event.deltaY * unit
-    if (delta < -WHEEL_SCROLL_INTENT_THRESHOLD && canScrollUp()) engageManualScrollLock()
+    const unit = event.deltaMode === 1 ? 16 : page
+    const delta = event.deltaMode === 0 ? event.deltaY : event.deltaY * unit
+    if (delta < -WHEEL_SCROLL_INTENT_THRESHOLD) engageManualScrollLock()
   }
 
   function handleTouchStart(event: TouchEvent) {
-    touchY = event.touches[0]?.clientY
+    touchStartY = event.touches[0]?.clientY
   }
 
   function handleTouchMove(event: TouchEvent) {
     const y = event.touches[0]?.clientY
-    if (touchY !== undefined && y !== undefined && y - touchY > TOUCH_SCROLL_INTENT_THRESHOLD && canScrollUp()) {
+    if (touchStartY !== undefined && y !== undefined && y - touchStartY > TOUCH_SCROLL_INTENT_THRESHOLD) {
       engageManualScrollLock()
     }
-    touchY = y
   }
 
   function handleTouchEnd() {
-    touchY = undefined
+    touchStartY = undefined
   }
 
   // Scroll to bottom

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -14,7 +14,8 @@ const TURNS_PER_BATCH = 10
 const INITIAL_TURNS = 5
 const WHEEL_SCROLL_INTENT_THRESHOLD = 4
 const TOUCH_SCROLL_INTENT_THRESHOLD = 12
-const WHEEL_LINE_HEIGHT = 16
+const WHEEL_LINE_HEIGHT = 32
+const USER_SCROLL_INTENT_MS = 500
 
 // Compute turn-level timing from user and assistant message timestamps
 function computeTurnTime(user: DisplayMessage, assistants: DisplayMessage[]): Turn["time"] {
@@ -81,18 +82,24 @@ export function MessageTimeline(props: {
 }) {
   let containerRef: HTMLDivElement | undefined
   let endRef: HTMLDivElement | undefined
-  let touchStartY: number | undefined
+  let touchId: number | undefined
+  let touchY: number | undefined
+  let touchDelta = 0
   let lastTop = 0
-  let userScrollingDown = false
+  let userScrollingUpUntil = 0
+  let userScrollingDownUntil = 0
+  let smoothScrollActive = false
 
   // Shared clock signal for relative timestamps — one timer for all turns
   const [now, setNow] = createSignal(Date.now())
   let tick: number | undefined
   onMount(() => {
     tick = window.setInterval(() => setNow(Date.now()), 30_000)
+    window.addEventListener("keydown", handleKeyDown)
   })
   onCleanup(() => {
     if (tick !== undefined) clearInterval(tick)
+    window.removeEventListener("keydown", handleKeyDown)
   })
 
   // Track which turns are expanded
@@ -168,10 +175,11 @@ export function MessageTimeline(props: {
   }
 
   function engageManualScrollLock() {
-    if (containerRef) {
+    if (containerRef && smoothScrollActive) {
       lastTop = containerRef.scrollTop
       // Cancel any in-flight smooth scroll so it cannot clear the manual override.
       containerRef.scrollTo({ top: containerRef.scrollTop, behavior: "auto" })
+      smoothScrollActive = false
     }
     setUserScrolledUp(true)
   }
@@ -187,22 +195,27 @@ export function MessageTimeline(props: {
     const previous = lastTop
     const scrollingUp = top < previous
     const scrollingDown = top > previous
+    const now = Date.now()
     lastTop = top
 
-    if (scrollingUp) {
+    if (nearBottom) smoothScrollActive = false
+
+    if (scrollingUp && now < userScrollingUpUntil) {
       engageManualScrollLock()
-    } else if (userScrolledUp() && nearBottom && scrollingDown && userScrollingDown) {
+    } else if (userScrolledUp() && nearBottom && scrollingDown && now < userScrollingDownUntil) {
       releaseManualScrollLock()
     }
-
-    userScrollingDown = false
     props.onScroll?.(nearBottom)
   }
 
   function handleWheel(event: WheelEvent) {
     const delta = normalizedWheelDelta(event)
-    if (delta < -WHEEL_SCROLL_INTENT_THRESHOLD) engageManualScrollLock()
-    if (delta > WHEEL_SCROLL_INTENT_THRESHOLD) userScrollingDown = true
+    const now = Date.now()
+    if (delta < -WHEEL_SCROLL_INTENT_THRESHOLD) {
+      userScrollingUpUntil = now + USER_SCROLL_INTENT_MS
+      engageManualScrollLock()
+    }
+    if (delta > WHEEL_SCROLL_INTENT_THRESHOLD) userScrollingDownUntil = now + USER_SCROLL_INTENT_MS
   }
 
   function normalizedWheelDelta(event: WheelEvent): number {
@@ -212,31 +225,53 @@ export function MessageTimeline(props: {
   }
 
   function handleKeyDown(event: KeyboardEvent) {
+    const target = event.target
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) return
+    if (target instanceof HTMLElement && target.isContentEditable) return
+
+    const now = Date.now()
     if (["ArrowUp", "PageUp", "Home"].includes(event.key) || (event.key === " " && event.shiftKey)) {
+      userScrollingUpUntil = now + USER_SCROLL_INTENT_MS
       engageManualScrollLock()
       return
     }
     if (["ArrowDown", "PageDown", "End"].includes(event.key) || (event.key === " " && !event.shiftKey)) {
-      userScrollingDown = true
+      userScrollingDownUntil = now + USER_SCROLL_INTENT_MS
     }
   }
 
   function handleTouchStart(event: TouchEvent) {
-    touchStartY = event.touches[0]?.clientY
+    if (touchId !== undefined) return
+    const touch = event.touches[0]
+    touchId = touch?.identifier
+    touchY = touch?.clientY
+    touchDelta = 0
   }
 
   function handleTouchMove(event: TouchEvent) {
-    const y = event.touches[0]?.clientY
-    if (touchStartY !== undefined && y !== undefined && y - touchStartY > TOUCH_SCROLL_INTENT_THRESHOLD) {
+    const touch = [...event.touches].find((item) => item.identifier === touchId)
+    const y = touch?.clientY
+    if (touchY === undefined || y === undefined) return
+
+    touchDelta += y - touchY
+    touchY = y
+
+    if (touchDelta > TOUCH_SCROLL_INTENT_THRESHOLD) {
+      userScrollingUpUntil = Date.now() + USER_SCROLL_INTENT_MS
       engageManualScrollLock()
+      touchDelta = 0
     }
-    if (touchStartY !== undefined && y !== undefined && touchStartY - y > TOUCH_SCROLL_INTENT_THRESHOLD) {
-      userScrollingDown = true
+    if (touchDelta < -TOUCH_SCROLL_INTENT_THRESHOLD) {
+      userScrollingDownUntil = Date.now() + USER_SCROLL_INTENT_MS
+      touchDelta = 0
     }
   }
 
-  function handleTouchEnd() {
-    touchStartY = undefined
+  function handleTouchEnd(event: TouchEvent) {
+    if (event.touches.length > 0) return
+    touchId = undefined
+    touchY = undefined
+    touchDelta = 0
   }
 
   // Scroll to bottom
@@ -246,6 +281,7 @@ export function MessageTimeline(props: {
     requestAnimationFrame(() => {
       // The user may scroll up before this frame runs; respect that late intent.
       if (userScrolledUp() && !force) return
+      smoothScrollActive = true
       endRef?.scrollIntoView({ behavior: "smooth" })
     })
   }

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -12,7 +12,8 @@ import { extractTextContent } from "../utils/message"
 // Number of turns to render initially and on each "load more"
 const TURNS_PER_BATCH = 10
 const INITIAL_TURNS = 5
-const SCROLL_INTENT_THRESHOLD = 4
+const WHEEL_SCROLL_INTENT_THRESHOLD = 4
+const TOUCH_SCROLL_INTENT_THRESHOLD = 12
 
 // Compute turn-level timing from user and assistant message timestamps
 function computeTurnTime(user: DisplayMessage, assistants: DisplayMessage[]): Turn["time"] {
@@ -216,16 +217,14 @@ export function MessageTimeline(props: {
     const scrollingDown = previous !== undefined && top > previous
     scroll.lastTop = top
 
-    if (scroll.programmatic) {
+    if (scrollingUp) {
+      engageManualScrollLock()
+    } else if (scroll.programmatic) {
       if (nearBottom) clearProgrammaticScroll()
       else scheduleProgrammaticScrollEnd()
-    } else if (scrollingUp) {
-      engageManualScrollLock()
-    } else if (!nearBottom) {
-      engageManualScrollLock()
     } else if (!scroll.manualLock) {
       setUserScrolledUp(false)
-    } else if (scrollingDown) {
+    } else if (nearBottom && scrollingDown) {
       releaseManualScrollLock()
     }
 
@@ -236,7 +235,7 @@ export function MessageTimeline(props: {
     const page = containerRef?.clientHeight ?? 1
     const unit = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : page
     const delta = event.deltaMode === WheelEvent.DOM_DELTA_PIXEL ? event.deltaY : event.deltaY * unit
-    if (delta < -SCROLL_INTENT_THRESHOLD && canScrollUp()) engageManualScrollLock()
+    if (delta < -WHEEL_SCROLL_INTENT_THRESHOLD && canScrollUp()) engageManualScrollLock()
   }
 
   function handleTouchStart(event: TouchEvent) {
@@ -245,7 +244,7 @@ export function MessageTimeline(props: {
 
   function handleTouchMove(event: TouchEvent) {
     const y = event.touches[0]?.clientY
-    if (touchY !== undefined && y !== undefined && y - touchY > SCROLL_INTENT_THRESHOLD && canScrollUp()) {
+    if (touchY !== undefined && y !== undefined && y - touchY > TOUCH_SCROLL_INTENT_THRESHOLD && canScrollUp()) {
       engageManualScrollLock()
     }
     touchY = y

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -14,6 +14,7 @@ const TURNS_PER_BATCH = 10
 const INITIAL_TURNS = 5
 const WHEEL_SCROLL_INTENT_THRESHOLD = 4
 const TOUCH_SCROLL_INTENT_THRESHOLD = 12
+const WHEEL_LINE_HEIGHT = 16
 
 // Compute turn-level timing from user and assistant message timestamps
 function computeTurnTime(user: DisplayMessage, assistants: DisplayMessage[]): Turn["time"] {
@@ -81,10 +82,8 @@ export function MessageTimeline(props: {
   let containerRef: HTMLDivElement | undefined
   let endRef: HTMLDivElement | undefined
   let touchStartY: number | undefined
-  // These flags mirror DOM scroll intent and do not drive rendering directly.
-  const scroll = {
-    lastTop: 0,
-  }
+  let lastTop = 0
+  let userScrollingDown = false
 
   // Shared clock signal for relative timestamps — one timer for all turns
   const [now, setNow] = createSignal(Date.now())
@@ -170,8 +169,9 @@ export function MessageTimeline(props: {
 
   function engageManualScrollLock() {
     if (containerRef) {
-      scroll.lastTop = containerRef.scrollTop
-      containerRef.scrollTop = containerRef.scrollTop
+      lastTop = containerRef.scrollTop
+      // Cancel any in-flight smooth scroll so it cannot clear the manual override.
+      containerRef.scrollTo({ top: containerRef.scrollTop, behavior: "auto" })
     }
     setUserScrolledUp(true)
   }
@@ -184,25 +184,41 @@ export function MessageTimeline(props: {
   function handleScroll() {
     const nearBottom = isNearBottom()
     const top = containerRef?.scrollTop ?? 0
-    const previous = scroll.lastTop
+    const previous = lastTop
     const scrollingUp = top < previous
     const scrollingDown = top > previous
-    scroll.lastTop = top
+    lastTop = top
 
     if (scrollingUp) {
       engageManualScrollLock()
-    } else if (userScrolledUp() && nearBottom && scrollingDown) {
+    } else if (userScrolledUp() && nearBottom && scrollingDown && userScrollingDown) {
       releaseManualScrollLock()
     }
 
+    userScrollingDown = false
     props.onScroll?.(nearBottom)
   }
 
   function handleWheel(event: WheelEvent) {
-    const page = containerRef?.clientHeight ?? 1
-    const unit = event.deltaMode === 1 ? 16 : page
-    const delta = event.deltaMode === 0 ? event.deltaY : event.deltaY * unit
+    const delta = normalizedWheelDelta(event)
     if (delta < -WHEEL_SCROLL_INTENT_THRESHOLD) engageManualScrollLock()
+    if (delta > WHEEL_SCROLL_INTENT_THRESHOLD) userScrollingDown = true
+  }
+
+  function normalizedWheelDelta(event: WheelEvent): number {
+    if (event.deltaMode === 1) return event.deltaY * WHEEL_LINE_HEIGHT
+    if (event.deltaMode === 2) return event.deltaY * (containerRef?.clientHeight ?? 1)
+    return event.deltaY
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (["ArrowUp", "PageUp", "Home"].includes(event.key) || (event.key === " " && event.shiftKey)) {
+      engageManualScrollLock()
+      return
+    }
+    if (["ArrowDown", "PageDown", "End"].includes(event.key) || (event.key === " " && !event.shiftKey)) {
+      userScrollingDown = true
+    }
   }
 
   function handleTouchStart(event: TouchEvent) {
@@ -213,6 +229,9 @@ export function MessageTimeline(props: {
     const y = event.touches[0]?.clientY
     if (touchStartY !== undefined && y !== undefined && y - touchStartY > TOUCH_SCROLL_INTENT_THRESHOLD) {
       engageManualScrollLock()
+    }
+    if (touchStartY !== undefined && y !== undefined && touchStartY - y > TOUCH_SCROLL_INTENT_THRESHOLD) {
+      userScrollingDown = true
     }
   }
 
@@ -225,6 +244,7 @@ export function MessageTimeline(props: {
     if (userScrolledUp() && !force) return
     if (force) releaseManualScrollLock()
     requestAnimationFrame(() => {
+      // The user may scroll up before this frame runs; respect that late intent.
       if (userScrolledUp() && !force) return
       endRef?.scrollIntoView({ behavior: "smooth" })
     })
@@ -241,7 +261,7 @@ export function MessageTimeline(props: {
 
   // Scroll to bottom on mount
   onMount(() => {
-    scroll.lastTop = containerRef?.scrollTop
+    lastTop = containerRef?.scrollTop ?? 0
     setTimeout(() => scrollToBottom(true), 100)
   })
 
@@ -278,6 +298,7 @@ export function MessageTimeline(props: {
       ref={containerRef}
       onScroll={handleScroll}
       onWheel={handleWheel}
+      onKeyDown={handleKeyDown}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}


### PR DESCRIPTION
## Summary
- Pause chat bottom-follow as soon as the user scrolls upward with wheel or touch input.
- Prevent programmatic autoscroll events from clearing the manual scroll override.
- Keep bottom-follow behavior active when the user has not scrolled away.

## Test
- cd app-prefixable && bun run build

Closes #417