### PR TITLE
fix: optimistically remove deleted session from sidebar (closes #427)

### DIFF
--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -2043,6 +2043,7 @@ export function Layout(props: ParentProps) {
     client.session.delete({ sessionID: session.id })
       .then(() => {
         setConfirmDeleteSession(null);
+        setSessions(prev => prev.filter(s => s.id !== session.id));
         cleanupNotifyState(session.id, session.directory);
         unpinSession(session.id);
         if (isActive(session.id)) {


### PR DESCRIPTION
## Summary
- After successful session deletion, immediately remove the session from the local sessions list
- No longer relies solely on SSE event for UI update, which fixes the issue when SSE connection is unstable

Closes #427