### PR TITLE
fix: add timeout to API health check to prevent UI startup hang

### DIFF
--- a/docker/kubeflow/start-server.sh
+++ b/docker/kubeflow/start-server.sh
@@ -47,7 +47,7 @@ API_PID=$!
 # Wait for API to be ready
 echo "Waiting for API server to start..."
 for i in {1..30}; do
-    if curl -s http://127.0.0.1:4096/health > /dev/null 2>&1; then
+    if curl -sf --max-time 2 http://127.0.0.1:4096/session/status > /dev/null 2>&1; then
         echo "API server is ready!"
         break
     fi

--- a/docker/kubeflow/start-server.sh
+++ b/docker/kubeflow/start-server.sh
@@ -52,7 +52,7 @@ for i in {1..30}; do
         break
     fi
     if [ $i -eq 30 ]; then
-        echo "ERROR: API server failed to start within the allotted time"
+        echo "ERROR: API server failed to start after 30 attempts with a 2s request timeout"
         exit 1
     fi
     sleep 1

--- a/docker/kubeflow/start-server.sh
+++ b/docker/kubeflow/start-server.sh
@@ -52,7 +52,7 @@ for i in {1..30}; do
         break
     fi
     if [ $i -eq 30 ]; then
-        echo "ERROR: API server failed to start within 30 seconds"
+        echo "ERROR: API server failed to start within the allotted time"
         exit 1
     fi
     sleep 1


### PR DESCRIPTION
## Problem

After merging the Debian base image (#440), the deployed notebook shows:

```
upstream connect error or disconnect/reset before headers. retried and the latest reset reason: remote connection failure, transport failure reason: delayed connect error: Connection refused
```

**Root cause**: The `curl -s http://127.0.0.1:4096/health` health check in `start-server.sh` has no `--max-time` timeout. When OpenCode accepts the TCP connection but is slow to respond during initialization, curl hangs indefinitely and the script never reaches the `exec bun run serve-ui.ts` line — so the UI never starts on port 8888.

## Fix

- Add `--max-time 2` to curl so it times out and retries
- Switch endpoint from `/health` (returns full SPA HTML, ~2.5KB) to `/session/status` (returns `{}`, fast JSON)
- Add `-f` flag to fail on HTTP errors

## Testing

Verified in the running pod that `curl -sf --max-time 2 http://127.0.0.1:4096/session/status` returns immediately with exit 0.