### PR TITLE
docs: prepare v0.9.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-08-13
+
+### Fixed
+- Reduce CPU and rendering overhead in long streaming sessions by throttling Markdown updates, avoiding unnecessary timeline regrouping, and sharing the active SSE connection (#449)
+
 ## [0.9.2] - 2026-05-29
 
 ### Fixed


### PR DESCRIPTION
## Summary
- document the streaming-session performance improvements included in v0.9.3
- prepare the changelog for the patch release

## Verification
- bun run build
- bun run typecheck
- bun test tests/: 349 passed
- bun run lint: known baseline with 34 errors and 90 warnings

Release PR for v0.9.3.