### PR TITLE
chore: bump OpenCode to v1.14.50 (fixes SSE stream closing immediately)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache \
 # via `opencode serve` or for CLI access within the container)
 # Pin version to ensure reproducible builds. Update by changing OPENCODE_VERSION.
 # Check releases at: https://github.com/anomalyco/opencode/releases
-ARG OPENCODE_VERSION=1.2.6
+ARG OPENCODE_VERSION=1.14.50
 ENV SHELL=/bin/bash
 RUN curl -fsSL https://opencode.ai/install | bash -s -- --version "${OPENCODE_VERSION}" && \
     mv /root/.opencode/bin/opencode /usr/local/bin/opencode && \

--- a/docker/kubeflow/Dockerfile
+++ b/docker/kubeflow/Dockerfile
@@ -50,7 +50,7 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
     rm -rf /root/.bun
 
 # Install OpenCode CLI. Update OPENCODE_VERSION after checking upstream releases.
-ARG OPENCODE_VERSION=1.14.48
+ARG OPENCODE_VERSION=1.14.50
 ENV SHELL=/bin/bash
 RUN curl -fsSL https://opencode.ai/install | bash -s -- --version "${OPENCODE_VERSION}" && \
     mv /root/.opencode/bin/opencode /usr/local/bin/opencode && \


### PR DESCRIPTION
## Summary
- Bump OpenCode from 1.2.6 to 1.14.50 in `docker/Dockerfile`
- Bump OpenCode from 1.14.48 to 1.14.50 in `docker/kubeflow/Dockerfile`

v1.14.50 fixes a regression where the `/event` SSE endpoint closed immediately after sending `server.connected`, preventing real-time event delivery. See [upstream issue #26866](https://github.com/anomalyco/opencode/issues/26866).