### PR TITLE
fix: restore live updates when SSE drops

### DIFF
--- a/app-prefixable/src/context/events.tsx
+++ b/app-prefixable/src/context/events.tsx
@@ -41,6 +41,7 @@ export function EventProvider(props: ParentProps) {
   // Connect to SSE endpoint using fetch (supports custom headers unlike EventSource)
   let abortController: AbortController | null = null
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let reconnectDelay = 3000
 
   function processEvent(rawData: string) {
     try {
@@ -97,6 +98,8 @@ export function EventProvider(props: ParentProps) {
     abortController = new AbortController()
     const signal = abortController.signal
 
+    let connectedAt = 0
+
     try {
       const response = await fetch(eventUrl, {
         headers: { ...authHeaders(), Accept: "text/event-stream" },
@@ -108,6 +111,7 @@ export function EventProvider(props: ParentProps) {
       }
 
       console.log("[Events] Connected")
+      connectedAt = Date.now()
 
       const reader = response.body.getReader()
       const decoder = new TextDecoder()
@@ -129,12 +133,13 @@ export function EventProvider(props: ParentProps) {
       if (signal.aborted) return // Intentional disconnect
       console.error("[Events] Connection error, reconnecting...", err)
       abortController = null
+      reconnectDelay = connectedAt && Date.now() - connectedAt > 10_000 ? 3000 : Math.min(reconnectDelay * 2, 30_000)
 
       if (!reconnectTimer) {
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null
           connect()
-        }, 3000)
+        }, reconnectDelay)
       }
     }
   }

--- a/app-prefixable/src/context/events.tsx
+++ b/app-prefixable/src/context/events.tsx
@@ -3,7 +3,7 @@ import { createStore, produce } from "solid-js/store"
 import type { Event, SessionStatus, QuestionRequest } from "../sdk/client"
 import { useSDK } from "./sdk"
 import { useServer } from "./server"
-import { createSSEParser } from "../utils/sse"
+import { createSSEParser, nextSSEReconnectDelay } from "../utils/sse"
 
 type EventHandler = (event: Event) => void
 
@@ -133,7 +133,7 @@ export function EventProvider(props: ParentProps) {
       if (signal.aborted) return // Intentional disconnect
       console.error("[Events] Connection error, reconnecting...", err)
       abortController = null
-      reconnectDelay = connectedAt && Date.now() - connectedAt > 10_000 ? 3000 : Math.min(reconnectDelay * 2, 30_000)
+      reconnectDelay = nextSSEReconnectDelay(connectedAt, Date.now(), reconnectDelay)
 
       if (!reconnectTimer) {
         reconnectTimer = setTimeout(() => {

--- a/app-prefixable/src/context/events.tsx
+++ b/app-prefixable/src/context/events.tsx
@@ -26,6 +26,7 @@ interface EventContextValue {
   statusReady: () => boolean
   pendingQuestions: Record<string, QuestionRequest | undefined>
   dismissQuestion: (sessionID: string, requestID: string) => void
+  setSessionStatus: (sessionID: string, status: SessionStatus) => void
 }
 
 const EventContext = createContext<EventContextValue>()
@@ -206,7 +207,7 @@ export function EventProvider(props: ParentProps) {
     }))
   }
 
-  return <EventContext.Provider value={{ subscribe, status, statusReady, pendingQuestions, dismissQuestion }}>{props.children}</EventContext.Provider>
+  return <EventContext.Provider value={{ subscribe, status, statusReady, pendingQuestions, dismissQuestion, setSessionStatus: setStatus }}>{props.children}</EventContext.Provider>
 }
 
 export function useEvents() {

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, onCleanup, batch, type ParentProps } from "solid-js"
+import { createContext, useContext, createSignal, onCleanup, batch, type ParentProps } from "solid-js"
 import { createStore, reconcile, produce } from "solid-js/store"
 import type { Session, Message, Part, Provider } from "../sdk/client"
 import { useSDK } from "./sdk"
@@ -41,6 +41,7 @@ interface SyncContextValue {
   messages: (sessionID: string) => MessageWithParts[]
   parts: (messageID: string) => Part[]
   providers: () => ProviderData
+  sseUnhealthy: () => boolean
   session: {
     sync: (sessionID: string) => Promise<void>
     get: (sessionID: string) => Session | undefined
@@ -193,10 +194,12 @@ export function SyncProvider(props: ParentProps) {
   })
 
   const inflight = new Map<string, Promise<void>>()
+  const [sseUnhealthy, setSseUnhealthy] = createSignal(false)
 
   // Connect to SSE endpoint using fetch (supports custom headers unlike EventSource)
   let abortController: AbortController | null = null
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let reconnectDelay = 3000
 
   async function connect() {
     if (abortController) return
@@ -207,6 +210,8 @@ export function SyncProvider(props: ParentProps) {
 
     abortController = new AbortController()
     const signal = abortController.signal
+
+    let connectedAt = 0
 
     try {
       const response = await fetch(eventUrl, {
@@ -219,6 +224,8 @@ export function SyncProvider(props: ParentProps) {
       }
 
       console.log("[Sync] Connected, bootstrapping...")
+      connectedAt = Date.now()
+      setSseUnhealthy(false)
       if (!store.ready) bootstrap()
 
       const reader = response.body.getReader()
@@ -246,13 +253,15 @@ export function SyncProvider(props: ParentProps) {
     } catch (err) {
       if (signal.aborted) return
       console.error("[Sync] Connection error, reconnecting...", err)
+      setSseUnhealthy(true)
       abortController = null
+      reconnectDelay = connectedAt && Date.now() - connectedAt > 10_000 ? 3000 : Math.min(reconnectDelay * 2, 30_000)
 
       if (!reconnectTimer) {
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null
           connect()
-        }, 3000)
+        }, reconnectDelay)
       }
     }
   }
@@ -563,6 +572,7 @@ export function SyncProvider(props: ParentProps) {
     messages: (sessionID: string) => store.message[sessionID] ?? [],
     parts: (messageID: string) => store.part[messageID] ?? [],
     providers: () => store.provider,
+    sseUnhealthy,
     session: {
       sync: syncSession,
       get: (sessionID: string) => {

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -86,7 +86,7 @@ function toolTime(part: Extract<Part, { type: "tool" }>) {
 
 function mergeSyncedPart(existing: Part, synced: Part) {
   if (existing.type !== synced.type) return synced
-  if (existing.type !== "tool" || synced.type !== "tool") return existing
+  if (existing.type !== "tool" || synced.type !== "tool") return synced
 
   const existingRank = toolRank(existing)
   const syncedRank = toolRank(synced)

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -3,7 +3,7 @@ import { createStore, reconcile, produce } from "solid-js/store"
 import type { Session, Message, Part, Provider } from "../sdk/client"
 import { useSDK } from "./sdk"
 import { useServer } from "./server"
-import { createSSEParser } from "../utils/sse"
+import { createSSEParser, nextSSEReconnectDelay } from "../utils/sse"
 
 // Event type - looser than SDK type to handle all events
 type SyncEvent = {
@@ -43,7 +43,7 @@ interface SyncContextValue {
   providers: () => ProviderData
   sseUnhealthy: () => boolean
   session: {
-    sync: (sessionID: string) => Promise<void>
+    sync: (sessionID: string) => Promise<boolean>
     get: (sessionID: string) => Session | undefined
   }
   refresh: () => Promise<void>
@@ -193,7 +193,7 @@ export function SyncProvider(props: ParentProps) {
     provider: { all: [], connected: [], default: {} },
   })
 
-  const inflight = new Map<string, Promise<void>>()
+  const inflight = new Map<string, Promise<boolean>>()
   const [sseUnhealthy, setSseUnhealthy] = createSignal(false)
 
   // Connect to SSE endpoint using fetch (supports custom headers unlike EventSource)
@@ -255,7 +255,7 @@ export function SyncProvider(props: ParentProps) {
       console.error("[Sync] Connection error, reconnecting...", err)
       setSseUnhealthy(true)
       abortController = null
-      reconnectDelay = connectedAt && Date.now() - connectedAt > 10_000 ? 3000 : Math.min(reconnectDelay * 2, 30_000)
+      reconnectDelay = nextSSEReconnectDelay(connectedAt, Date.now(), reconnectDelay)
 
       if (!reconnectTimer) {
         reconnectTimer = setTimeout(() => {
@@ -534,8 +534,10 @@ export function SyncProvider(props: ParentProps) {
             }
           }
         })
+        return true
       } catch (err) {
         console.error("[Sync] Failed to sync session:", sessionID, err)
+        return false
       }
     })()
 

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -84,8 +84,15 @@ function toolTime(part: Extract<Part, { type: "tool" }>) {
   return part.state.time.end
 }
 
+function mergeTextLikePart(existing: Extract<Part, { text: string }>, synced: Extract<Part, { text: string }>) {
+  if ((existing.text ?? "").length > (synced.text ?? "").length) return existing
+  return synced
+}
+
 function mergeSyncedPart(existing: Part, synced: Part) {
   if (existing.type !== synced.type) return synced
+  if (existing.type === "text" && synced.type === "text") return mergeTextLikePart(existing, synced)
+  if (existing.type === "reasoning" && synced.type === "reasoning") return mergeTextLikePart(existing, synced)
   if (existing.type !== "tool" || synced.type !== "tool") return synced
 
   const existingRank = toolRank(existing)

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -800,6 +800,8 @@ export function Session() {
         .then((res) => {
           if (state.stopped || sessionId() !== id) return;
           const status = res?.data?.[id]?.type;
+          const polled = res?.data?.[id];
+          if (polled) events.setSessionStatus(id, polled);
           if (status === "idle") {
             setOptimisticMessage(null);
             setPendingUserMessageText(null);

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -795,10 +795,10 @@ export function Session() {
       if (state.pending || state.stopped) return;
       state.pending = true;
       sync.session.sync(id)
-        .then(() => client.session.status({ directory }))
+        .then((synced) => synced ? client.session.status({ directory }) : undefined)
         .then((res) => {
           if (state.stopped || sessionId() !== id) return;
-          const status = res.data?.[id]?.type;
+          const status = res?.data?.[id]?.type;
           if (status === "idle") {
             setOptimisticMessage(null);
             setPendingUserMessageText(null);

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -750,7 +750,8 @@ export function Session() {
       // Use sync context to load session data - no local state needed
       setLoadingHistory(true);
       setProcessing(false); // Reset processing state for new session
-      sync.session.sync(id).then(() => {
+      sync.session.sync(id).then((synced) => {
+        if (!synced) return;
         setLoadingHistory(false);
         // Initialize per-session model from existing messages if not already set
         if (!providers.getSessionModel(id)) {
@@ -1435,8 +1436,8 @@ export function Session() {
   createEffect(() => {
     const id = params.id;
     if (!id) return;
-    // loadingHistory() stays true when sync.session.sync() rejects,
-    // so this effect only fires after a successful sync — not on transient failures.
+    // loadingHistory() stays true when sync.session.sync() fails,
+    // so this effect only fires after a successful sync, not on transient failures.
     if (loadingHistory()) return;
     const found = sync.session.get(id);
     // Non-archived session exists — keep it

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -787,6 +787,40 @@ export function Session() {
   });
 
   createEffect(() => {
+    const id = sessionId();
+    if (!id || !processing() || !sync.sseUnhealthy()) return;
+
+    const state = { pending: false, stopped: false };
+    const poll = () => {
+      if (state.pending || state.stopped) return;
+      state.pending = true;
+      sync.session.sync(id)
+        .then(() => client.session.status({ directory }))
+        .then((res) => {
+          if (state.stopped || sessionId() !== id) return;
+          const status = res.data?.[id]?.type;
+          if (status === "idle") {
+            setOptimisticMessage(null);
+            setPendingUserMessageText(null);
+            wasProcessing.value = false;
+            setProcessing(false);
+          }
+        })
+        .catch((err) => console.warn("[Session] SSE fallback poll failed:", err))
+        .finally(() => {
+          state.pending = false;
+        });
+    };
+
+    poll();
+    const interval = setInterval(poll, 2000);
+    onCleanup(() => {
+      state.stopped = true;
+      clearInterval(interval);
+    });
+  });
+
+  createEffect(() => {
     const blocked = followupAutoPaused();
     if (!blocked) return;
     if (followups().some((item) => item.id === blocked)) return;

--- a/app-prefixable/src/utils/sse.ts
+++ b/app-prefixable/src/utils/sse.ts
@@ -7,6 +7,11 @@
 
 export type SSECallback = (data: string) => void
 
+export function nextSSEReconnectDelay(connectedAt: number, now: number, current: number) {
+  if (connectedAt && now - connectedAt > 10_000) return 3000
+  return Math.min(current * 2, 30_000)
+}
+
 /**
  * Creates a stateful SSE line parser. Feed it chunks from a ReadableStream
  * and it will invoke `onData` with the concatenated data payload for each

--- a/app-prefixable/tests/events.test.ts
+++ b/app-prefixable/tests/events.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { sessionStatusEvent } from "../src/context/events"
+import { nextSSEReconnectDelay } from "../src/utils/sse"
 
 describe("sessionStatusEvent", () => {
   test("normalizes session.status events", () => {
@@ -18,5 +19,10 @@ describe("sessionStatusEvent", () => {
 
   test("ignores unrelated events", () => {
     expect(sessionStatusEvent({ type: "message.updated", properties: {} })).toBeUndefined()
+  })
+
+  test("immediate SSE close backs off reconnects", () => {
+    expect(nextSSEReconnectDelay(Date.now(), Date.now(), 3000)).toBe(6000)
+    expect(nextSSEReconnectDelay(Date.now(), Date.now(), 30_000)).toBe(30_000)
   })
 })

--- a/app-prefixable/tests/sync.test.ts
+++ b/app-prefixable/tests/sync.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { applyPartDelta, mergeMessageUpdate, mergePartUpdate, mergeSessionMessages } from "../src/context/sync"
 import type { MessageWithParts } from "../src/context/sync"
 import type { Message, Part } from "../src/sdk/client"
+import { nextSSEReconnectDelay } from "../src/utils/sse"
 
 const user = (id: string, sessionID = "ses_1"): Message => ({
   id,
@@ -124,5 +125,16 @@ describe("sync event helpers", () => {
 
     expect(merged.map((m) => m.info.id)).toEqual(["msg_1", "msg_2"])
     expect(merged[0].parts.map((p) => p.id)).toEqual(["part_1", "part_2"])
+  })
+
+  test("immediate SSE close backs off reconnects", () => {
+    expect(nextSSEReconnectDelay(Date.now(), Date.now(), 3000)).toBe(6000)
+    expect(nextSSEReconnectDelay(Date.now(), Date.now(), 30_000)).toBe(30_000)
+  })
+
+  test("long-lived SSE resets reconnect delay", () => {
+    const connectedAt = Date.now() - 11_000
+
+    expect(nextSSEReconnectDelay(connectedAt, Date.now(), 30_000)).toBe(3000)
   })
 })

--- a/app-prefixable/tests/sync.test.ts
+++ b/app-prefixable/tests/sync.test.ts
@@ -117,6 +117,16 @@ describe("sync event helpers", () => {
     })
   })
 
+  test("session sync advances stale text parts from snapshots", () => {
+    const existing = [message(user("msg_1"), [text("part_1", "msg_1", "hel")])]
+    const synced = [message(user("msg_1"), [text("part_1", "msg_1", "hello")])]
+
+    expect(mergeSessionMessages(existing, synced)[0].parts[0]).toMatchObject({
+      type: "text",
+      text: "hello",
+    })
+  })
+
   test("session sync preserves SSE-only messages and parts", () => {
     const existing = [message(user("msg_1"), [text("part_1", "msg_1"), text("part_2", "msg_1")]), message(user("msg_2"), [])]
     const synced = [message(user("msg_1"), [text("part_1", "msg_1")])]

--- a/app-prefixable/tests/sync.test.ts
+++ b/app-prefixable/tests/sync.test.ts
@@ -127,6 +127,16 @@ describe("sync event helpers", () => {
     })
   })
 
+  test("session sync preserves longer SSE text parts", () => {
+    const existing = [message(user("msg_1"), [text("part_1", "msg_1", "hello")])]
+    const synced = [message(user("msg_1"), [text("part_1", "msg_1", "hel")])]
+
+    expect(mergeSessionMessages(existing, synced)[0].parts[0]).toMatchObject({
+      type: "text",
+      text: "hello",
+    })
+  })
+
   test("session sync preserves SSE-only messages and parts", () => {
     const existing = [message(user("msg_1"), [text("part_1", "msg_1"), text("part_2", "msg_1")]), message(user("msg_2"), [])]
     const synced = [message(user("msg_1"), [text("part_1", "msg_1")])]


### PR DESCRIPTION
## Summary
- Track sync SSE health and expose when the stream has failed.
- Poll only the active processing session while sync SSE is unhealthy so message/tool state updates without manual Refresh.
- Add capped SSE reconnect backoff for both event consumers to avoid noisy immediate-close loops while still allowing recovery.

## Verification
- `cd app-prefixable && bun run build`
- `cd app-prefixable && bun run typecheck`
- `cd app-prefixable && bun test tests/sync.test.ts tests/events.test.ts`
- `cd app-prefixable && bun test tests/`

Closes #424