### PR TITLE
fix: block OpenAI browser auth in notebooks

### DIFF
--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -444,7 +444,7 @@ export function ProviderProvider(props: ParentProps) {
     }
 
     try {
-      const connected = await reloadProviderConnected(providerID)
+      const connected = await waitProviderConnected(providerID, true)
       if (connected !== undefined) return connected
     } catch (e) {
       console.error("Connected provider, but failed to reload provider state:", e)
@@ -461,7 +461,7 @@ export function ProviderProvider(props: ParentProps) {
     }
 
     try {
-      const connected = await reloadProviderConnected(providerID)
+      const connected = await waitProviderConnected(providerID, false)
       if (connected !== undefined) return connected === false
     } catch (e) {
       console.error("Disconnected provider, but failed to reload provider state:", e)
@@ -487,6 +487,16 @@ export function ProviderProvider(props: ParentProps) {
 
   async function reloadProviderConnected(providerID: string) {
     return (await reloadProviders())?.connected.includes(providerID)
+  }
+
+  async function waitProviderConnected(providerID: string, expected: boolean) {
+    await client.instance.dispose()
+    for (const delay of [0, 250, 500, 1000, 1500]) {
+      if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay))
+      const connected = (await refetchProviders())?.connected.includes(providerID)
+      if (connected === expected) return connected
+    }
+    return undefined
   }
 
   async function startOAuth(providerID: string, methodIndex: number): Promise<OAuthAuthorization | undefined> {
@@ -515,12 +525,12 @@ export function ProviderProvider(props: ParentProps) {
     }
 
     try {
-      const connected = await reloadProviderConnected(providerID)
+      const connected = await waitProviderConnected(providerID, true)
       if (connected !== undefined) return connected
     } catch (e) {
       console.error("Completed OAuth, but failed to reload provider state:", e)
     }
-    return (await providerConnected(providerID)) === true
+    return true
   }
 
   function refetch() {

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -226,7 +226,7 @@ export function ProviderProvider(props: ParentProps) {
   })
 
   // Fetch providers
-  const [providerData, { refetch: refetchProviders }] = createResource(async () => {
+  const [providerData, { mutate: setProviderData, refetch: refetchProviders }] = createResource(async () => {
     try {
       const res = await client.provider.list()
       const data = res.data as ProviderListData | undefined
@@ -491,12 +491,27 @@ export function ProviderProvider(props: ParentProps) {
 
   async function waitProviderConnected(providerID: string, expected: boolean) {
     await client.instance.dispose()
-    for (const delay of [0, 250, 500, 1000, 1500]) {
+    for (const delay of [0, 500, 1000, 2000, 3000, 5000, 8000]) {
       if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay))
       const connected = (await refetchProviders())?.connected.includes(providerID)
-      if (connected === expected) return connected
+      if (connected === expected) {
+        updateProviderConnected(providerID, expected)
+        return connected
+      }
     }
     return undefined
+  }
+
+  function updateProviderConnected(providerID: string, connected: boolean) {
+    setProviderData((data) => {
+      if (!data) return data
+      if (connected && data.connected.includes(providerID)) return data
+      if (!connected && !data.connected.includes(providerID)) return data
+      return {
+        ...data,
+        connected: connected ? [...data.connected, providerID] : data.connected.filter((id) => id !== providerID),
+      }
+    })
   }
 
   async function startOAuth(providerID: string, methodIndex: number): Promise<OAuthAuthorization | undefined> {
@@ -521,7 +536,7 @@ export function ProviderProvider(props: ParentProps) {
       })
     } catch (e) {
       console.error("Failed to complete OAuth:", e)
-      return (await providerConnected(providerID)) === true
+      return (await waitProviderConnected(providerID, true)) === true
     }
 
     try {
@@ -530,6 +545,7 @@ export function ProviderProvider(props: ParentProps) {
     } catch (e) {
       console.error("Completed OAuth, but failed to reload provider state:", e)
     }
+    updateProviderConnected(providerID, true)
     return true
   }
 

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -20,7 +20,7 @@ import { SETTINGS_BASE_TABS } from "./settings-tabs"
 import { TelegramSettings } from "../components/telegram-settings"
 import { invalidateTelegramSourceIdCache, writeFile } from "../utils/extended-api"
 import { ALARM_CHANNELS_STORAGE_KEY, readAlarmChannels, writeAlarmChannels, type AlarmChannels } from "../utils/notify"
-import { browserOAuthUnsupported, extractProviderAuthCode, providerOAuthMethodUnsupported } from "../utils/provider-auth"
+import { OPENAI_BROWSER_OAUTH_UNSUPPORTED_MESSAGE, browserOAuthUnsupported, extractProviderAuthCode, providerOAuthMethodUnsupported } from "../utils/provider-auth"
 import type { TelegramHealthResponse, TelegramSettingsResponse } from "../utils/telegram-settings"
 import type { Config, PermissionActionConfig } from "../sdk/client"
 
@@ -621,7 +621,7 @@ Add your project-specific instructions here.
     const providerName = getProviderDisplayName(providerID)
 
     if (method && oauthMethodUnsupported(providerID, method.label)) {
-      setError(`${providerName} browser authentication uses a localhost callback and is only supported when this UI runs on your local machine. Use API key authentication or a headless/code method instead.`)
+      setError(`${providerName}: ${OPENAI_BROWSER_OAUTH_UNSUPPORTED_MESSAGE}`)
       return
     }
 
@@ -1522,7 +1522,7 @@ Add your project-specific instructions here.
                                     </button>
                                     <Show when={oauthMethodUnsupported(selectedProvider()!, method.label)}>
                                       <p class="text-xs" style={{ color: "var(--text-weak)" }}>
-                                        Browser authentication uses a localhost callback and is only supported when this UI runs on your local machine. Use API key authentication or a headless/code method in notebooks.
+                                        {OPENAI_BROWSER_OAUTH_UNSUPPORTED_MESSAGE}
                                       </p>
                                     </Show>
                                   </div>

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -617,12 +617,18 @@ Add your project-specific instructions here.
     setError(null)
     setSuccess(null)
 
+    const method = providers.authMethods[providerID]?.[methodIndex]
+    const providerName = getProviderDisplayName(providerID)
+
+    if (method && oauthMethodUnsupported(providerID, method.label)) {
+      setError(`${providerName} browser authentication uses a local callback and is not supported in Kubeflow notebooks. Use ChatGPT Pro/Plus (headless) or API key authentication instead.`)
+      return
+    }
+
     const result = await providers.startOAuth(providerID, methodIndex)
 
     if (result) {
       const code = extractProviderAuthCode(result.instructions)
-
-      const providerName = getProviderDisplayName(providerID)
 
       if (browserOAuthUnsupported({
         authUrl: result.url,
@@ -683,7 +689,7 @@ Add your project-specific instructions here.
   }
 
   function oauthMethodUnsupported(providerID: string, label: string) {
-    return providerOAuthMethodUnsupported({ providerID, label, browserHostname: window.location.hostname })
+    return providerOAuthMethodUnsupported({ providerID, label, browserHostname: window.location.hostname, basePath: basePath.basePath })
   }
 
   async function handleOAuthComplete() {

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -621,7 +621,7 @@ Add your project-specific instructions here.
     const providerName = getProviderDisplayName(providerID)
 
     if (method && oauthMethodUnsupported(providerID, method.label)) {
-      setError(`${providerName} browser authentication uses a local callback and is not supported in Kubeflow notebooks. Use ChatGPT Pro/Plus (headless) or API key authentication instead.`)
+      setError(`${providerName} browser authentication uses a localhost callback and is only supported when this UI runs on your local machine. Use API key authentication or a headless/code method instead.`)
       return
     }
 

--- a/app-prefixable/src/pages/settings.tsx
+++ b/app-prefixable/src/pages/settings.tsx
@@ -1358,7 +1358,7 @@ Add your project-specific instructions here.
                         </div>
 
                         {/* Provider grid - max height with scroll */}
-                        <div class="grid grid-cols-2 gap-2 max-h-64 overflow-y-auto">
+                        <div class={`grid grid-cols-2 gap-2 overflow-y-auto pr-1 ${selectedProvider() ? "max-h-36" : "max-h-64"}`}>
                           <For each={filteredProviders()}>
                             {(provider) => (
                               <button
@@ -1397,6 +1397,12 @@ Add your project-specific instructions here.
                             )}
                           </For>
                         </div>
+
+                        <Show when={filteredProviders().length > (selectedProvider() ? 4 : 8)}>
+                          <p class="mt-2 text-xs" style={{ color: "var(--text-weak)" }}>
+                            Scroll this provider list for more options. Connection methods appear below the selected provider.
+                          </p>
+                        </Show>
 
                         <Show when={filteredProviders().length === 0 && providerSearch()}>
                           <p class="text-sm text-center py-4" style={{ color: "var(--text-weak)" }}>

--- a/app-prefixable/src/utils/provider-auth.ts
+++ b/app-prefixable/src/utils/provider-auth.ts
@@ -3,6 +3,10 @@ export function isLocalBrowserHost(hostname: string) {
   return host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === "::1" || host === "[::1]"
 }
 
+export function isNotebookBasePath(basePath: string) {
+  return /^\/notebook\//.test(basePath)
+}
+
 function urlHasLoopbackTarget(value: string): boolean {
   try {
     const url = new URL(value)
@@ -22,8 +26,8 @@ export function browserOAuthUnsupported(input: { authUrl: string; method: "auto"
   return urlHasLoopbackTarget(input.authUrl)
 }
 
-export function providerOAuthMethodUnsupported(input: { providerID: string; label: string; browserHostname: string }) {
-  if (isLocalBrowserHost(input.browserHostname)) return false
+export function providerOAuthMethodUnsupported(input: { providerID: string; label: string; browserHostname: string; basePath?: string }) {
+  if (isLocalBrowserHost(input.browserHostname) && !isNotebookBasePath(input.basePath ?? "")) return false
   if (input.providerID !== "openai") return false
   return /\b(browser|local)\b/i.test(input.label)
 }

--- a/app-prefixable/src/utils/provider-auth.ts
+++ b/app-prefixable/src/utils/provider-auth.ts
@@ -3,6 +3,8 @@ export function isLocalBrowserHost(hostname: string) {
   return host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === "::1" || host === "[::1]"
 }
 
+export const OPENAI_BROWSER_OAUTH_UNSUPPORTED_MESSAGE = "Browser authentication uses a localhost callback and is not supported when this UI is served through a notebook proxy. Use API key authentication or a headless/code method instead."
+
 export function isNotebookBasePath(basePath: string) {
   return /^\/notebook\//.test(basePath)
 }

--- a/app-prefixable/src/utils/provider-auth.ts
+++ b/app-prefixable/src/utils/provider-auth.ts
@@ -3,7 +3,7 @@ export function isLocalBrowserHost(hostname: string) {
   return host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === "::1" || host === "[::1]"
 }
 
-export const OPENAI_BROWSER_OAUTH_UNSUPPORTED_MESSAGE = "Browser authentication uses a localhost callback and is not supported when this UI is served through a notebook proxy. Use API key authentication or a headless/code method instead."
+export const OPENAI_BROWSER_OAUTH_UNSUPPORTED_MESSAGE = "Browser authentication uses a localhost callback and is not supported from remote or notebook-proxied UIs. Use API key authentication or a headless/code method instead."
 
 export function isNotebookBasePath(basePath: string) {
   return /^\/notebook\//.test(basePath)

--- a/app-prefixable/tests/provider-auth.test.ts
+++ b/app-prefixable/tests/provider-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { browserOAuthUnsupported, extractProviderAuthCode, isLocalBrowserHost, providerOAuthMethodUnsupported } from "../src/utils/provider-auth"
+import { browserOAuthUnsupported, extractProviderAuthCode, isLocalBrowserHost, isNotebookBasePath, providerOAuthMethodUnsupported } from "../src/utils/provider-auth"
 
 describe("provider auth helpers", () => {
   test("extracts GitHub-style device codes", () => {
@@ -19,6 +19,11 @@ describe("provider auth helpers", () => {
     expect(isLocalBrowserHost("127.0.0.1")).toBe(true)
     expect(isLocalBrowserHost("0.0.0.0")).toBe(true)
     expect(isLocalBrowserHost("notebook.example.com")).toBe(false)
+  })
+
+  test("detects notebook base paths", () => {
+    expect(isNotebookBasePath("/notebook/admin/opencode-admin-5386")).toBe(true)
+    expect(isNotebookBasePath("/")).toBe(false)
   })
 
   test("blocks remote browser OAuth that redirects to loopback", () => {
@@ -42,5 +47,14 @@ describe("provider auth helpers", () => {
 
   test("keeps OpenAI headless methods available on remote hosts", () => {
     expect(providerOAuthMethodUnsupported({ providerID: "openai", label: "Headless login", browserHostname: "notebook.example.com" })).toBe(false)
+  })
+
+  test("marks OpenAI browser methods unsupported on notebook prefixes", () => {
+    expect(providerOAuthMethodUnsupported({
+      providerID: "openai",
+      label: "ChatGPT Pro/Plus (browser)",
+      browserHostname: "localhost",
+      basePath: "/notebook/admin/opencode-admin-5386",
+    })).toBe(true)
   })
 })

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -125,6 +125,25 @@ async function openAIBrowserOAuthMethods() {
   return blockedOpenAIMethods
 }
 
+function shouldDisposeAfterAuthMutation(path: string, req: Request, response: Response) {
+  if (!response.ok) return false
+  if (!POST_AUTH_METHODS.has(req.method)) return false
+  if (/^\/auth\/[^/]+$/.test(path)) return true
+  return /^\/provider\/[^/]+\/oauth\/callback$/.test(path)
+}
+
+const POST_AUTH_METHODS = new Set(["POST", "DELETE"])
+
+async function disposeInstanceAfterAuthMutation(path: string, req: Request, response: Response) {
+  if (!shouldDisposeAfterAuthMutation(path, req, response)) return
+  const dispose = new URL("/instance/dispose", API_URL)
+  const res = await fetch(dispose.toString(), { method: "POST" }).catch((e) => {
+    console.error("[Proxy] Failed to dispose instance after auth mutation:", e)
+    return undefined
+  })
+  if (res && !res.ok) console.error("[Proxy] Failed to dispose instance after auth mutation:", res.status, res.statusText)
+}
+
 const server = Bun.serve<{ path: string; search: string }>({
   port: PORT,
   hostname: "0.0.0.0",
@@ -248,6 +267,7 @@ const server = Bun.serve<{ path: string; search: string }>({
           headers,
           body,
         })
+        await disposeInstanceAfterAuthMutation(path, req, response)
         return withNoStoreHeaders(normalizeProxiedResponse(response))
       } catch (e) {
         console.error("[Proxy] API error:", e)

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -43,6 +43,7 @@ function validateBasePath(path: string): string {
 const validatedBasePath = validateBasePath(BASE_PATH)
 const basePathWithoutTrailing = validatedBasePath.endsWith("/") ? validatedBasePath.slice(0, -1) : validatedBasePath
 const basePathWithTrailing = validatedBasePath.endsWith("/") ? validatedBasePath : validatedBasePath + "/"
+const isNotebookBasePath = /^\/notebook\//.test(basePathWithTrailing)
 
 // MIME types for static files
 const mimeTypes: Record<string, string> = {
@@ -85,6 +86,22 @@ function withNoStoreHeaders(response: Response) {
     statusText: response.statusText,
     headers,
   })
+}
+
+async function rejectUnsupportedAuth(path: string, req: Request) {
+  if (!isNotebookBasePath) return undefined
+  if (req.method !== "POST") return undefined
+  if (path !== "/provider/openai/oauth/authorize") return undefined
+
+  const body = await req.clone().json().catch(() => null) as { method?: unknown } | null
+  if (body?.method !== 0) return undefined
+
+  return withNoStoreHeaders(new Response(JSON.stringify({
+    error: "OpenAI browser authentication uses a localhost callback and is not supported in notebooks. Use headless/code or API key authentication instead.",
+  }), {
+    status: 400,
+    headers: { "Content-Type": "application/json" },
+  }))
 }
 
 const server = Bun.serve<{ path: string; search: string }>({
@@ -200,6 +217,9 @@ const server = Bun.serve<{ path: string; search: string }>({
 
       // Regular API requests
       console.log("[Proxy] API:", req.method, path)
+      const rejected = await rejectUnsupportedAuth(path, req)
+      if (rejected) return rejected
+
       try {
         const body = req.method === "GET" || req.method === "HEAD" ? undefined : req.body
         const response = await fetch(target.toString(), {

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -44,6 +44,7 @@ const validatedBasePath = validateBasePath(BASE_PATH)
 const basePathWithoutTrailing = validatedBasePath.endsWith("/") ? validatedBasePath.slice(0, -1) : validatedBasePath
 const basePathWithTrailing = validatedBasePath.endsWith("/") ? validatedBasePath : validatedBasePath + "/"
 const isNotebookBasePath = /^\/notebook\//.test(basePathWithTrailing)
+const OPENAI_BROWSER_OAUTH_UNSUPPORTED_MESSAGE = "OpenAI browser authentication uses a localhost callback and is not supported in notebooks. Use headless/code or API key authentication instead."
 
 // MIME types for static files
 const mimeTypes: Record<string, string> = {
@@ -72,6 +73,7 @@ function isPtyWebSocket(path: string): boolean {
 
 // Track last non-polling activity for Kubeflow idle culling
 let lastActivity = Date.now()
+let blockedOpenAIMethods: Promise<Set<number>> | undefined
 
 // Store for backend WebSocket connections (keyed by client WebSocket)
 const backendConnections = new WeakMap<object, WebSocket>()
@@ -94,14 +96,33 @@ async function rejectUnsupportedAuth(path: string, req: Request) {
   if (path !== "/provider/openai/oauth/authorize") return undefined
 
   const body = await req.clone().json().catch(() => null) as { method?: unknown } | null
-  if (body?.method !== 0) return undefined
+  if (typeof body?.method !== "number") return undefined
+  const blocked = await openAIBrowserOAuthMethods()
+  if (!blocked.has(body.method)) return undefined
 
   return withNoStoreHeaders(new Response(JSON.stringify({
-    error: "OpenAI browser authentication uses a localhost callback and is not supported in notebooks. Use headless/code or API key authentication instead.",
+    error: OPENAI_BROWSER_OAUTH_UNSUPPORTED_MESSAGE,
   }), {
     status: 400,
     headers: { "Content-Type": "application/json" },
   }))
+}
+
+async function openAIBrowserOAuthMethods() {
+  blockedOpenAIMethods ??= fetch(new URL("/provider/auth", API_URL).toString())
+    .then((res) => res.ok ? res.json() : undefined)
+    .then((data) => {
+      const methods = Array.isArray(data?.openai) ? data.openai : []
+      return new Set<number>(methods.flatMap((method: { type?: string; label?: string }, index: number) => {
+        if (method.type !== "oauth") return []
+        return /\b(browser|local)\b/i.test(method.label ?? "") ? [index] : []
+      }))
+    })
+    .catch((e) => {
+      console.error("[Proxy] Failed to fetch OpenAI auth methods:", e)
+      return new Set<number>()
+    })
+  return blockedOpenAIMethods
 }
 
 const server = Bun.serve<{ path: string; search: string }>({

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -110,7 +110,10 @@ async function rejectUnsupportedAuth(path: string, req: Request) {
 
 async function openAIBrowserOAuthMethods() {
   blockedOpenAIMethods ??= fetch(new URL("/provider/auth", API_URL).toString())
-    .then((res) => res.ok ? res.json() : undefined)
+    .then((res) => {
+      if (res.ok) return res.json()
+      throw new Error(`OpenAI auth methods request failed: ${res.status} ${res.statusText}`)
+    })
     .then((data) => {
       const methods = Array.isArray(data?.openai) ? data.openai : []
       return new Set<number>(methods.flatMap((method: { type?: string; label?: string }, index: number) => {
@@ -120,6 +123,7 @@ async function openAIBrowserOAuthMethods() {
     })
     .catch((e) => {
       console.error("[Proxy] Failed to fetch OpenAI auth methods:", e)
+      blockedOpenAIMethods = undefined
       return new Set<number>()
     })
   return blockedOpenAIMethods

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -284,13 +284,13 @@ const server = Bun.serve<{ path: string; search: string }>({
       const ext = path.split(".").pop()?.toLowerCase() || ""
       const contentType = mimeTypes[ext] || "application/octet-stream"
 
+      const cacheControl = ext === "js" || ext === "css" || ext === "map"
+        ? "no-cache"
+        : "public, max-age=31536000, immutable"
       return new Response(file, {
         headers: {
           "Content-Type": contentType,
-          // Cache static assets
-          ...(ext !== "html" && {
-            "Cache-Control": "public, max-age=31536000, immutable",
-          }),
+          ...(ext !== "html" && { "Cache-Control": cacheControl }),
         },
       })
     }

--- a/docker/serve-ui.ts
+++ b/docker/serve-ui.ts
@@ -131,12 +131,12 @@ async function openAIBrowserOAuthMethods() {
 
 function shouldDisposeAfterAuthMutation(path: string, req: Request, response: Response) {
   if (!response.ok) return false
-  if (!POST_AUTH_METHODS.has(req.method)) return false
+  if (!AUTH_MUTATION_METHODS.has(req.method)) return false
   if (/^\/auth\/[^/]+$/.test(path)) return true
   return /^\/provider\/[^/]+\/oauth\/callback$/.test(path)
 }
 
-const POST_AUTH_METHODS = new Set(["POST", "DELETE"])
+const AUTH_MUTATION_METHODS = new Set(["POST", "PUT", "DELETE"])
 
 async function disposeInstanceAfterAuthMutation(path: string, req: Request, response: Response) {
   if (!shouldDisposeAfterAuthMutation(path, req, response)) return


### PR DESCRIPTION
## Summary
- treat Kubeflow notebook base paths as unsupported for OpenAI browser/local OAuth
- block the OAuth start handler before calling the backend if an unsupported method is selected
- keep OpenAI headless and API key auth available for notebooks

## Validation
- bun run typecheck
- bun run test
- bun run build

## Diagnosis
On fat-peagle, notebook opencode-admin-5386 runs image v0.9.1-763b5a6 with OpenCode 1.15.7. OpenAI OAuth tokens were written to auth.json after using the browser method, but /provider still did not include openai in connected providers. The failing UI path was the notebook-proxied "ChatGPT Pro/Plus (browser)" method; notebooks should use headless OAuth or API key auth instead.