### PR TITLE
fix: prevent thinking indicator from getting stuck (closes #430)

### DIFF
--- a/app-prefixable/src/context/events.tsx
+++ b/app-prefixable/src/context/events.tsx
@@ -114,6 +114,23 @@ export function EventProvider(props: ParentProps) {
       console.log("[Events] Connected")
       connectedAt = Date.now()
 
+      // Clear seen-sets on reconnect so the HTTP re-seed below picks up real status
+      sseSeenStatuses.clear()
+      sseAskedQuestions.clear()
+      sseClearedRequests.clear()
+
+      // Re-seed session statuses from HTTP after reconnect
+      if (directory) {
+        client.session.status({ directory })
+          .then((res) => {
+            const statuses = (res.data ?? {}) as Record<string, SessionStatus>
+            for (const [sessionID, s] of Object.entries(statuses)) {
+              if (!sseSeenStatuses.has(sessionID)) setStatus(sessionID, s)
+            }
+          })
+          .catch((err) => console.error("[Events] Failed to re-seed statuses:", err))
+      }
+
       const reader = response.body.getReader()
       const decoder = new TextDecoder()
       const parser = createSSEParser((data) => processEvent(data))

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -782,7 +782,8 @@ export function Session() {
       setProcessing(true);
       return;
     }
-    if (type === "idle") {
+    // Any non-busy status (including idle or unknown) means not processing
+    if (type) {
       setProcessing(false);
     }
   });
@@ -821,6 +822,26 @@ export function Session() {
       state.stopped = true;
       clearInterval(interval);
     });
+  });
+
+  // Watchdog: if processing stays true for 60s without resolution, re-fetch status
+  createEffect(() => {
+    const id = sessionId();
+    if (!id || !processing()) return;
+    const timer = setTimeout(() => {
+      if (!processing() || sessionId() !== id) return;
+      client.session.status({ directory })
+        .then((res) => {
+          const polled = (res.data ?? {})[id];
+          if (!polled || sessionId() !== id) return;
+          events.setSessionStatus(id, polled);
+          if (polled.type !== "busy" && polled.type !== "retry") {
+            setProcessing(false);
+          }
+        })
+        .catch((err) => console.warn("[Session] Watchdog poll failed:", err));
+    }, 60_000);
+    onCleanup(() => clearTimeout(timer));
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary
- Clear sseSeenStatuses on SSE reconnect so HTTP seed re-fetches real session status
- Handle unknown status types as idle to prevent stuck indicators
- Add 60s watchdog timer to re-fetch status if processing appears stuck

Closes #430