### PR TITLE
perf: reduce long session streaming render cost

### DIFF
--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -20,6 +20,18 @@ type TurnRef = {
   assistantIds: string[]
 }
 
+type MessageStructure = {
+  id: string
+  role: DisplayMessage["role"]
+  error: boolean
+  parts: string[]
+}
+
+type TurnRefState = {
+  structure: MessageStructure[]
+  refs: TurnRef[]
+}
+
 // Compute turn-level timing from user and assistant message timestamps
 function computeTurnTime(user: DisplayMessage, assistants: DisplayMessage[]): Turn["time"] {
   const started = user.time?.created
@@ -71,10 +83,30 @@ function hasStructuredContent(message: DisplayMessage): boolean {
   return message.parts.some((p) => p.type === "tool" || p.type === "text" || p.type === "reasoning")
 }
 
-function timelineStructure(messages: DisplayMessage[]) {
-  return messages
-    .map((msg) => `${msg.id}:${msg.role}:${msg.error ? 1 : 0}:${msg.parts.map((p) => p.type).join(",")}`)
-    .join("|")
+function messageStructure(messages: DisplayMessage[]) {
+  return messages.map((msg) => ({
+    id: msg.id,
+    role: msg.role,
+    error: !!msg.error,
+    parts: msg.parts.map((part) => part.type),
+  }))
+}
+
+function sameTimelineStructure(prev: MessageStructure[], next: MessageStructure[]) {
+  if (prev.length !== next.length) return false
+
+  for (let i = 0; i < next.length; i++) {
+    const a = prev[i]
+    const b = next[i]
+    if (a.id !== b.id || a.role !== b.role || a.error !== b.error) return false
+    if (a.parts.length !== b.parts.length) return false
+
+    for (let j = 0; j < b.parts.length; j++) {
+      if (a.parts[j] !== b.parts[j]) return false
+    }
+  }
+
+  return true
 }
 
 export function MessageTimeline(props: {
@@ -104,7 +136,6 @@ export function MessageTimeline(props: {
   const [userScrolledUp, setUserScrolledUp] = createSignal(false)
   // Track previous turn IDs for session switch detection
   const [prevTurnIds, setPrevTurnIds] = createSignal<Set<string>>(new Set())
-  const structure = createMemo(() => timelineStructure(props.messages))
 
   const messageById = createMemo(() => {
     const map = new Map<string, DisplayMessage>()
@@ -113,11 +144,16 @@ export function MessageTimeline(props: {
   })
 
   // Convert messages to turn references only when structure changes.
-  const turnRefs = createMemo(() => {
-    structure()
-    const filtered = untrack(() => props.messages).filter(hasStructuredContent)
-    return messagesToTurnRefs(filtered)
+  const turnRefState = createMemo<TurnRefState>((prev) => {
+    const messages = props.messages
+    const structure = messageStructure(messages)
+    if (prev && sameTimelineStructure(prev.structure, structure)) {
+      return { structure, refs: prev.refs }
+    }
+    return { structure, refs: messagesToTurnRefs(messages.filter(hasStructuredContent)) }
   })
+
+  const turnRefs = () => turnRefState().refs
 
   function resolveTurn(ref: TurnRef): Turn | undefined {
     const map = messageById()

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -144,7 +144,7 @@ export function MessageTimeline(props: {
     const messages = props.messages
     const structure = messageStructure(messages)
     if (prev && sameTimelineStructure(prev.structure, structure)) {
-      return { structure, refs: prev.refs }
+      return prev
     }
     return { structure, refs: messagesToTurnRefs(messages.filter(hasStructuredContent)) }
   })

--- a/app-prefixable/src/components/message-timeline.tsx
+++ b/app-prefixable/src/components/message-timeline.tsx
@@ -24,7 +24,7 @@ type MessageStructure = {
   id: string
   role: DisplayMessage["role"]
   error: boolean
-  parts: string[]
+  partCount: number
 }
 
 type TurnRefState = {
@@ -88,7 +88,7 @@ function messageStructure(messages: DisplayMessage[]) {
     id: msg.id,
     role: msg.role,
     error: !!msg.error,
-    parts: msg.parts.map((part) => part.type),
+    partCount: msg.parts.length,
   }))
 }
 
@@ -99,11 +99,7 @@ function sameTimelineStructure(prev: MessageStructure[], next: MessageStructure[
     const a = prev[i]
     const b = next[i]
     if (a.id !== b.id || a.role !== b.role || a.error !== b.error) return false
-    if (a.parts.length !== b.parts.length) return false
-
-    for (let j = 0; j < b.parts.length; j++) {
-      if (a.parts[j] !== b.parts[j]) return false
-    }
+    if (a.partCount !== b.partCount) return false
   }
 
   return true

--- a/app-prefixable/src/components/message-turn.tsx
+++ b/app-prefixable/src/components/message-turn.tsx
@@ -908,10 +908,10 @@ export function MessageTurn(props: {
           {/* Assistant messages */}
           <For each={props.turn.assistantMessages}>
             {(message) => {
-              const text = extractTextContent(message.parts).trim()
-              const tools = hasTools(message)
-              const meta = () => message.parts.filter((part) => isAgentPart(part) || isSnapshotPart(part) || isRetryPart(part) || isPatchPart(part) || isCompactionPart(part))
-              const subtasks = () => message.parts.filter(isSubtaskPart)
+              const text = createMemo(() => extractTextContent(message.parts).trim())
+              const tools = createMemo(() => hasTools(message))
+              const meta = createMemo(() => message.parts.filter((part) => isAgentPart(part) || isSnapshotPart(part) || isRetryPart(part) || isPatchPart(part) || isCompactionPart(part)))
+              const subtasks = createMemo(() => message.parts.filter(isSubtaskPart))
               const messageTime = createMemo(() => {
                 const created = message.time?.created
                 if (created == null) return undefined
@@ -954,8 +954,8 @@ export function MessageTurn(props: {
                       )}
                     </Show>
                     {/* Text content */}
-                    <Show when={text}>
-                      <Markdown content={text} class="text-sm" />
+                    <Show when={text()}>
+                      {(content) => <Markdown content={content()} class="text-sm" />}
                     </Show>
                     {/* Agent, snapshot, retry, patch, and compaction parts */}
                     <Show when={meta().length > 0}>
@@ -982,7 +982,7 @@ export function MessageTurn(props: {
                       </div>
                     </Show>
                     {/* Tool calls */}
-                    <Show when={tools}>
+                    <Show when={tools()}>
                       <div class="mt-2">
                         <MessageParts parts={message.parts} />
                       </div>

--- a/app-prefixable/src/context/sync.tsx
+++ b/app-prefixable/src/context/sync.tsx
@@ -75,6 +75,37 @@ export function applyPartDelta(part: Part, field: string, delta: string) {
   return { ...part, text: `${part.text ?? ""}${delta}` }
 }
 
+function applyPartDeltaInPlace(parts: Part[] | undefined, partID: string, field: string, delta: string) {
+  if (!parts) return false
+  const idx = parts.findIndex((p) => p.id === partID)
+  if (idx === -1) return false
+  const next = applyPartDelta(parts[idx], field, delta)
+  if (next === parts[idx]) return false
+  parts[idx] = next
+  return true
+}
+
+function updateMessagePartInPlace(messages: MessageWithParts[] | undefined, messageID: string, part: Part) {
+  if (!messages || messages.length === 0) return false
+  const msgIdx = messages.findIndex((m) => m.info.id === messageID)
+  if (msgIdx === -1) return false
+  messages[msgIdx].parts = mergePartUpdate(messages[msgIdx].parts, part)
+  return true
+}
+
+function applyMessagePartDeltaInPlace(
+  messages: MessageWithParts[] | undefined,
+  messageID: string,
+  partID: string,
+  field: string,
+  delta: string,
+) {
+  if (!messages || messages.length === 0) return false
+  const msgIdx = messages.findIndex((m) => m.info.id === messageID)
+  if (msgIdx === -1) return false
+  return applyPartDeltaInPlace(messages[msgIdx].parts, partID, field, delta)
+}
+
 function toolRank(part: Extract<Part, { type: "tool" }>) {
   if (part.state.status === "pending") return 0
   if (part.state.status === "running") return 1
@@ -376,18 +407,11 @@ export function SyncProvider(props: ParentProps) {
       setStore("part", part.messageID, (existing: Part[] | undefined) => mergePartUpdate(existing, part))
 
       // Update parts in existing messages only - don't synthesize messages from parts
-      setStore("message", part.sessionID, (msgs: MessageWithParts[]) => {
-        if (!msgs || msgs.length === 0) return msgs
-
-        const msgIdx = msgs.findIndex((m) => m.info.id === part.messageID)
-        if (msgIdx === -1) return msgs
-
-        // Update existing message parts
-        return msgs.map((m, i) => {
-          if (i !== msgIdx) return m
-          return { ...m, parts: mergePartUpdate(m.parts, part) }
-        })
-      })
+      if (store.message[part.sessionID]) {
+        setStore("message", part.sessionID, produce((msgs: MessageWithParts[]) => {
+          updateMessagePartInPlace(msgs, part.messageID, part)
+        }))
+      }
     }
 
     if (event.type === "message.part.delta") {
@@ -397,18 +421,14 @@ export function SyncProvider(props: ParentProps) {
       const text = delta.delta
 
       if (store.part[delta.messageID]) {
-        setStore("part", delta.messageID, (existing: Part[]) =>
-          existing.map((p) => (p.id === delta.partID ? applyPartDelta(p, field, text) : p)),
-        )
+        setStore("part", delta.messageID, produce((existing: Part[]) => {
+          applyPartDeltaInPlace(existing, delta.partID!, field, text)
+        }))
       }
 
       if (store.message[delta.sessionID]) {
-        setStore("message", delta.sessionID, (messages: MessageWithParts[]) => messages.map((m) => {
-          if (m.info.id !== delta.messageID) return m
-          return {
-            ...m,
-            parts: m.parts.map((p) => (p.id === delta.partID ? applyPartDelta(p, field, text) : p)),
-          }
+        setStore("message", delta.sessionID, produce((messages: MessageWithParts[]) => {
+          applyMessagePartDeltaInPlace(messages, delta.messageID!, delta.partID!, field, text)
         }))
       }
     }

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -257,6 +257,42 @@ export function Session() {
     return msgs.slice(0, revertIndex);
   }
 
+  function displayMessage(msg: ReturnType<typeof sync.messages>[number]) {
+    const cached = displayMessageCache.get(msg.info.id);
+    if (cached?.source === msg) return cached.display;
+
+    const display = {
+      get id() {
+        return msg.info.id;
+      },
+      get role() {
+        return msg.info.role;
+      },
+      get parts() {
+        return msg.parts;
+      },
+      get error() {
+        return msg.info.role === "assistant" ? msg.info.error : undefined;
+      },
+      get time() {
+        if (msg.info.role === "assistant") return { created: msg.info.time.created, completed: msg.info.time.completed };
+        return { created: msg.info.time.created };
+      },
+      get modelID() {
+        return msg.info.role === "assistant" ? msg.info.modelID : undefined;
+      },
+      get providerID() {
+        return msg.info.role === "assistant" ? msg.info.providerID : undefined;
+      },
+      get tokens() {
+        return msg.info.role === "assistant" ? msg.info.tokens : undefined;
+      },
+    } satisfies DisplayMessage;
+
+    displayMessageCache.set(msg.info.id, { source: msg, display });
+    return display;
+  }
+
   function assistantFinished(id: string) {
     const msgs = visibleSyncMessages(id);
     const last = msgs[msgs.length - 1]?.info;
@@ -354,6 +390,7 @@ export function Session() {
   const [pendingUserMessageText, setPendingUserMessageText] = createSignal<
     string | null
   >(null);
+  const displayMessageCache = new Map<string, { source: ReturnType<typeof sync.messages>[number]; display: DisplayMessage }>();
 
   const pendingPermissions = createMemo(() => permission.pendingForSession(sessionId() ?? ""));
   const inputBlocked = createMemo(() => !!pendingQuestion() || pendingPermissions().length > 0);
@@ -944,27 +981,12 @@ export function Session() {
   const syncMessages = createMemo(() => {
     const id = sessionId();
     if (!id) return [];
-    return visibleSyncMessages(id).map((msg) => {
-      const info = msg.info;
-      if (info.role === "assistant") {
-        return {
-          id: info.id,
-          role: info.role,
-          parts: msg.parts,
-          error: info.error,
-          time: { created: info.time.created, completed: info.time.completed },
-          modelID: info.modelID,
-          providerID: info.providerID,
-          tokens: info.tokens,
-        };
-      }
-      return {
-        id: info.id,
-        role: info.role,
-        parts: msg.parts,
-        time: { created: info.time.created },
-      };
-    });
+    const result = visibleSyncMessages(id).map(displayMessage);
+    const visible = new Set(result.map((msg) => msg.id));
+    for (const key of displayMessageCache.keys()) {
+      if (!visible.has(key)) displayMessageCache.delete(key);
+    }
+    return result;
   });
 
   // Includes optimistic message if present and not yet in sync

--- a/app-prefixable/src/pages/session.tsx
+++ b/app-prefixable/src/pages/session.tsx
@@ -275,8 +275,7 @@ export function Session() {
         return msg.info.role === "assistant" ? msg.info.error : undefined;
       },
       get time() {
-        if (msg.info.role === "assistant") return { created: msg.info.time.created, completed: msg.info.time.completed };
-        return { created: msg.info.time.created };
+        return msg.info.time;
       },
       get modelID() {
         return msg.info.role === "assistant" ? msg.info.modelID : undefined;


### PR DESCRIPTION
## Summary
- update streaming part deltas in place instead of recreating full message arrays
- cache display message wrappers so long active sessions avoid rebuilding every message object per token
- reuse timeline turn refs when only text changes and make visible turn content reactive

## Verification
- bun run typecheck
- bun run build