### PR TITLE
fix: refresh stale directory provider state

### DIFF
--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -243,14 +243,18 @@ export function ProviderProvider(props: ParentProps) {
       if (!data) return undefined
 
       if (directory) {
-        const globalRes = await globalClient.provider.list()
-        const globalData = globalRes.data as ProviderListData | undefined
-        const stale = (globalData?.connected ?? []).some((id) => !data.connected.includes(id))
-        if (stale) {
-          await client.instance.dispose()
-          const refreshed = await client.provider.list()
-          const refreshedData = refreshed.data as ProviderListData | undefined
-          if (refreshedData) return normalizeProviderData(refreshedData)
+        try {
+          const globalRes = await globalClient.provider.list()
+          const globalData = globalRes.data as ProviderListData | undefined
+          const stale = (globalData?.connected ?? []).some((id) => !data.connected.includes(id))
+          if (stale) {
+            await client.instance.dispose()
+            const refreshed = await client.provider.list()
+            const refreshedData = refreshed.data as ProviderListData | undefined
+            if (refreshedData) return normalizeProviderData(refreshedData)
+          }
+        } catch (e) {
+          console.warn("Failed to refresh stale directory provider state:", e)
         }
       }
 

--- a/app-prefixable/src/context/providers.tsx
+++ b/app-prefixable/src/context/providers.tsx
@@ -131,7 +131,7 @@ interface ProviderContextValue {
 const ProviderContext = createContext<ProviderContextValue>()
 
 export function ProviderProvider(props: ParentProps) {
-  const { client, directory } = useSDK()
+  const { client, global: globalClient, directory } = useSDK()
   const cfg = useConfig()
   const storageKey = modelsStorageKey(directory)
   const variantKey = variantsStorageKey(directory)
@@ -225,20 +225,36 @@ export function ProviderProvider(props: ParentProps) {
     }
   })
 
+  function normalizeProviderData(data: ProviderListData) {
+    const all = data.all.map((provider) => ({
+      ...provider,
+      models: Object.fromEntries(
+        Object.entries(provider.models).map(([k, m]) => [k, { ...m, providerID: provider.id }])
+      ),
+    }))
+    return { ...data, all }
+  }
+
   // Fetch providers
   const [providerData, { mutate: setProviderData, refetch: refetchProviders }] = createResource(async () => {
     try {
       const res = await client.provider.list()
       const data = res.data as ProviderListData | undefined
       if (!data) return undefined
-      // Inject providerID into each model since the SDK response doesn't include it
-      const all = data.all.map((provider) => ({
-        ...provider,
-        models: Object.fromEntries(
-          Object.entries(provider.models).map(([k, m]) => [k, { ...m, providerID: provider.id }])
-        ),
-      }))
-      return { ...data, all }
+
+      if (directory) {
+        const globalRes = await globalClient.provider.list()
+        const globalData = globalRes.data as ProviderListData | undefined
+        const stale = (globalData?.connected ?? []).some((id) => !data.connected.includes(id))
+        if (stale) {
+          await client.instance.dispose()
+          const refreshed = await client.provider.list()
+          const refreshedData = refreshed.data as ProviderListData | undefined
+          if (refreshedData) return normalizeProviderData(refreshedData)
+        }
+      }
+
+      return normalizeProviderData(data)
     } catch (e) {
       console.error("Failed to fetch providers:", e)
       return undefined


### PR DESCRIPTION
## Summary
- detect when a directory-scoped OpenCode instance has stale connected provider state
- compare directory provider state against global provider auth state
- dispose and refetch the directory instance once when it is missing globally connected providers

## Diagnosis
In the Kubeflow OpenCode notebook, /provider without x-opencode-directory returned connected providers [openai, opencode], but /provider with x-opencode-directory for /home/jovyan/kubeflow-examples returned only [opencode]. The model picker uses the directory-scoped SDK client, so it only showed OpenCode/Open Zen models until the directory instance was manually disposed.

## Verification
- bun run typecheck
- bun test tests/provider-auth.test.ts tests/model-variant.test.ts
- bun run build