### PR TITLE
fix: prevent UI proxy session load hangs

### DIFF
--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -73,6 +73,17 @@ function stripHopByHopHeaders(headers: Headers) {
   }
 }
 
+function normalizeDevProxiedResponse(response: Response) {
+  const normalized = normalizeProxiedResponse(response)
+  const headers = new Headers(normalized.headers)
+  stripHopByHopHeaders(headers)
+  return new Response(normalized.body, {
+    status: normalized.status,
+    statusText: normalized.statusText,
+    headers,
+  })
+}
+
 const server = Bun.serve<{ target: string }>({
   port: PORT,
   idleTimeout: 0, // Disable timeout for SSE connections
@@ -169,7 +180,7 @@ const server = Bun.serve<{ target: string }>({
           body,
           signal: req.signal,
         })
-        return withNoStoreHeaders(normalizeProxiedResponse(response))
+        return withNoStoreHeaders(normalizeDevProxiedResponse(response))
       } catch (e) {
         console.error("[Proxy] API error:", e)
         return withNoStoreHeaders(new Response("API proxy error", { status: 502 }))

--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -48,6 +48,31 @@ function withNoStoreHeaders(response: Response) {
   })
 }
 
+function stripHopByHopHeaders(headers: Headers) {
+  const connection = headers.get("connection")
+  if (connection) {
+    for (const name of connection.split(",")) {
+      const trimmed = name.trim()
+      if (trimmed) headers.delete(trimmed)
+    }
+  }
+
+  for (const name of [
+    "connection",
+    "content-length",
+    "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+  ]) {
+    headers.delete(name)
+  }
+}
+
 const server = Bun.serve<{ target: string }>({
   port: PORT,
   idleTimeout: 0, // Disable timeout for SSE connections
@@ -94,9 +119,7 @@ const server = Bun.serve<{ target: string }>({
     if (isApiPath(strippedPath)) {
       const target = new URL(strippedPath + url.search, API_URL)
       const headers = new Headers(req.headers)
-      headers.delete("host")
-      headers.delete("connection")
-      headers.delete("content-length")
+      stripHopByHopHeaders(headers)
 
       // SSE requests - just pass through the response body directly
       if (strippedPath.startsWith("/event")) {

--- a/app-prefixable/dev.ts
+++ b/app-prefixable/dev.ts
@@ -94,6 +94,9 @@ const server = Bun.serve<{ target: string }>({
     if (isApiPath(strippedPath)) {
       const target = new URL(strippedPath + url.search, API_URL)
       const headers = new Headers(req.headers)
+      headers.delete("host")
+      headers.delete("connection")
+      headers.delete("content-length")
 
       // SSE requests - just pass through the response body directly
       if (strippedPath.startsWith("/event")) {
@@ -102,6 +105,7 @@ const server = Bun.serve<{ target: string }>({
           const response = await fetch(target.toString(), {
             method: req.method,
             headers,
+            signal: req.signal,
           })
 
           if (!response.ok) {
@@ -140,6 +144,7 @@ const server = Bun.serve<{ target: string }>({
           method: req.method,
           headers,
           body,
+          signal: req.signal,
         })
         return withNoStoreHeaders(normalizeProxiedResponse(response))
       } catch (e) {

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -576,10 +576,9 @@ export function GlobalEventsProvider(props: ParentProps & {
 
       const limitedWanted = wantedDirectories(current.dirs, current.active)
 
-      for (const [dir, timer] of reconnectTimers) {
+      for (const [dir] of [...reconnectTimers]) {
         if (limitedWanted.has(dir)) continue
-        clearTimeout(timer)
-        reconnectTimers.delete(dir)
+        disconnectDirectory(dir)
       }
 
       // Disconnect directories we no longer need (including newly-active project)

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -159,6 +159,12 @@ export function GlobalEventsProvider(props: ParentProps & {
     }, 5000))
   }
 
+  function wantedDirectories(dirs: string[], active: string | undefined) {
+    const wanted = new Set(dirs.slice(0, MAX_GLOBAL_EVENT_CONNECTIONS + 1))
+    if (active) wanted.delete(active)
+    return new Set([...wanted].slice(0, MAX_GLOBAL_EVENT_CONNECTIONS))
+  }
+
   function connectToDirectory(dir: string) {
     if (connections.has(dir)) return
     // Don't connect when a remote server is active
@@ -351,9 +357,8 @@ export function GlobalEventsProvider(props: ParentProps & {
           if (disposed) return
           // Don't reconnect when a remote server is active — local projects don't exist there
           if (!activeServer().isDefault) return
-          const active = props.activeDirectory()
-          const wanted = props.projects().some((p) => p.worktree === dir)
-          if (wanted && dir !== active) {
+          const wanted = wantedDirectories(props.projects().map((p) => p.worktree), props.activeDirectory())
+          if (wanted.has(dir)) {
             connectToDirectory(dir)
             return
           }
@@ -569,10 +574,13 @@ export function GlobalEventsProvider(props: ParentProps & {
         return
       }
 
-      const wanted = new Set(current.dirs.slice(0, MAX_GLOBAL_EVENT_CONNECTIONS + 1))
-      if (current.active) wanted.delete(current.active)
+      const limitedWanted = wantedDirectories(current.dirs, current.active)
 
-      const limitedWanted = new Set([...wanted].slice(0, MAX_GLOBAL_EVENT_CONNECTIONS))
+      for (const [dir, timer] of reconnectTimers) {
+        if (limitedWanted.has(dir)) continue
+        clearTimeout(timer)
+        reconnectTimers.delete(dir)
+      }
 
       // Disconnect directories we no longer need (including newly-active project)
       for (const dir of [...connections.keys()]) {

--- a/app-prefixable/src/context/global-events.tsx
+++ b/app-prefixable/src/context/global-events.tsx
@@ -10,6 +10,8 @@ import { createStore, produce } from "solid-js/store"
 import { useServer } from "./server"
 import { createSSEParser } from "../utils/sse"
 
+const MAX_GLOBAL_EVENT_CONNECTIONS = 16
+
 /**
  * Alert priority: permission (highest) > question > busy
  */
@@ -567,18 +569,20 @@ export function GlobalEventsProvider(props: ParentProps & {
         return
       }
 
-      const wanted = new Set(current.dirs)
+      const wanted = new Set(current.dirs.slice(0, MAX_GLOBAL_EVENT_CONNECTIONS + 1))
       if (current.active) wanted.delete(current.active)
+
+      const limitedWanted = new Set([...wanted].slice(0, MAX_GLOBAL_EVENT_CONNECTIONS))
 
       // Disconnect directories we no longer need (including newly-active project)
       for (const dir of [...connections.keys()]) {
-        if (!wanted.has(dir)) {
+        if (!limitedWanted.has(dir)) {
           disconnectDirectory(dir)
         }
       }
 
       // Connect to new inactive directories
-      for (const dir of wanted) {
+      for (const dir of limitedWanted) {
         if (!connections.has(dir)) {
           connectToDirectory(dir)
         }


### PR DESCRIPTION
## Summary
- limit background global event SSE connections for inactive projects
- strip hop-by-hop headers in the dev API proxy
- abort upstream dev proxy fetches when client requests are aborted

## Diagnosis
The OpenCode backend continued to answer /session directly, but the UI dev proxy hung on /session and /api/session. The UI server process had many established backend connections, consistent with accumulated background SSE proxy connections. Restarting the UI server clears those sockets, which explains the observed workaround.

## Verification
- bun run typecheck
- bun test tests/sse.test.ts tests/events.test.ts tests/sync.test.ts
- bun run build