### PR TITLE
fix: preserve tracking state across SSE reconnect in global-events (closes #432)

### DIFF
--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -294,7 +294,9 @@ export function GlobalEventsProvider(props: ParentProps & {
           const wanted = props.projects().some((p) => p.worktree === dir)
           if (wanted && dir !== active) {
             connectToDirectory(dir)
+            return
           }
+          disconnectDirectory(dir)
         }, 5000)
         reconnectTimers.set(dir, reconnectTimer)
       }

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -282,6 +282,8 @@ export function GlobalEventsProvider(props: ParentProps & {
       } catch {
         if (controller.signal.aborted) return
         if (disposed) return
+        const old = connections.get(dir)
+        if (old) old.controller.abort()
         connections.delete(dir)
         const reconnectTimer = setTimeout(() => {
           reconnectTimers.delete(dir)

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -282,7 +282,7 @@ export function GlobalEventsProvider(props: ParentProps & {
       } catch {
         if (controller.signal.aborted) return
         if (disposed) return
-        disconnectDirectory(dir)
+        connections.delete(dir)
         const reconnectTimer = setTimeout(() => {
           reconnectTimers.delete(dir)
           if (disposed) return


### PR DESCRIPTION
## Summary
- When SSE for inactive projects drops, the catch block no longer calls disconnectDirectory() which destroyed all tracking state and alerts
- Only the connection reference is cleaned up; tracking data (busy/permission/question sets) and alerts persist across reconnect cycles
- This fixes badges disappearing and reappearing constantly with unreliable SSE connections

Closes #432