### PR TITLE
fix: refresh sessions after SSE reconnect (closes #426)

### DIFF
--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1164,7 +1164,10 @@ export function Layout(props: ParentProps) {
     return "Session bootstrap failed. Check API connectivity and retry.";
   }
 
+  let lastSessionsLoadAt = 0;
+
   async function loadSessions() {
+    lastSessionsLoadAt = Date.now();
     try {
       const res = await client.session.list({ roots: true });
       const data = res.data;
@@ -1587,8 +1590,7 @@ export function Layout(props: ParentProps) {
     let sessionsTimer: number | undefined;
     const unsub = events.subscribe((event) => {
       if (event.type === "server.connected") {
-        // Debounce to avoid duplicate fetch when server.connected fires
-        // immediately after mount's loadSessions() call
+        if (Date.now() - lastSessionsLoadAt < 5000) return;
         if (sessionsTimer !== undefined) clearTimeout(sessionsTimer);
         sessionsTimer = window.setTimeout(() => {
           sessionsTimer = undefined;

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1610,7 +1610,10 @@ export function Layout(props: ParentProps) {
       }
     });
 
-    onCleanup(unsub);
+    onCleanup(() => {
+      unsub();
+      if (sessionsTimer !== undefined) clearTimeout(sessionsTimer);
+    });
   });
 
   onMount(() => {

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1582,6 +1582,8 @@ export function Layout(props: ParentProps) {
   });
 
   onMount(() => {
+    loadSessions();
+
     const unsub = events.subscribe((event) => {
       if (event.type === "server.connected") {
         loadSessions();

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1584,9 +1584,16 @@ export function Layout(props: ParentProps) {
   onMount(() => {
     loadSessions();
 
+    let sessionsTimer: number | undefined;
     const unsub = events.subscribe((event) => {
       if (event.type === "server.connected") {
-        loadSessions();
+        // Debounce to avoid duplicate fetch when server.connected fires
+        // immediately after mount's loadSessions() call
+        if (sessionsTimer !== undefined) clearTimeout(sessionsTimer);
+        sessionsTimer = window.setTimeout(() => {
+          sessionsTimer = undefined;
+          loadSessions();
+        }, 500);
         return;
       }
       if (

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1582,8 +1582,6 @@ export function Layout(props: ParentProps) {
   });
 
   onMount(() => {
-    loadSessions();
-
     const unsub = events.subscribe((event) => {
       if (event.type === "server.connected") {
         loadSessions();

--- a/app-prefixable/src/pages/layout.tsx
+++ b/app-prefixable/src/pages/layout.tsx
@@ -1585,6 +1585,10 @@ export function Layout(props: ParentProps) {
     loadSessions();
 
     const unsub = events.subscribe((event) => {
+      if (event.type === "server.connected") {
+        loadSessions();
+        return;
+      }
       if (
         event.type === "session.created" ||
         event.type === "session.updated" ||


### PR DESCRIPTION
## Summary
- After SSE reconnection, trigger a re-fetch of the session list so no events are missed during the disconnect window
- Inactive project SSE streams already re-seed via seedDirectory() on reconnect, so no changes needed there

Closes #426