### PR TITLE
fix: calm streaming autoscroll

### DIFF
--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -172,7 +172,8 @@ export function MessageTimeline(props: {
   function scrollToBottom(force = false) {
     if (userScrolledUp() && !force) return
     requestAnimationFrame(() => {
-      endRef?.scrollIntoView({ behavior: "smooth" })
+      if (!containerRef) return
+      containerRef.scrollTop = containerRef.scrollHeight
     })
   }
 
@@ -369,7 +370,8 @@ export function FlatMessageList(props: { messages: DisplayMessage[]; processing:
   function scrollToBottom(force = false) {
     if (userScrolledUp() && !force) return
     requestAnimationFrame(() => {
-      endRef?.scrollIntoView({ behavior: "smooth" })
+      if (!containerRef) return
+      containerRef.scrollTop = containerRef.scrollHeight
     })
   }
 


### PR DESCRIPTION
## Summary
- Replaces repeated smooth scroll animations during streaming with instant bottom pinning.
- Keeps existing near-bottom/user-scrolled-up gate so updates only follow while the user is already at the bottom.
- Supersedes #418 with a smaller UX-focused fix.

Closes #417