### PR TITLE
ci: Route tagged OpenCode builds to releases

### DIFF
--- a/.github/scripts/probe-registry-manifest.sh
+++ b/.github/scripts/probe-registry-manifest.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )); then
+  echo "Usage: $0 <manifest-url> <access-token>" >&2
+  exit 2
+fi
+
+URL="$1"
+TOKEN="$2"
+CURL_BIN="${CURL_BIN:-curl}"
+BODY=$(mktemp)
+trap 'rm -f "$BODY"' EXIT
+
+ACCEPT="application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json"
+
+if ! HTTP_STATUS=$("$CURL_BIN" --silent --show-error --output "$BODY" \
+  --connect-timeout 10 \
+  --max-time 30 \
+  --request GET \
+  --write-out "%{http_code}" \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Accept: $ACCEPT" \
+  "$URL"); then
+  echo "Registry manifest request failed" >&2
+  exit 1
+fi
+
+case "$HTTP_STATUS" in
+  200)
+    echo "present"
+    ;;
+  404)
+    if jq -e '
+      .errors as $errors |
+      ($errors | type == "array" and length > 0) and
+      ($errors | all(.code == "MANIFEST_UNKNOWN"))
+    ' "$BODY" > /dev/null 2>&1; then
+      echo "missing"
+      exit 0
+    fi
+
+    echo "Registry returned an unconfirmed or ambiguous 404" >&2
+    exit 1
+    ;;
+  *)
+    echo "Registry returned HTTP $HTTP_STATUS" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/probe-registry-manifest.test.sh
+++ b/.github/scripts/probe-registry-manifest.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROBE="$ROOT/probe-registry-manifest.sh"
+WORKFLOW="$ROOT/../workflows/pk-opencode.yml"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cat > "$TMP/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+accept=""
+connect_timeout=""
+max_time=""
+output=""
+request=""
+
+while (( $# > 0 )); do
+  case "$1" in
+    --connect-timeout)
+      connect_timeout="$2"
+      shift 2
+      ;;
+    --max-time)
+      max_time="$2"
+      shift 2
+      ;;
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --request)
+      request="$2"
+      shift 2
+      ;;
+    --header)
+      if [[ "$2" == Accept:* ]]; then
+        accept="${2#Accept: }"
+      fi
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[[ "$connect_timeout" == "10" && "$max_time" == "30" ]] || exit 97
+[[ "$request" == "GET" && -n "$output" ]] || exit 97
+
+media_types=(
+  "application/vnd.oci.image.manifest.v1+json"
+  "application/vnd.oci.image.index.v1+json"
+  "application/vnd.docker.distribution.manifest.v2+json"
+  "application/vnd.docker.distribution.manifest.list.v2+json"
+)
+for media_type in "${media_types[@]}"; do
+  [[ "$accept" == *"$media_type"* ]] || exit 98
+done
+
+printf '%s' "${MOCK_BODY:-}" > "$output"
+printf '%s' "${MOCK_STATUS:-000}"
+exit "${MOCK_EXIT:-0}"
+EOF
+chmod +x "$TMP/curl"
+
+expect_result() {
+  local expected="$1"
+  local status="$2"
+  local body="$3"
+  local result
+
+  if ! result=$(CURL_BIN="$TMP/curl" MOCK_STATUS="$status" MOCK_BODY="$body" \
+    bash "$PROBE" "https://registry.example/manifests/v1.2.3" "token"); then
+    echo "Expected $status response to produce $expected" >&2
+    exit 1
+  fi
+  [[ "$result" == "$expected" ]]
+}
+
+expect_failure() {
+  local status="$1"
+  local body="$2"
+  local exit_code="${3:-0}"
+
+  if CURL_BIN="$TMP/curl" MOCK_STATUS="$status" MOCK_BODY="$body" MOCK_EXIT="$exit_code" \
+    bash "$PROBE" "https://registry.example/manifests/v1.2.3" "token" > /dev/null 2>&1; then
+    echo "Expected $status response to fail" >&2
+    exit 1
+  fi
+}
+
+expect_result "present" "200" '{}'
+expect_result "missing" "404" '{"errors":[{"code":"MANIFEST_UNKNOWN"}]}'
+expect_failure "404" '{"errors":[{"code":"NAME_UNKNOWN"}]}'
+expect_failure "404" '{"errors":[{"code":"MANIFEST_UNKNOWN"},{"code":"NAME_UNKNOWN"}]}'
+expect_failure "404" '{}'
+expect_failure "404" 'not-json'
+expect_failure "401" '{"errors":[{"code":"UNAUTHORIZED"}]}'
+expect_failure "500" '{}'
+expect_failure "000" '' "28"
+
+for file in "$PROBE" "$WORKFLOW"; do
+  grep -F -- "--connect-timeout 10" "$file" > /dev/null
+  grep -F -- "--max-time 30" "$file" > /dev/null
+done

