### PR TITLE
fix: recover stuck project busy badges

### DIFF
--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -66,6 +66,7 @@ export function GlobalEventsProvider(props: ParentProps & {
   // missed/renamed completion event cannot leave the project badge spinning.
   const statusPollTimers = new Map<string, ReturnType<typeof setInterval>>()
   const statusPollPending = new Set<string>()
+  const statusVersions = new Map<string, Map<string, number>>()
 
   // Per-directory tracking sets for deduplication
   const perDir = new Map<string, {
@@ -92,6 +93,16 @@ export function GlobalEventsProvider(props: ParentProps & {
     }
     perDir.set(dir, tracking)
     return tracking
+  }
+
+  function statusVersion(dir: string, sid: string) {
+    return statusVersions.get(dir)?.get(sid) ?? 0
+  }
+
+  function bumpStatusVersion(dir: string, sid: string) {
+    const versions = statusVersions.get(dir) ?? new Map<string, number>()
+    versions.set(sid, (versions.get(sid) ?? 0) + 1)
+    statusVersions.set(dir, versions)
   }
 
   function recalcAlerts(dir: string) {
@@ -266,6 +277,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         if (!sid || !type) return
         if (tracking.subAgents.has(sid)) return
         if (tracking.rootSessions && !tracking.rootSessions.has(sid)) return
+        bumpStatusVersion(dir, sid)
 
         if (type === "busy" || type === "retry") {
           tracking.busySessions.add(sid)
@@ -359,6 +371,7 @@ export function GlobalEventsProvider(props: ParentProps & {
       permReseedTimers.delete(dir)
     }
     stopStatusPoll(dir)
+    statusVersions.delete(dir)
     perDir.delete(dir)
     setAlerts(produce((draft) => { delete draft[dir] }))
   }
@@ -483,7 +496,8 @@ export function GlobalEventsProvider(props: ParentProps & {
   function seedStatuses(dir: string, roots: Set<string> | null) {
     const tracking = perDir.get(dir)
     if (!tracking) return  // disconnected: do not recreate tracking while seeding
-    const before = new Set(tracking.busySessions)
+    const before = new Map<string, number>()
+    for (const sid of tracking.busySessions) before.set(sid, statusVersion(dir, sid))
     return fetch(`${serverUrl()}/session/status?directory=${encodeURIComponent(dir)}`, { headers: authHeaders() })
       .then((r) => r.json())
       .then((data) => {
@@ -495,6 +509,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         }
         tracking.busySessions.clear()
         for (const [sid, s] of Object.entries(statuses)) {
+          if (before.has(sid) && statusVersion(dir, sid) !== before.get(sid)) continue
           if (!tracking.subAgents.has(sid) && (roots === null || roots.has(sid)) && (s?.type === "busy" || s?.type === "retry")) {
             tracking.busySessions.add(sid)
           }
@@ -534,6 +549,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         for (const [, timer] of statusPollTimers) clearInterval(timer)
         statusPollTimers.clear()
         statusPollPending.clear()
+        statusVersions.clear()
         return
       }
 
@@ -575,6 +591,7 @@ export function GlobalEventsProvider(props: ParentProps & {
     }
     statusPollTimers.clear()
     statusPollPending.clear()
+    statusVersions.clear()
   })
 
   function badge(directory: string) {

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -127,7 +127,6 @@ export function GlobalEventsProvider(props: ParentProps & {
     if (!timer) return
     clearInterval(timer)
     statusPollTimers.delete(dir)
-    statusPollPending.delete(dir)
   }
 
   function ensureStatusPoll(dir: string) {
@@ -201,6 +200,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         if (info?.id && info?.parentID) {
           const sid = info.id
           tracking.subAgents.add(sid)
+          bumpStatusVersion(dir, sid)
           let changed = false
           if (tracking.permissionSessions.delete(sid)) changed = true
           if (tracking.questionSessions.delete(sid)) changed = true
@@ -218,6 +218,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         const sid = info?.id
         if (sid) {
           tracking.subAgents.delete(sid)
+          bumpStatusVersion(dir, sid)
           let changed = false
           if (tracking.permissionSessions.delete(sid)) changed = true
           if (tracking.questionSessions.delete(sid)) changed = true

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -65,7 +65,7 @@ export function GlobalEventsProvider(props: ParentProps & {
   // While a project is marked busy, periodically reconcile with REST so a
   // missed/renamed completion event cannot leave the project badge spinning.
   const statusPollTimers = new Map<string, ReturnType<typeof setInterval>>()
-  const statusPollPending = new Set<string>()
+  const statusPollPending = new Map<string, symbol>()
   const statusVersions = new Map<string, Map<string, number>>()
   const generations = new Map<string, number>()
 
@@ -128,6 +128,7 @@ export function GlobalEventsProvider(props: ParentProps & {
     if (!timer) return
     clearInterval(timer)
     statusPollTimers.delete(dir)
+    statusPollPending.delete(dir)
   }
 
   function ensureStatusPoll(dir: string) {
@@ -147,9 +148,12 @@ export function GlobalEventsProvider(props: ParentProps & {
         return
       }
       if (statusPollPending.has(dir)) return
-      statusPollPending.add(dir)
+      const token = Symbol()
+      statusPollPending.set(dir, token)
       Promise.resolve(seedStatuses(dir, tracking.rootSessions, generations.get(dir) ?? 0))
-        .finally(() => statusPollPending.delete(dir))
+        .finally(() => {
+          if (statusPollPending.get(dir) === token) statusPollPending.delete(dir)
+        })
     }, 5000))
   }
 

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -120,6 +120,10 @@ export function GlobalEventsProvider(props: ParentProps & {
   function ensureStatusPoll(dir: string) {
     if (statusPollTimers.has(dir)) return
     statusPollTimers.set(dir, setInterval(() => {
+      if (disposed) {
+        stopStatusPoll(dir)
+        return
+      }
       const tracking = perDir.get(dir)
       if (!tracking || tracking.busySessions.size === 0) {
         stopStatusPoll(dir)
@@ -510,6 +514,8 @@ export function GlobalEventsProvider(props: ParentProps & {
         reconnectTimers.clear()
         for (const [, timer] of permReseedTimers) clearTimeout(timer)
         permReseedTimers.clear()
+        for (const [, timer] of statusPollTimers) clearInterval(timer)
+        statusPollTimers.clear()
         return
       }
 
@@ -546,6 +552,10 @@ export function GlobalEventsProvider(props: ParentProps & {
       clearTimeout(timer)
     }
     permReseedTimers.clear()
+    for (const [, timer] of statusPollTimers) {
+      clearInterval(timer)
+    }
+    statusPollTimers.clear()
   })
 
   function badge(directory: string) {

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -131,6 +131,10 @@ export function GlobalEventsProvider(props: ParentProps & {
         stopStatusPoll(dir)
         return
       }
+      if (!connections.has(dir)) {
+        stopStatusPoll(dir)
+        return
+      }
       if (statusPollPending.has(dir)) return
       statusPollPending.add(dir)
       Promise.resolve(seedStatuses(dir, tracking.rootSessions))
@@ -319,6 +323,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         const old = connections.get(dir)
         if (old) old.controller.abort()
         connections.delete(dir)
+        stopStatusPoll(dir)
         const reconnectTimer = setTimeout(() => {
           reconnectTimers.delete(dir)
           if (disposed) return
@@ -478,17 +483,23 @@ export function GlobalEventsProvider(props: ParentProps & {
   function seedStatuses(dir: string, roots: Set<string> | null) {
     const tracking = perDir.get(dir)
     if (!tracking) return  // disconnected: do not recreate tracking while seeding
+    const before = new Set(tracking.busySessions)
     return fetch(`${serverUrl()}/session/status?directory=${encodeURIComponent(dir)}`, { headers: authHeaders() })
       .then((r) => r.json())
       .then((data) => {
         if (!perDir.has(dir)) return  // disconnected while fetching
         const statuses = (data?.data ?? data ?? {}) as Record<string, { type?: string }>
+        const added = new Set<string>()
+        for (const sid of tracking.busySessions) {
+          if (!before.has(sid) && !tracking.subAgents.has(sid)) added.add(sid)
+        }
         tracking.busySessions.clear()
         for (const [sid, s] of Object.entries(statuses)) {
           if (!tracking.subAgents.has(sid) && (roots === null || roots.has(sid)) && (s?.type === "busy" || s?.type === "retry")) {
             tracking.busySessions.add(sid)
           }
         }
+        for (const sid of added) tracking.busySessions.add(sid)
         if (tracking.busySessions.size > 0) ensureStatusPoll(dir)
         if (tracking.busySessions.size === 0) stopStatusPoll(dir)
         recalcAlerts(dir)

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -65,6 +65,7 @@ export function GlobalEventsProvider(props: ParentProps & {
   // While a project is marked busy, periodically reconcile with REST so a
   // missed/renamed completion event cannot leave the project badge spinning.
   const statusPollTimers = new Map<string, ReturnType<typeof setInterval>>()
+  const statusPollPending = new Set<string>()
 
   // Per-directory tracking sets for deduplication
   const perDir = new Map<string, {
@@ -115,6 +116,7 @@ export function GlobalEventsProvider(props: ParentProps & {
     if (!timer) return
     clearInterval(timer)
     statusPollTimers.delete(dir)
+    statusPollPending.delete(dir)
   }
 
   function ensureStatusPoll(dir: string) {
@@ -129,7 +131,10 @@ export function GlobalEventsProvider(props: ParentProps & {
         stopStatusPoll(dir)
         return
       }
-      seedStatuses(dir, tracking.rootSessions)
+      if (statusPollPending.has(dir)) return
+      statusPollPending.add(dir)
+      Promise.resolve(seedStatuses(dir, tracking.rootSessions))
+        .finally(() => statusPollPending.delete(dir))
     }, 5000))
   }
 
@@ -265,6 +270,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         if (type !== "busy" && type !== "retry") {
           tracking.busySessions.delete(sid)
         }
+        if (tracking.busySessions.size === 0) stopStatusPoll(dir)
         recalcAlerts(dir)
       }
     }
@@ -516,6 +522,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         permReseedTimers.clear()
         for (const [, timer] of statusPollTimers) clearInterval(timer)
         statusPollTimers.clear()
+        statusPollPending.clear()
         return
       }
 
@@ -556,6 +563,7 @@ export function GlobalEventsProvider(props: ParentProps & {
       clearInterval(timer)
     }
     statusPollTimers.clear()
+    statusPollPending.clear()
   })
 
   function badge(directory: string) {

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -67,6 +67,7 @@ export function GlobalEventsProvider(props: ParentProps & {
   const statusPollTimers = new Map<string, ReturnType<typeof setInterval>>()
   const statusPollPending = new Set<string>()
   const statusVersions = new Map<string, Map<string, number>>()
+  const generations = new Map<string, number>()
 
   // Per-directory tracking sets for deduplication
   const perDir = new Map<string, {
@@ -147,7 +148,7 @@ export function GlobalEventsProvider(props: ParentProps & {
       }
       if (statusPollPending.has(dir)) return
       statusPollPending.add(dir)
-      Promise.resolve(seedStatuses(dir, tracking.rootSessions))
+      Promise.resolve(seedStatuses(dir, tracking.rootSessions, generations.get(dir) ?? 0))
         .finally(() => statusPollPending.delete(dir))
     }, 5000))
   }
@@ -167,6 +168,8 @@ export function GlobalEventsProvider(props: ParentProps & {
     const dirParam = `?directory=${encodeURIComponent(dir)}`
     const url = `${serverUrl()}/event${dirParam}`
     const controller = new AbortController()
+    const generation = (generations.get(dir) ?? 0) + 1
+    generations.set(dir, generation)
 
     connections.set(dir, { controller })
 
@@ -312,7 +315,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         // Seed runs concurrently so events arriving during seed are captured
         // under the MAX_BUFFER cap instead of accumulating unbounded in the
         // network buffer.
-        seedDirectory(dir).then(() => {
+        seedDirectory(dir, generation).then(() => {
           const conn = connections.get(dir)
           if (!conn || conn.controller !== controller) return
           seeded = true
@@ -407,13 +410,14 @@ export function GlobalEventsProvider(props: ParentProps & {
   // Seed permission/question/status state from REST for a directory.
   // First fetches root session IDs, then seeds only root sessions.
   // Returns a promise that resolves when all seeds complete (or fail).
-  async function seedDirectory(dir: string) {
+  async function seedDirectory(dir: string, generation = generations.get(dir) ?? 0) {
     // Ensure tracking exists before any async work so the perDir.has(dir)
     // guards in seed functions correctly detect disconnection (rather than
     // failing because the entry was never created).
     const tracking = getTracking(dir)
     const roots = await fetchRootSessionIds(dir)
     if (!perDir.has(dir)) return  // disconnected while fetching
+    if ((generations.get(dir) ?? 0) !== generation) return
 
     // Store root session IDs so SSE handlers can filter pre-existing
     // sub-agents that we never saw a session.created event for.
@@ -429,6 +433,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         })
         .then((data) => {
           if (!data || !perDir.has(dir)) return
+          if ((generations.get(dir) ?? 0) !== generation) return
           const all = Array.isArray(data) ? data : (data?.data ?? [])
           for (const s of all) {
             if (s?.parentID && s?.id) tracking.subAgents.add(s.id as string)
@@ -440,7 +445,7 @@ export function GlobalEventsProvider(props: ParentProps & {
     await Promise.allSettled([
       seedPermissions(dir, roots),
       seedQuestions(dir, roots),
-      seedStatuses(dir, roots),
+      seedStatuses(dir, roots, generation),
     ])
   }
 
@@ -494,7 +499,7 @@ export function GlobalEventsProvider(props: ParentProps & {
       .catch((e) => console.warn("[GlobalEvents] Failed to seed questions for", dir, e))
   }
 
-  function seedStatuses(dir: string, roots: Set<string> | null) {
+  function seedStatuses(dir: string, roots: Set<string> | null, generation = generations.get(dir) ?? 0) {
     const tracking = perDir.get(dir)
     if (!tracking) return  // disconnected: do not recreate tracking while seeding
     const before = new Map(statusVersions.get(dir) ?? [])
@@ -505,6 +510,7 @@ export function GlobalEventsProvider(props: ParentProps & {
       .then((r) => r.json())
       .then((data) => {
         if (!perDir.has(dir)) return  // disconnected while fetching
+        if ((generations.get(dir) ?? 0) !== generation) return
         const statuses = (data?.data ?? data ?? {}) as Record<string, { type?: string }>
         const added = new Set<string>()
         for (const sid of tracking.busySessions) {
@@ -553,6 +559,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         statusPollTimers.clear()
         statusPollPending.clear()
         statusVersions.clear()
+        generations.clear()
         return
       }
 
@@ -595,6 +602,7 @@ export function GlobalEventsProvider(props: ParentProps & {
     statusPollTimers.clear()
     statusPollPending.clear()
     statusVersions.clear()
+    generations.clear()
   })
 
   function badge(directory: string) {

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -497,8 +497,10 @@ export function GlobalEventsProvider(props: ParentProps & {
   function seedStatuses(dir: string, roots: Set<string> | null) {
     const tracking = perDir.get(dir)
     if (!tracking) return  // disconnected: do not recreate tracking while seeding
-    const before = new Map<string, number>()
-    for (const sid of tracking.busySessions) before.set(sid, statusVersion(dir, sid))
+    const before = new Map(statusVersions.get(dir) ?? [])
+    for (const sid of tracking.busySessions) {
+      if (!before.has(sid)) before.set(sid, 0)
+    }
     return fetch(`${serverUrl()}/session/status?directory=${encodeURIComponent(dir)}`, { headers: authHeaders() })
       .then((r) => r.json())
       .then((data) => {
@@ -510,7 +512,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         }
         tracking.busySessions.clear()
         for (const [sid, s] of Object.entries(statuses)) {
-          if (before.has(sid) && statusVersion(dir, sid) !== before.get(sid)) continue
+          if (statusVersion(dir, sid) !== (before.get(sid) ?? 0)) continue
           if (!tracking.subAgents.has(sid) && (roots === null || roots.has(sid)) && (s?.type === "busy" || s?.type === "retry")) {
             tracking.busySessions.add(sid)
           }

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -62,6 +62,10 @@ export function GlobalEventsProvider(props: ParentProps & {
   // events from spawning overlapping fetch requests that race each other
   const permReseedTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
+  // While a project is marked busy, periodically reconcile with REST so a
+  // missed/renamed completion event cannot leave the project badge spinning.
+  const statusPollTimers = new Map<string, ReturnType<typeof setInterval>>()
+
   // Per-directory tracking sets for deduplication
   const perDir = new Map<string, {
     permissionSessions: Set<string>
@@ -104,6 +108,25 @@ export function GlobalEventsProvider(props: ParentProps & {
       busy: tracking.busySessions.size,
       totalSessions: allSessions.size,
     })
+  }
+
+  function stopStatusPoll(dir: string) {
+    const timer = statusPollTimers.get(dir)
+    if (!timer) return
+    clearInterval(timer)
+    statusPollTimers.delete(dir)
+  }
+
+  function ensureStatusPoll(dir: string) {
+    if (statusPollTimers.has(dir)) return
+    statusPollTimers.set(dir, setInterval(() => {
+      const tracking = perDir.get(dir)
+      if (!tracking || tracking.busySessions.size === 0) {
+        stopStatusPoll(dir)
+        return
+      }
+      seedStatuses(dir, tracking.rootSessions)
+    }, 5000))
   }
 
   function connectToDirectory(dir: string) {
@@ -223,18 +246,19 @@ export function GlobalEventsProvider(props: ParentProps & {
         return
       }
 
-      if (event.type === "session.status") {
+      if (event.type === "session.status" || event.type === "session.idle") {
         const props = event.properties as { sessionID?: string; status?: { type?: string } }
         const sid = props?.sessionID
-        const type = props?.status?.type
+        const type = event.type === "session.idle" ? "idle" : props?.status?.type
         if (!sid || !type) return
         if (tracking.subAgents.has(sid)) return
         if (tracking.rootSessions && !tracking.rootSessions.has(sid)) return
 
         if (type === "busy" || type === "retry") {
           tracking.busySessions.add(sid)
+          ensureStatusPoll(dir)
         }
-        if (type === "idle") {
+        if (type !== "busy" && type !== "retry") {
           tracking.busySessions.delete(sid)
         }
         recalcAlerts(dir)
@@ -319,6 +343,7 @@ export function GlobalEventsProvider(props: ParentProps & {
       clearTimeout(reseed)
       permReseedTimers.delete(dir)
     }
+    stopStatusPoll(dir)
     perDir.delete(dir)
     setAlerts(produce((draft) => { delete draft[dir] }))
   }
@@ -454,6 +479,8 @@ export function GlobalEventsProvider(props: ParentProps & {
             tracking.busySessions.add(sid)
           }
         }
+        if (tracking.busySessions.size > 0) ensureStatusPoll(dir)
+        if (tracking.busySessions.size === 0) stopStatusPoll(dir)
         recalcAlerts(dir)
       })
       .catch((e) => console.warn("[GlobalEvents] Failed to seed statuses for", dir, e))

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -505,7 +505,7 @@ export function GlobalEventsProvider(props: ParentProps & {
         const statuses = (data?.data ?? data ?? {}) as Record<string, { type?: string }>
         const added = new Set<string>()
         for (const sid of tracking.busySessions) {
-          if (!before.has(sid) && !tracking.subAgents.has(sid)) added.add(sid)
+          if ((!before.has(sid) || statusVersion(dir, sid) !== before.get(sid)) && !tracking.subAgents.has(sid)) added.add(sid)
         }
         tracking.busySessions.clear()
         for (const [sid, s] of Object.entries(statuses)) {


### PR DESCRIPTION
## Summary
- handle session.idle and all non-busy status events when clearing project busy badges
- reconcile busy project badges with /session/status while a project is marked busy
- stop the reconcile timer when no busy sessions remain or the project listener disconnects

## Tests
- bun run typecheck
- bun test tests/
- bun run build