### PR TITLE
fix: avoid false provider auth failures

### DIFF
--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -441,7 +441,7 @@ export function ProviderProvider(props: ParentProps) {
       const connected = await providerConnected(providerID)
       // Dispose instance to reload provider state, then refresh
       await reloadProviders()
-      return connected ?? providerData()?.connected.includes(providerID) ?? false
+      return connected === true || providerData()?.connected.includes(providerID) === true
     } catch (e) {
       console.error("Failed to connect provider:", e)
       return (await providerConnected(providerID)) === true
@@ -454,7 +454,7 @@ export function ProviderProvider(props: ParentProps) {
       const connected = await providerConnected(providerID)
       // Dispose instance to reload provider state, then refresh
       await reloadProviders()
-      return connected === false || !providerData()?.connected.includes(providerID)
+      return connected === false || providerData()?.connected.includes(providerID) === false
     } catch (e) {
       console.error("Failed to disconnect provider:", e)
       return (await providerConnected(providerID)) === false
@@ -500,7 +500,7 @@ export function ProviderProvider(props: ParentProps) {
       const connected = await providerConnected(providerID)
       // Dispose instance to reload provider state, then refresh
       await reloadProviders()
-      return connected ?? providerData()?.connected.includes(providerID) ?? false
+      return connected === true || providerData()?.connected.includes(providerID) === true
     } catch (e) {
       console.error("Failed to complete OAuth:", e)
       return (await providerConnected(providerID)) === true

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -438,30 +438,38 @@ export function ProviderProvider(props: ParentProps) {
         providerID,
         auth: { type: "api", key: apiKey },
       })
-      const connected = await providerConnected(providerID)
-      // Dispose instance to reload provider state, then refresh
-      await reloadProviders()
-      return connected === true || providerData()?.connected.includes(providerID) === true
     } catch (e) {
       console.error("Failed to connect provider:", e)
       return (await providerConnected(providerID)) === true
     }
+
+    try {
+      const connected = await reloadProviderConnected(providerID)
+      if (connected !== undefined) return connected
+    } catch (e) {
+      console.error("Connected provider, but failed to reload provider state:", e)
+    }
+    return (await providerConnected(providerID)) === true
   }
 
   async function disconnectProvider(providerID: string): Promise<boolean> {
     try {
       await client.auth.remove({ providerID })
-      const connected = await providerConnected(providerID)
-      // Dispose instance to reload provider state, then refresh
-      await reloadProviders()
-      return connected === false || providerData()?.connected.includes(providerID) === false
     } catch (e) {
       console.error("Failed to disconnect provider:", e)
       return (await providerConnected(providerID)) === false
     }
+
+    try {
+      const connected = await reloadProviderConnected(providerID)
+      if (connected !== undefined) return connected === false
+    } catch (e) {
+      console.error("Disconnected provider, but failed to reload provider state:", e)
+    }
+    return (await providerConnected(providerID)) === false
   }
 
-  async function providerConnected(providerID: string) {
+  async function providerConnected(providerID: string): Promise<boolean | undefined> {
     try {
       const res = await client.provider.list()
       const data = res.data as ProviderListData | undefined
@@ -474,7 +482,11 @@ export function ProviderProvider(props: ParentProps) {
 
   async function reloadProviders() {
     await client.instance.dispose()
-    await refetchProviders()
+    return await refetchProviders()
+  }
+
+  async function reloadProviderConnected(providerID: string) {
+    return (await reloadProviders())?.connected.includes(providerID)
   }
 
   async function startOAuth(providerID: string, methodIndex: number): Promise<OAuthAuthorization | undefined> {
@@ -497,14 +509,18 @@ export function ProviderProvider(props: ParentProps) {
         method: methodIndex,
         code,
       })
-      const connected = await providerConnected(providerID)
-      // Dispose instance to reload provider state, then refresh
-      await reloadProviders()
-      return connected === true || providerData()?.connected.includes(providerID) === true
     } catch (e) {
       console.error("Failed to complete OAuth:", e)
       return (await providerConnected(providerID)) === true
     }
+
+    try {
+      const connected = await reloadProviderConnected(providerID)
+      if (connected !== undefined) return connected
+    } catch (e) {
+      console.error("Completed OAuth, but failed to reload provider state:", e)
+    }
+    return (await providerConnected(providerID)) === true
   }
 
   function refetch() {

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -438,27 +438,43 @@ export function ProviderProvider(props: ParentProps) {
         providerID,
         auth: { type: "api", key: apiKey },
       })
+      const connected = await providerConnected(providerID)
       // Dispose instance to reload provider state, then refresh
-      await client.instance.dispose()
-      await refetchProviders()
-      return true
+      await reloadProviders()
+      return connected ?? providerData()?.connected.includes(providerID) ?? false
     } catch (e) {
       console.error("Failed to connect provider:", e)
-      return false
+      return (await providerConnected(providerID)) === true
     }
   }
 
   async function disconnectProvider(providerID: string): Promise<boolean> {
     try {
       await client.auth.remove({ providerID })
+      const connected = await providerConnected(providerID)
       // Dispose instance to reload provider state, then refresh
-      await client.instance.dispose()
-      await refetchProviders()
-      return true
+      await reloadProviders()
+      return connected === false || !providerData()?.connected.includes(providerID)
     } catch (e) {
       console.error("Failed to disconnect provider:", e)
-      return false
+      return (await providerConnected(providerID)) === false
     }
+  }
+
+  async function providerConnected(providerID: string) {
+    try {
+      const res = await client.provider.list()
+      const data = res.data as ProviderListData | undefined
+      return data?.connected.includes(providerID)
+    } catch (e) {
+      console.error("Failed to check provider connection:", e)
+      return undefined
+    }
+  }
+
+  async function reloadProviders() {
+    await client.instance.dispose()
+    await refetchProviders()
   }
 
   async function startOAuth(providerID: string, methodIndex: number): Promise<OAuthAuthorization | undefined> {
@@ -481,13 +497,13 @@ export function ProviderProvider(props: ParentProps) {
         method: methodIndex,
         code,
       })
+      const connected = await providerConnected(providerID)
       // Dispose instance to reload provider state, then refresh
-      await client.instance.dispose()
-      await refetchProviders()
-      return true
+      await reloadProviders()
+      return connected ?? providerData()?.connected.includes(providerID) ?? false
     } catch (e) {
       console.error("Failed to complete OAuth:", e)
-      return false
+      return (await providerConnected(providerID)) === true
     }
   }
 


### PR DESCRIPTION
## Summary
- verify provider connection state after API key auth, OAuth callback, and disconnect
- avoid showing auth failure when OpenCode already persisted the provider state but UI reload/dispose work fails
- share provider reload logic across connect/disconnect/OAuth flows

## Validation
- bun run typecheck
- bun run test
- bun run build

## Cluster check
Investigated opencode-admin-8292 in admin on fat-peagle. OpenAI OAuth was persisted in auth.json and /provider reported openai connected even though the UI showed "Authentication failed or was cancelled. Please try again."