--- a/.github/scripts/validate-image-tag.sh
+++ b/.github/scripts/validate-image-tag.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG="${1:-}"
+KIND="${2:-}"
+
+if (( ${#TAG} > 128 )); then
+  echo "Docker tag must not exceed 128 characters" >&2
+  exit 1
+fi
+
+case "$KIND" in
+  release)
+    if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+      echo "Release tag must match vX.Y.Z or vX.Y.Z-rcN" >&2
+      exit 1
+    fi
+    ;;
+  development)
+    if [[ ! "$TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]*$ ]]; then
+      echo "Development version is not a valid Docker tag" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Tag kind must be release or development" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/validate-image-tag.test.sh
+++ b/.github/scripts/validate-image-tag.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+VALIDATOR=(bash "$ROOT/validate-image-tag.sh")
+
+expect_valid() {
+  if ! "${VALIDATOR[@]}" "$1" "$2" > /dev/null; then
+    echo "Expected valid $2 tag: $1" >&2
+    exit 1
+  fi
+}
+
+expect_invalid() {
+  if "${VALIDATOR[@]}" "$1" "$2" > /dev/null 2>&1; then
+    echo "Expected invalid $2 tag: $1" >&2
+    exit 1
+  fi
+}
+
+release_128="v$(printf '1%.0s' {1..123}).1.1"
+release_129="v$(printf '1%.0s' {1..124}).1.1"
+development_128="a$(printf 'x%.0s' {1..127})"
+development_129="a$(printf 'x%.0s' {1..128})"
+
+expect_valid "v0.0.0" release
+expect_valid "v12.34.56-rc7" release
+expect_valid "$release_128" release
+expect_invalid "v1.2" release
+expect_invalid "v1.2.3-rc" release
+expect_invalid "v1.2.3-alpha1" release
+expect_invalid "$release_129" release
+
+expect_valid "v1.2.3-a1b2c3d" development
+expect_valid "release_candidate-1.2" development
+expect_valid "$development_128" development
+expect_invalid "invalid/tag-a1b2c3d" development
+expect_invalid "-invalid" development
+expect_invalid "$development_129" development
+expect_invalid "valid-tag" unknown

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   IMAGE_NAME: pk-opencode
-  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube-internal/prokube-dev' }}"
+  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube/development' }}"
 
 jobs:
   build-prefixable-image:

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   IMAGE_NAME: pk-opencode
-  IMAGE_PUSH_PATH: "${{ secrets.GCP_ARTIFACT_REGISTRY_PATH }}"
+  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube-internal/prokube-customer' }}"
 
 jobs:
   build-prefixable-image:
@@ -66,13 +66,12 @@ jobs:
       - name: Build and push image
         run: |
           # GCP Artifact Registry tags
-          LATEST_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:latest"
           VERSION_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}"
           COMMIT_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:commit-${{ github.sha }}"
 
           # Build the Kubeflow image
           docker build \
-            -t $LATEST_TAG \
+            -t "$VERSION_TAG" \
             -f docker/kubeflow/Dockerfile \
             --platform linux/amd64 \
             --build-arg OPENCODE_VERSION=1.15.7 \
@@ -85,18 +84,22 @@ jobs:
             .
 
           # Tag for different versions
-          docker tag $LATEST_TAG $VERSION_TAG
-          docker tag $LATEST_TAG $COMMIT_TAG
+          docker tag "$VERSION_TAG" "$COMMIT_TAG"
 
           # Push to GCP Artifact Registry
-          docker push $LATEST_TAG
-          docker push $VERSION_TAG
-          docker push $COMMIT_TAG
+          docker push "$VERSION_TAG"
+          docker push "$COMMIT_TAG"
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            LATEST_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:latest"
+            docker tag "$VERSION_TAG" "$LATEST_TAG"
+            docker push "$LATEST_TAG"
+            echo "LATEST_TAG=$LATEST_TAG" >> "$GITHUB_ENV"
+          fi
 
           # Save tags for summary
-          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
-          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
-          echo "COMMIT_TAG=$COMMIT_TAG" >> $GITHUB_ENV
+          echo "VERSION_TAG=$VERSION_TAG" >> "$GITHUB_ENV"
+          echo "COMMIT_TAG=$COMMIT_TAG" >> "$GITHUB_ENV"
 
       - name: Generate summary
         run: |
@@ -108,7 +111,6 @@ jobs:
           ### Image Tags
           | Tag | URL |
           |-----|-----|
-          | latest | \`${{ env.LATEST_TAG }}\` |
           | version | \`${{ env.VERSION_TAG }}\` |
           | commit | \`${{ env.COMMIT_TAG }}\` |
 
@@ -116,7 +118,6 @@ jobs:
           <summary>Full image URLs for copy/paste</summary>
 
           \`\`\`
-          ${{ env.LATEST_TAG }}
           ${{ env.VERSION_TAG }}
           ${{ env.COMMIT_TAG }}
           \`\`\`

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   IMAGE_NAME: pk-opencode
-  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube-internal/prokube-customer' }}"
+  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube-internal/prokube-customer' }}"
 
 jobs:
   build-prefixable-image:

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -102,7 +102,14 @@ jobs:
           echo "COMMIT_TAG=$COMMIT_TAG" >> "$GITHUB_ENV"
 
       - name: Generate summary
+        env:
+          LATEST_TAG: ${{ env.LATEST_TAG }}
         run: |
+          LATEST_ROW=""
+          if [[ -n "$LATEST_TAG" ]]; then
+            LATEST_ROW="| latest | \`$LATEST_TAG\` |"
+          fi
+
           cat <<EOF > summary.md
           ## Docker Image Published
 
@@ -111,6 +118,7 @@ jobs:
           ### Image Tags
           | Tag | URL |
           |-----|-----|
+          $LATEST_ROW
           | version | \`${{ env.VERSION_TAG }}\` |
           | commit | \`${{ env.COMMIT_TAG }}\` |
 
@@ -118,6 +126,7 @@ jobs:
           <summary>Full image URLs for copy/paste</summary>
 
           \`\`\`
+          $LATEST_TAG
           ${{ env.VERSION_TAG }}
           ${{ env.COMMIT_TAG }}
           \`\`\`

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   IMAGE_NAME: pk-opencode
-  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube-internal/prokube-customer' }}"
+  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube-internal/prokube-dev' }}"
 
 jobs:
   build-prefixable-image:

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -8,7 +8,9 @@ on:
 
 env:
   IMAGE_NAME: pk-opencode
-  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube/development' }}"
+  IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube/development' }}"
+  IS_RELEASE: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}"
+  RELEASE_TAG: "${{ github.ref_name }}"
 
 jobs:
   build-prefixable-image:
@@ -27,10 +29,8 @@ jobs:
       - name: Generate dynamic version
         id: version
         run: |
-          CURRENT_TAG=$(git tag --points-at HEAD | head -n 1)
-
-          if [ -n "$CURRENT_TAG" ]; then
-            VERSION="${CURRENT_TAG}"
+          if [[ "$IS_RELEASE" == "true" ]]; then
+            VERSION="$RELEASE_TAG"
           else
             LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
             SHORT_COMMIT=$(git rev-parse --short HEAD)
@@ -67,7 +67,6 @@ jobs:
         run: |
           # GCP Artifact Registry tags
           VERSION_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}"
-          COMMIT_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:commit-${{ github.sha }}"
 
           # Build the Kubeflow image
           docker build \
@@ -83,31 +82,34 @@ jobs:
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             .
 
-          # Tag for different versions
-          docker tag "$VERSION_TAG" "$COMMIT_TAG"
-
           # Push to GCP Artifact Registry
           docker push "$VERSION_TAG"
-          docker push "$COMMIT_TAG"
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$IS_RELEASE" != "true" ]]; then
+            COMMIT_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:commit-${{ github.sha }}"
             LATEST_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:latest"
+            docker tag "$VERSION_TAG" "$COMMIT_TAG"
             docker tag "$VERSION_TAG" "$LATEST_TAG"
+            docker push "$COMMIT_TAG"
             docker push "$LATEST_TAG"
+            echo "COMMIT_TAG=$COMMIT_TAG" >> "$GITHUB_ENV"
             echo "LATEST_TAG=$LATEST_TAG" >> "$GITHUB_ENV"
           fi
 
           # Save tags for summary
           echo "VERSION_TAG=$VERSION_TAG" >> "$GITHUB_ENV"
-          echo "COMMIT_TAG=$COMMIT_TAG" >> "$GITHUB_ENV"
 
       - name: Generate summary
-        env:
-          LATEST_TAG: ${{ env.LATEST_TAG }}
         run: |
-          LATEST_ROW=""
-          if [[ -n "$LATEST_TAG" ]]; then
-            LATEST_ROW="| latest | \`$LATEST_TAG\` |"
+          TAG_ROWS="| version | \`$VERSION_TAG\` |"
+          IMAGE_URLS="$VERSION_TAG"
+          if [[ -n "$COMMIT_TAG" ]]; then
+            TAG_ROWS="$TAG_ROWS
+          | commit | \`$COMMIT_TAG\` |
+          | latest | \`$LATEST_TAG\` |"
+            IMAGE_URLS="$IMAGE_URLS
+          $COMMIT_TAG
+          $LATEST_TAG"
           fi
 
           cat <<EOF > summary.md
@@ -118,17 +120,13 @@ jobs:
           ### Image Tags
           | Tag | URL |
           |-----|-----|
-          $LATEST_ROW
-          | version | \`${{ env.VERSION_TAG }}\` |
-          | commit | \`${{ env.COMMIT_TAG }}\` |
+          $TAG_ROWS
 
           <details>
           <summary>Full image URLs for copy/paste</summary>
 
           \`\`\`
-          $LATEST_TAG
-          ${{ env.VERSION_TAG }}
-          ${{ env.COMMIT_TAG }}
+          $IMAGE_URLS
           \`\`\`
           </details>
           EOF
@@ -172,7 +170,7 @@ jobs:
 
   create-release:
     needs: build-prefixable-image
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -27,13 +27,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate release tag
-        if: env.IS_RELEASE == 'true'
-        run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
-            echo "Release tag must match vX.Y.Z or vX.Y.Z-rcN"
-            exit 1
-          fi
+      - name: Test image tag validation
+        run: bash .github/scripts/validate-image-tag.test.sh
 
       - name: Generate dynamic version
         id: version
@@ -49,16 +44,18 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Generated version: ${VERSION}"
 
-      - name: Determine Docker tag
+      - name: Validate and set Docker tag
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          if [ -n "${{ steps.version.outputs.VERSION }}" ]; then
-            DOCKER_TAG="${{ steps.version.outputs.VERSION }}"
-          else
-            DOCKER_TAG="latest"
+          TAG_KIND="development"
+          if [[ "$IS_RELEASE" == "true" ]]; then
+            TAG_KIND="release"
           fi
 
-          echo "DOCKER_TAG=$DOCKER_TAG" >> "$GITHUB_ENV"
-          echo "VERSION_TAG=$IMAGE_PUSH_PATH/$IMAGE_NAME:$DOCKER_TAG" >> "$GITHUB_ENV"
+          bash .github/scripts/validate-image-tag.sh "$VERSION" "$TAG_KIND"
+          echo "DOCKER_TAG=$VERSION" >> "$GITHUB_ENV"
+          echo "VERSION_TAG=$IMAGE_PUSH_PATH/$IMAGE_NAME:$VERSION" >> "$GITHUB_ENV"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -112,6 +109,9 @@ jobs:
 
       - name: Build and push image
         if: env.PUBLISH_IMAGE == 'true'
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REPOSITORY_URL: ${{ github.event.repository.html_url }}
         run: |
           # Build the Kubeflow image
           docker build \
@@ -123,16 +123,16 @@ jobs:
             --build-arg KF_EXAMPLES_REPO=https://github.com/prokube-ai/kubeflow-examples.git \
             --label "org.opencontainers.image.title=OpenCode Prefixable UI" \
             --label "org.opencontainers.image.description=Prefix-aware OpenCode Web UI for Kubeflow" \
-            --label "org.opencontainers.image.source=${{ github.event.repository.html_url }}" \
-            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --label "org.opencontainers.image.source=$REPOSITORY_URL" \
+            --label "org.opencontainers.image.revision=$COMMIT_SHA" \
             .
 
           # Push to GCP Artifact Registry
           docker push "$VERSION_TAG"
 
           if [[ "$IS_RELEASE" != "true" ]]; then
-            COMMIT_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:commit-${{ github.sha }}"
-            LATEST_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:latest"
+            COMMIT_TAG="$IMAGE_PUSH_PATH/$IMAGE_NAME:commit-$COMMIT_SHA"
+            LATEST_TAG="$IMAGE_PUSH_PATH/$IMAGE_NAME:latest"
             docker tag "$VERSION_TAG" "$COMMIT_TAG"
             docker tag "$VERSION_TAG" "$LATEST_TAG"
             docker push "$COMMIT_TAG"
@@ -163,7 +163,7 @@ jobs:
           cat <<EOF > summary.md
           ## Docker Image $RESULT
 
-          **Version:** \`${{ env.DOCKER_TAG }}\`
+          **Version:** \`$DOCKER_TAG\`
 
           ### Image Tags
           | Tag | URL |

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -27,8 +27,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Test image tag validation
-        run: bash .github/scripts/validate-image-tag.test.sh
+      - name: Test publishing contracts
+        run: |
+          bash .github/scripts/validate-image-tag.test.sh
+          bash .github/scripts/probe-registry-manifest.test.sh
 
       - name: Generate dynamic version
         id: version
@@ -72,25 +74,22 @@ jobs:
           ACCESS_TOKEN=$(gcloud auth print-access-token)
           REGISTRY_URL="https://europe-west3-docker.pkg.dev/v2/prokube/releases/$IMAGE_NAME/manifests/$DOCKER_TAG"
 
-          if ! HTTP_STATUS=$(curl --silent --show-error --head --output /dev/null \
-            --write-out "%{http_code}" \
-            --header "Authorization: Bearer $ACCESS_TOKEN" \
-            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-            "$REGISTRY_URL"); then
+          if ! PROBE_RESULT=$(bash .github/scripts/probe-registry-manifest.sh \
+            "$REGISTRY_URL" "$ACCESS_TOKEN"); then
             echo "Failed to query release image $VERSION_TAG"
             exit 1
           fi
 
-          case "$HTTP_STATUS" in
-            200)
+          case "$PROBE_RESULT" in
+            present)
               echo "Release image $VERSION_TAG already exists; skipping build and push."
               echo "PUBLISH_IMAGE=false" >> "$GITHUB_ENV"
               ;;
-            404)
+            missing)
               echo "Release image $VERSION_TAG does not exist; it will be published."
               ;;
             *)
-              echo "Registry returned HTTP $HTTP_STATUS while checking $VERSION_TAG"
+              echo "Registry probe returned an invalid result for $VERSION_TAG"
               exit 1
               ;;
           esac
@@ -230,6 +229,8 @@ jobs:
         run: |
           RELEASE_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"
           if ! HTTP_STATUS=$(curl --silent --show-error --output /dev/null \
+            --connect-timeout 10 \
+            --max-time 30 \
             --write-out "%{http_code}" \
             --header "Authorization: Bearer $GH_TOKEN" \
             --header "Accept: application/vnd.github+json" \

--- a/.github/workflows/pk-opencode.yml
+++ b/.github/workflows/pk-opencode.yml
@@ -10,6 +10,7 @@ env:
   IMAGE_NAME: pk-opencode
   IMAGE_PUSH_PATH: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && 'europe-west3-docker.pkg.dev/prokube/releases' || 'europe-west3-docker.pkg.dev/prokube/development' }}"
   IS_RELEASE: "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}"
+  PUBLISH_IMAGE: "true"
   RELEASE_TAG: "${{ github.ref_name }}"
 
 jobs:
@@ -26,6 +27,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate release tag
+        if: env.IS_RELEASE == 'true'
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+            echo "Release tag must match vX.Y.Z or vX.Y.Z-rcN"
+            exit 1
+          fi
+
       - name: Generate dynamic version
         id: version
         run: |
@@ -37,23 +46,60 @@ jobs:
             VERSION="${LATEST_TAG}-${SHORT_COMMIT}"
           fi
 
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Generated version: ${VERSION}"
 
       - name: Determine Docker tag
         run: |
           if [ -n "${{ steps.version.outputs.VERSION }}" ]; then
-            echo "DOCKER_TAG=${{ steps.version.outputs.VERSION }}" >> $GITHUB_ENV
+            DOCKER_TAG="${{ steps.version.outputs.VERSION }}"
           else
-            echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+            DOCKER_TAG="latest"
           fi
+
+          echo "DOCKER_TAG=$DOCKER_TAG" >> "$GITHUB_ENV"
+          echo "VERSION_TAG=$IMAGE_PUSH_PATH/$IMAGE_NAME:$DOCKER_TAG" >> "$GITHUB_ENV"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
           credentials_json: "${{ secrets.GCP_SA_KEY }}"
 
+      - name: Set up Google Cloud SDK
+        if: env.IS_RELEASE == 'true'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Check release image
+        if: env.IS_RELEASE == 'true'
+        run: |
+          ACCESS_TOKEN=$(gcloud auth print-access-token)
+          REGISTRY_URL="https://europe-west3-docker.pkg.dev/v2/prokube/releases/$IMAGE_NAME/manifests/$DOCKER_TAG"
+
+          if ! HTTP_STATUS=$(curl --silent --show-error --head --output /dev/null \
+            --write-out "%{http_code}" \
+            --header "Authorization: Bearer $ACCESS_TOKEN" \
+            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            "$REGISTRY_URL"); then
+            echo "Failed to query release image $VERSION_TAG"
+            exit 1
+          fi
+
+          case "$HTTP_STATUS" in
+            200)
+              echo "Release image $VERSION_TAG already exists; skipping build and push."
+              echo "PUBLISH_IMAGE=false" >> "$GITHUB_ENV"
+              ;;
+            404)
+              echo "Release image $VERSION_TAG does not exist; it will be published."
+              ;;
+            *)
+              echo "Registry returned HTTP $HTTP_STATUS while checking $VERSION_TAG"
+              exit 1
+              ;;
+          esac
+
       - name: Docker Login to Google Artifact Registry
+        if: env.PUBLISH_IMAGE == 'true'
         uses: docker/login-action@v3
         with:
           registry: europe-west3-docker.pkg.dev
@@ -61,13 +107,12 @@ jobs:
           password: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Docker Buildx
+        if: env.PUBLISH_IMAGE == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push image
+        if: env.PUBLISH_IMAGE == 'true'
         run: |
-          # GCP Artifact Registry tags
-          VERSION_TAG="${{ env.IMAGE_PUSH_PATH }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}"
-
           # Build the Kubeflow image
           docker build \
             -t "$VERSION_TAG" \
@@ -96,11 +141,14 @@ jobs:
             echo "LATEST_TAG=$LATEST_TAG" >> "$GITHUB_ENV"
           fi
 
-          # Save tags for summary
-          echo "VERSION_TAG=$VERSION_TAG" >> "$GITHUB_ENV"
-
       - name: Generate summary
         run: |
+          if [[ "$PUBLISH_IMAGE" == "true" ]]; then
+            RESULT="Published"
+          else
+            RESULT="Already Published"
+          fi
+
           TAG_ROWS="| version | \`$VERSION_TAG\` |"
           IMAGE_URLS="$VERSION_TAG"
           if [[ -n "$COMMIT_TAG" ]]; then
@@ -113,7 +161,7 @@ jobs:
           fi
 
           cat <<EOF > summary.md
-          ## Docker Image Published
+          ## Docker Image $RESULT
 
           **Version:** \`${{ env.DOCKER_TAG }}\`
 
@@ -131,7 +179,7 @@ jobs:
           </details>
           EOF
 
-          cat summary.md >> $GITHUB_STEP_SUMMARY
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
@@ -179,6 +227,29 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create GitHub Release
-        run: gh release create "${{ github.ref_name }}" --generate-notes --title "${{ github.ref_name }}"
+        run: |
+          RELEASE_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"
+          if ! HTTP_STATUS=$(curl --silent --show-error --output /dev/null \
+            --write-out "%{http_code}" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "$RELEASE_URL"); then
+            echo "Failed to query GitHub release $RELEASE_TAG"
+            exit 1
+          fi
+
+          case "$HTTP_STATUS" in
+            200)
+              echo "GitHub release $RELEASE_TAG already exists; skipping creation."
+              ;;
+            404)
+              gh release create "$RELEASE_TAG" --generate-notes --title "$RELEASE_TAG"
+              ;;
+            *)
+              echo "GitHub returned HTTP $HTTP_STATUS while checking release $RELEASE_TAG"
+              exit 1
+              ;;
+          esac
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Kubeflow-specific features:
 
 See [docker/kubeflow/README.md](docker/kubeflow/README.md) for Kubeflow deployment details.
 
+### Published Image Tags
+
+Release tags must match `vX.Y.Z` or `vX.Y.Z-rcN`. Tag-triggered builds publish only that unchanged tag to `prokube/releases`; reruns skip an image that already exists. Manual builds publish `<nearest-git-tag>-<short-commit>`, `commit-<full-commit>`, and `latest` to `prokube/development`. All generated Docker tags must be valid and no longer than 128 characters.
+
 ### Reverse Proxy Examples
 
 See [examples/](examples/) for nginx and Traefik configurations.


### PR DESCRIPTION
## Summary
- Publish builds triggered by Git tag pushes to europe-west3-docker.pkg.dev/prokube/releases.
- Publish manual builds to europe-west3-docker.pkg.dev/prokube/development.
- Avoid publishing the mutable latest tag for tagged releases while preserving it for manual builds.

## Testing
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -shellcheck= .github/workflows/pk-opencode.yml
- git diff --check

## Deployment configuration
- The GitHub Actions service account has writer access to prokube/development and prokube/releases.
- The development-cluster service account has reader access to both repositories.